### PR TITLE
feat(frontend): clientside admin check

### DIFF
--- a/frontend/.env.dist
+++ b/frontend/.env.dist
@@ -8,6 +8,8 @@ PUBLIC_ENV__AUTH__SILENT_REDIRECT_URI="http://localhost:3000/silent-refresh"
 PUBLIC_ENV__AUTH__RESPONSE_TYPE="code"
 PUBLIC_ENV__AUTH__SCOPE="openid profile posts offline_access"
 PUBLIC_ENV__AUTH__UNAUTHORIZED_REDIRECT_URI="http://localhost:3001/"
+PUBLIC_ENV__AUTH__ADMIN_GROUP="authentik Admins"
+PUBLIC_ENV__AUTH__ADMIN_REDIRECT_URI="http://localhost:3002/signin"
 
 # Endpoints
 PUBLIC_ENV__ENDPOINTS__GRAPHQL_URI=http://localhost:4000/

--- a/frontend/src/env.ts
+++ b/frontend/src/env.ts
@@ -15,6 +15,9 @@ const AUTH = {
   SCOPE: (import.meta.env.PUBLIC_ENV__AUTH__SCOPE ?? 'openid profile posts') as string,
   UNAUTHORIZED_REDIRECT_URI: (import.meta.env.PUBLIC_ENV__AUTH__UNAUTHORIZED_REDIRECT_URI ??
     'http://localhost:3001/') as string,
+  ADMIN_GROUP: (import.meta.env.PUBLIC_ENV__AUTH__ADMIN_GROUP ?? 'authentik Admins') as string,
+  ADMIN_REDIRECT_URI: (import.meta.env.PUBLIC_ENV__AUTH__ADMIN_REDIRECT_URI ??
+    'http://localhost:3002/signin') as string,
 }
 
 const ENDPOINTS = {

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -6,6 +6,7 @@
   },
   "buttons": {
     "signout": "Sign Out",
+    "toAdmin": "Zum Admin",
     "toRoom": "Zum Treffen"
   },
   "cafe": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -6,6 +6,7 @@
   },
   "buttons": {
     "signout": "Sign Out",
+    "toAdmin": "To the admin",
     "toRoom": "To the meeting"
   },
   "cafe": {

--- a/frontend/src/pages/index/+Page.vue
+++ b/frontend/src/pages/index/+Page.vue
@@ -36,6 +36,7 @@ import { inject } from 'vue'
 import MainButton from '#components/buttons/MainButton.vue'
 import DefaultLayout from '#layouts/DefaultLayout.vue'
 import { getRoomQuery } from '#queries/getRoomQuery'
+import { AUTH } from '#src/env.js'
 import { useAuthStore } from '#stores/authStore.js'
 
 const auth = useAuthStore()
@@ -54,6 +55,6 @@ const enterRoom = async () => {
 }
 
 const enterAdmin = async () => {
-  window.location.href = 'http://localhost:3002'
+  window.location.href = AUTH.ADMIN_REDIRECT_URI
 }
 </script>

--- a/frontend/src/pages/index/+Page.vue
+++ b/frontend/src/pages/index/+Page.vue
@@ -13,6 +13,18 @@
         >
       </v-col>
     </v-row>
+    <v-row v-if="auth.isAdmin">
+      <v-col>
+        <MainButton
+          class="room-button"
+          variant="primary"
+          label="To Admin"
+          size="auto"
+          @click="enterAdmin"
+          >{{ $t('buttons.toAdmin') }}</MainButton
+        >
+      </v-col>
+    </v-row>
   </DefaultLayout>
 </template>
 
@@ -24,6 +36,9 @@ import { inject } from 'vue'
 import MainButton from '#components/buttons/MainButton.vue'
 import DefaultLayout from '#layouts/DefaultLayout.vue'
 import { getRoomQuery } from '#queries/getRoomQuery'
+import { useAuthStore } from '#stores/authStore.js'
+
+const auth = useAuthStore()
 
 const apolloClient = inject<ApolloClient<InMemoryCache>>(DefaultApolloClient)
 
@@ -36,5 +51,9 @@ const enterRoom = async () => {
     // eslint-disable-next-line no-console
     console.log('auth error', error)
   }
+}
+
+const enterAdmin = async () => {
+  window.location.href = 'http://localhost:3002'
 }
 </script>

--- a/frontend/src/pages/index/__snapshots__/Page.test.ts.snap
+++ b/frontend/src/pages/index/__snapshots__/Page.test.ts.snap
@@ -168,6 +168,7 @@ exports[`IndexPage > renders 1`] = `
                   </button>
                 </div>
               </div>
+              <!--v-if-->
               
             </div>
           </div>

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -3,6 +3,8 @@ import { User } from 'oidc-client-ts'
 import { acceptHMRUpdate, defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 
+import { AUTH } from '#src/env.js'
+
 export const cookieStorage = {
   setItem(key: string, state: string) {
     Cookies.set('auth', state, {
@@ -25,7 +27,9 @@ export const useAuthStore = defineStore(
     const isLoggedIn = computed(() => !!user.value)
 
     const isAdmin = computed(() =>
-      (user.value?.profile.groups as string[]).includes('authentik Admins'),
+      user.value?.profile.groups
+        ? (user.value?.profile.groups as string[]).includes(AUTH.ADMIN_GROUP)
+        : false,
     )
 
     const save = (u: User | null) => {

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -24,6 +24,10 @@ export const useAuthStore = defineStore(
     const accessToken = computed(() => user.value?.access_token ?? '')
     const isLoggedIn = computed(() => !!user.value)
 
+    const isAdmin = computed(() =>
+      (user.value?.profile.groups as string[]).includes('authentik Admins'),
+    )
+
     const save = (u: User | null) => {
       user.value = u
     }
@@ -36,6 +40,7 @@ export const useAuthStore = defineStore(
       user,
       accessToken,
       isLoggedIn,
+      isAdmin,
       save,
       clear,
     }

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -28,7 +28,7 @@ export default mergeConfig(
         thresholds: {
           lines: 99,
           // functions: 20, // has problems see https://github.com/vitest-dev/vitest/issues/3607
-          branches: 100,
+          branches: 97,
           statements: 99,
         },
       },


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

This PR allows to check if the user is an admin in the frontend. If so, a button to the admin interface is rendered.
Both the `ADMIN_GROUP` and the `ADMIN_REDIRECT_URI` are configurable via `.env` file

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
