### PR TITLE
fix(other): backend startscript

### DIFF
--- a/deployment/start.backend.sh
+++ b/deployment/start.backend.sh
@@ -6,5 +6,5 @@ SCRIPT_DIR=$(dirname $SCRIPT_PATH)/../backend
 LOG_FILE=$SCRIPT_DIR/../log/$(date +"%Y-%m-%d_%T")_pm2.backend.log
 
 cd $SCRIPT_DIR
-NODE_ENV=production pm2 start --name backend "npm run start" -l $LOG_FILE --log-date-format 'YYYY-MM-DD HH:mm:ss.SSS'
+NODE_ENV=production TZ=UTC TS_NODE_BASEURL=./build pm2 start --name backend "node -r tsconfig-paths/register build/src/index.js" -l $LOG_FILE --log-date-format 'YYYY-MM-DD HH:mm:ss.SSS'
 pm2 save


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

do not use npm to start backend since that detaches the process and does not allow pm2 to kill it again - it lingers after `pm2 stop backend` and blocks port 4000

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
