### PR TITLE
fix(presenter): fix vike warning @

### DIFF
--- a/presenter/src/assets/sass/style.scss
+++ b/presenter/src/assets/sass/style.scss
@@ -3,7 +3,7 @@
     font-family: Poppins;
     font-style: normal;
     font-weight: 100;
-    src: url('@/assets/fonts/Poppins/poppins-v20-latin-100.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+    src: url('#assets/fonts/Poppins/poppins-v20-latin-100.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
     font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   }
 
@@ -12,7 +12,7 @@
     font-family: Poppins;
     font-style: italic;
     font-weight: 100;
-    src: url('@/assets/fonts/Poppins/poppins-v20-latin-100italic.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+    src: url('#assets/fonts/Poppins/poppins-v20-latin-100italic.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
     font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   }
 
@@ -21,7 +21,7 @@
     font-family: Poppins;
     font-style: normal;
     font-weight: 200;
-    src: url('@/assets/fonts/Poppins/poppins-v20-latin-200.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+    src: url('#assets/fonts/Poppins/poppins-v20-latin-200.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
     font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   }
 
@@ -30,7 +30,7 @@
     font-family: Poppins;
     font-style: italic;
     font-weight: 200;
-    src: url('@/assets/fonts/Poppins/poppins-v20-latin-200italic.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+    src: url('#assets/fonts/Poppins/poppins-v20-latin-200italic.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
     font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   }
 
@@ -39,7 +39,7 @@
     font-family: Poppins;
     font-style: normal;
     font-weight: 300;
-    src: url('@/assets/fonts/Poppins/poppins-v20-latin-300.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+    src: url('#assets/fonts/Poppins/poppins-v20-latin-300.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
     font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   }
 
@@ -48,7 +48,7 @@
     font-family: Poppins;
     font-style: italic;
     font-weight: 300;
-    src: url('@/assets/fonts/Poppins/poppins-v20-latin-300italic.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+    src: url('#assets/fonts/Poppins/poppins-v20-latin-300italic.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
     font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   }
 
@@ -57,7 +57,7 @@
     font-family: Poppins;
     font-style: normal;
     font-weight: 400;
-    src: url('@/assets/fonts/Poppins/poppins-v20-latin-regular.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+    src: url('#assets/fonts/Poppins/poppins-v20-latin-regular.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
     font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   }
 
@@ -66,7 +66,7 @@
     font-family: Poppins;
     font-style: italic;
     font-weight: 400;
-    src: url('@/assets/fonts/Poppins/poppins-v20-latin-italic.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+    src: url('#assets/fonts/Poppins/poppins-v20-latin-italic.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
     font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   }
 
@@ -75,7 +75,7 @@
     font-family: Poppins;
     font-style: normal;
     font-weight: 500;
-    src: url('@/assets/fonts/Poppins/poppins-v20-latin-500.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+    src: url('#assets/fonts/Poppins/poppins-v20-latin-500.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
     font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   }
 
@@ -84,7 +84,7 @@
     font-family: Poppins;
     font-style: italic;
     font-weight: 500;
-    src: url('@/assets/fonts/Poppins/poppins-v20-latin-500italic.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+    src: url('#assets/fonts/Poppins/poppins-v20-latin-500italic.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
     font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   }
 
@@ -93,7 +93,7 @@
     font-family: Poppins;
     font-style: normal;
     font-weight: 600;
-    src: url('@/assets/fonts/Poppins/poppins-v20-latin-600.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+    src: url('#assets/fonts/Poppins/poppins-v20-latin-600.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
     font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   }
 
@@ -102,7 +102,7 @@
     font-family: Poppins;
     font-style: italic;
     font-weight: 600;
-    src: url('@/assets/fonts/Poppins/poppins-v20-latin-600italic.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+    src: url('#assets/fonts/Poppins/poppins-v20-latin-600italic.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
     font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   }
 
@@ -111,7 +111,7 @@
     font-family: Poppins;
     font-style: normal;
     font-weight: 700;
-    src: url('@/assets/fonts/Poppins/poppins-v20-latin-700.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+    src: url('#assets/fonts/Poppins/poppins-v20-latin-700.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
     font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   }
 
@@ -120,7 +120,7 @@
     font-family: Poppins;
     font-style: italic;
     font-weight: 700;
-    src: url('@/assets/fonts/Poppins/poppins-v20-latin-700italic.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+    src: url('#assets/fonts/Poppins/poppins-v20-latin-700italic.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
     font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   }
 
@@ -129,7 +129,7 @@
     font-family: Poppins;
     font-style: normal;
     font-weight: 800;
-    src: url('@/assets/fonts/Poppins/poppins-v20-latin-800.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+    src: url('#assets/fonts/Poppins/poppins-v20-latin-800.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
     font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   }
 
@@ -138,7 +138,7 @@
     font-family: Poppins;
     font-style: italic;
     font-weight: 800;
-    src: url('@/assets/fonts/Poppins/poppins-v20-latin-800italic.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+    src: url('#assets/fonts/Poppins/poppins-v20-latin-800italic.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
     font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   }
 
@@ -147,7 +147,7 @@
     font-family: Poppins;
     font-style: normal;
     font-weight: 900;
-    src: url('@/assets/fonts/Poppins/poppins-v20-latin-900.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+    src: url('#assets/fonts/Poppins/poppins-v20-latin-900.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
     font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   }
 
@@ -156,6 +156,6 @@
     font-family: Poppins;
     font-style: italic;
     font-weight: 900;
-    src: url('@/assets/fonts/Poppins/poppins-v20-latin-900italic.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+    src: url('#assets/fonts/Poppins/poppins-v20-latin-900italic.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
     font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   }

--- a/presenter/src/assets/sass/style.scss
+++ b/presenter/src/assets/sass/style.scss
@@ -3,7 +3,7 @@
     font-family: Poppins;
     font-style: normal;
     font-weight: 100;
-    src: url('#assets/fonts/Poppins/poppins-v20-latin-100.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+    src: url('/src/assets/fonts/Poppins/poppins-v20-latin-100.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
     font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   }
 
@@ -12,7 +12,7 @@
     font-family: Poppins;
     font-style: italic;
     font-weight: 100;
-    src: url('#assets/fonts/Poppins/poppins-v20-latin-100italic.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+    src: url('/src/assets/fonts/Poppins/poppins-v20-latin-100italic.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
     font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   }
 
@@ -21,7 +21,7 @@
     font-family: Poppins;
     font-style: normal;
     font-weight: 200;
-    src: url('#assets/fonts/Poppins/poppins-v20-latin-200.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+    src: url('/src/assets/fonts/Poppins/poppins-v20-latin-200.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
     font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   }
 
@@ -30,7 +30,7 @@
     font-family: Poppins;
     font-style: italic;
     font-weight: 200;
-    src: url('#assets/fonts/Poppins/poppins-v20-latin-200italic.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+    src: url('/src/assets/fonts/Poppins/poppins-v20-latin-200italic.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
     font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   }
 
@@ -39,7 +39,7 @@
     font-family: Poppins;
     font-style: normal;
     font-weight: 300;
-    src: url('#assets/fonts/Poppins/poppins-v20-latin-300.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+    src: url('/src/assets/fonts/Poppins/poppins-v20-latin-300.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
     font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   }
 
@@ -48,7 +48,7 @@
     font-family: Poppins;
     font-style: italic;
     font-weight: 300;
-    src: url('#assets/fonts/Poppins/poppins-v20-latin-300italic.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+    src: url('/src/assets/fonts/Poppins/poppins-v20-latin-300italic.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
     font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   }
 
@@ -57,7 +57,7 @@
     font-family: Poppins;
     font-style: normal;
     font-weight: 400;
-    src: url('#assets/fonts/Poppins/poppins-v20-latin-regular.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+    src: url('/src/assets/fonts/Poppins/poppins-v20-latin-regular.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
     font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   }
 
@@ -66,7 +66,7 @@
     font-family: Poppins;
     font-style: italic;
     font-weight: 400;
-    src: url('#assets/fonts/Poppins/poppins-v20-latin-italic.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+    src: url('/src/assets/fonts/Poppins/poppins-v20-latin-italic.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
     font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   }
 
@@ -75,7 +75,7 @@
     font-family: Poppins;
     font-style: normal;
     font-weight: 500;
-    src: url('#assets/fonts/Poppins/poppins-v20-latin-500.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+    src: url('/src/assets/fonts/Poppins/poppins-v20-latin-500.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
     font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   }
 
@@ -84,7 +84,7 @@
     font-family: Poppins;
     font-style: italic;
     font-weight: 500;
-    src: url('#assets/fonts/Poppins/poppins-v20-latin-500italic.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+    src: url('/src/assets/fonts/Poppins/poppins-v20-latin-500italic.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
     font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   }
 
@@ -93,7 +93,7 @@
     font-family: Poppins;
     font-style: normal;
     font-weight: 600;
-    src: url('#assets/fonts/Poppins/poppins-v20-latin-600.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+    src: url('/src/assets/fonts/Poppins/poppins-v20-latin-600.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
     font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   }
 
@@ -102,7 +102,7 @@
     font-family: Poppins;
     font-style: italic;
     font-weight: 600;
-    src: url('#assets/fonts/Poppins/poppins-v20-latin-600italic.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+    src: url('/src/assets/fonts/Poppins/poppins-v20-latin-600italic.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
     font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   }
 
@@ -111,7 +111,7 @@
     font-family: Poppins;
     font-style: normal;
     font-weight: 700;
-    src: url('#assets/fonts/Poppins/poppins-v20-latin-700.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+    src: url('/src/assets/fonts/Poppins/poppins-v20-latin-700.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
     font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   }
 
@@ -120,7 +120,7 @@
     font-family: Poppins;
     font-style: italic;
     font-weight: 700;
-    src: url('#assets/fonts/Poppins/poppins-v20-latin-700italic.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+    src: url('/src/assets/fonts/Poppins/poppins-v20-latin-700italic.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
     font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   }
 
@@ -129,7 +129,7 @@
     font-family: Poppins;
     font-style: normal;
     font-weight: 800;
-    src: url('#assets/fonts/Poppins/poppins-v20-latin-800.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+    src: url('/src/assets/fonts/Poppins/poppins-v20-latin-800.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
     font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   }
 
@@ -138,7 +138,7 @@
     font-family: Poppins;
     font-style: italic;
     font-weight: 800;
-    src: url('#assets/fonts/Poppins/poppins-v20-latin-800italic.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+    src: url('/src/assets/fonts/Poppins/poppins-v20-latin-800italic.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
     font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   }
 
@@ -147,7 +147,7 @@
     font-family: Poppins;
     font-style: normal;
     font-weight: 900;
-    src: url('#assets/fonts/Poppins/poppins-v20-latin-900.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+    src: url('/src/assets/fonts/Poppins/poppins-v20-latin-900.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
     font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   }
 
@@ -156,6 +156,6 @@
     font-family: Poppins;
     font-style: italic;
     font-weight: 900;
-    src: url('#assets/fonts/Poppins/poppins-v20-latin-900italic.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+    src: url('/src/assets/fonts/Poppins/poppins-v20-latin-900italic.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
     font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   }

--- a/presenter/src/components/sections/FirstSection.vue
+++ b/presenter/src/components/sections/FirstSection.vue
@@ -22,7 +22,7 @@
               playsinline
               @ended="triggerNextSlide"
             >
-              <source src="#assets/video/header_video.mp4" type="video/mp4" />
+              <source :src="Video" type="video/mp4" />
             </video>
           </v-sheet>
         </v-carousel-item>
@@ -71,6 +71,7 @@ const { result, loading, error } = useQuery(HELLO_QUERY)
 import { ref } from 'vue'
 
 import VideoPoster from '#assets/img/video_placeholder.png'
+import Video from '#assets/video/header_video.mp4'
 import MainButton from '#components/inputs/MainButton.vue'
 import LogoImage from '#components/menu/LogoImage.vue'
 

--- a/presenter/src/components/sections/FirstSection.vue
+++ b/presenter/src/components/sections/FirstSection.vue
@@ -22,7 +22,7 @@
               playsinline
               @ended="triggerNextSlide"
             >
-              <source src="@/assets/video/header_video.mp4" type="video/mp4" />
+              <source src="#assets/video/header_video.mp4" type="video/mp4" />
             </video>
           </v-sheet>
         </v-carousel-item>

--- a/presenter/vite.config.ts
+++ b/presenter/vite.config.ts
@@ -38,7 +38,6 @@ const config: UserConfig = {
       '#plugins': path.join(__dirname, '/renderer/plugins'),
       '#context': path.join(__dirname, '/renderer/context'),
       '#types': path.join(__dirname, '/types'),
-      '@': path.resolve(__dirname, 'src'),
     },
   },
   css: {


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

fix vike warning @

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [x] this is only one of two warnings - the other is not fixed - but I started an inquery on discord -> reason is vue-i18n and its currently not fixable
- [ ] sass-imports can be linked to vike - see https://github.com/vitejs/vite/issues/650 and https://github.com/postcss/postcss-import#resolve
