### PR TITLE
guard showcase (DO NOT MERGE)

### DIFF
--- a/frontend/src/pages/_error/+Page.vue
+++ b/frontend/src/pages/_error/+Page.vue
@@ -1,14 +1,18 @@
 <template>
-  <div v-if="is404">
-    <h1>{{ $t('error.404.h1') }}</h1>
-    <p>{{ $t('error.404.text') }}</p>
-  </div>
-  <div v-else>
-    <h1>{{ $t('error.500.h1') }}</h1>
-    <p>{{ $t('error.500.text') }}</p>
-  </div>
+  <DefaultLayout>
+    <div v-if="is404">
+      <h1>{{ $t('error.404.h1') }}</h1>
+      <p>{{ $t('error.404.text') }}</p>
+    </div>
+    <div v-else>
+      <h1>{{ $t('error.500.h1') }}</h1>
+      <p>{{ $t('error.500.text') }}</p>
+    </div>
+  </DefaultLayout>
 </template>
 
 <script lang="ts" setup>
+import DefaultLayout from '#layouts/DefaultLayout.vue'
+
 defineProps({ is404: Boolean })
 </script>

--- a/frontend/src/pages/about/+guard.ts
+++ b/frontend/src/pages/about/+guard.ts
@@ -1,0 +1,10 @@
+import { render } from 'vike/abort'
+
+import type { GuardAsync } from 'vike/types'
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/require-await
+const guard: GuardAsync = async (pageContext): ReturnType<GuardAsync> => {
+  throw render(401, 'This page is forbidden.')
+}
+
+export { guard }


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
 Guard added to about page that _always_ renders the 404 error page

 In development everything works as expected. The error is shown when entering the page from outside, when navigating inside the app and also when reloading the page.

In production though, the error page is only shown when navigating inside the app. _No_ error is shown, when coming from outside or reloading the page.


### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
