### PR TITLE
chore(other): set dependabot package update pr limit to none

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,5 @@
 version: 2
+open-pull-requests-limit: 0
 updates:
 - package-ecosystem: "github-actions"
   directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
 - package-ecosystem: "github-actions"
-  open-pull-requests-limit: 0
+  open-pull-requests-limit: 999
   directory: "/"
   rebase-strategy: "disabled"
   schedule:
@@ -10,7 +10,7 @@ updates:
     timezone: "Europe/Berlin"
     time: "03:00"
 - package-ecosystem: npm
-  open-pull-requests-limit: 0
+  open-pull-requests-limit: 999
   directory: "/"
   rebase-strategy: "disabled"
   schedule:
@@ -19,7 +19,7 @@ updates:
     timezone: "Europe/Berlin"
     time: "03:00"
 - package-ecosystem: docker
-  open-pull-requests-limit: 0
+  open-pull-requests-limit: 999
   directory: "/"
   rebase-strategy: "disabled"
   schedule:
@@ -30,7 +30,7 @@ updates:
 
 # presenter
 - package-ecosystem: npm
-  open-pull-requests-limit: 0
+  open-pull-requests-limit: 999
   directory: "/presenter"
   rebase-strategy: "disabled"
   schedule:
@@ -39,7 +39,7 @@ updates:
     timezone: "Europe/Berlin"
     time: "03:00"
 - package-ecosystem: docker
-  open-pull-requests-limit: 0
+  open-pull-requests-limit: 999
   directory: "/presenter"
   rebase-strategy: "disabled"
   schedule:
@@ -50,7 +50,7 @@ updates:
 
 # frontend
 - package-ecosystem: npm
-  open-pull-requests-limit: 0
+  open-pull-requests-limit: 999
   directory: "/frontend"
   rebase-strategy: "disabled"
   schedule:
@@ -59,7 +59,7 @@ updates:
     timezone: "Europe/Berlin"
     time: "03:00"
 - package-ecosystem: docker
-  open-pull-requests-limit: 0
+  open-pull-requests-limit: 999
   directory: "/frontend"
   rebase-strategy: "disabled"
   schedule:
@@ -70,7 +70,7 @@ updates:
 
 # backend
 - package-ecosystem: npm
-  open-pull-requests-limit: 0
+  open-pull-requests-limit: 999
   directory: "/backend"
   rebase-strategy: "disabled"
   schedule:
@@ -79,7 +79,7 @@ updates:
     timezone: "Europe/Berlin"
     time: "03:00"
 - package-ecosystem: docker
-  open-pull-requests-limit: 0
+  open-pull-requests-limit: 999
   directory: "/backend"
   rebase-strategy: "disabled"
   schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
-open-pull-requests-limit: 0
 updates:
 - package-ecosystem: "github-actions"
+  open-pull-requests-limit: 0
   directory: "/"
   rebase-strategy: "disabled"
   schedule:
@@ -10,6 +10,7 @@ updates:
     timezone: "Europe/Berlin"
     time: "03:00"
 - package-ecosystem: npm
+  open-pull-requests-limit: 0
   directory: "/"
   rebase-strategy: "disabled"
   schedule:
@@ -18,6 +19,7 @@ updates:
     timezone: "Europe/Berlin"
     time: "03:00"
 - package-ecosystem: docker
+  open-pull-requests-limit: 0
   directory: "/"
   rebase-strategy: "disabled"
   schedule:
@@ -28,6 +30,7 @@ updates:
 
 # presenter
 - package-ecosystem: npm
+  open-pull-requests-limit: 0
   directory: "/presenter"
   rebase-strategy: "disabled"
   schedule:
@@ -36,6 +39,7 @@ updates:
     timezone: "Europe/Berlin"
     time: "03:00"
 - package-ecosystem: docker
+  open-pull-requests-limit: 0
   directory: "/presenter"
   rebase-strategy: "disabled"
   schedule:
@@ -46,6 +50,7 @@ updates:
 
 # frontend
 - package-ecosystem: npm
+  open-pull-requests-limit: 0
   directory: "/frontend"
   rebase-strategy: "disabled"
   schedule:
@@ -54,6 +59,7 @@ updates:
     timezone: "Europe/Berlin"
     time: "03:00"
 - package-ecosystem: docker
+  open-pull-requests-limit: 0
   directory: "/frontend"
   rebase-strategy: "disabled"
   schedule:
@@ -64,6 +70,7 @@ updates:
 
 # backend
 - package-ecosystem: npm
+  open-pull-requests-limit: 0
   directory: "/backend"
   rebase-strategy: "disabled"
   schedule:
@@ -72,6 +79,7 @@ updates:
     timezone: "Europe/Berlin"
     time: "03:00"
 - package-ecosystem: docker
+  open-pull-requests-limit: 0
   directory: "/backend"
   rebase-strategy: "disabled"
   schedule:


### PR DESCRIPTION
## 🍰 Pullrequest
Thanks to @ulfgebhardt's observations, we noticed that dependabotper default only generates 5 package update bump pull requests.
This change removes this limitation.