### PR TITLE
refactor(other): refine package update management by dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -108,6 +108,56 @@ updates:
     day: "saturday"
     timezone: "Europe/Berlin"
     time: "03:00"
+  groups:
+    eslint:
+      applies-to: version-updates
+      patterns:
+        - "*eslint*"
+    pinia:
+      applies-to: version-updates
+      patterns:
+        - "*pinia*"
+    react:
+      applies-to: version-updates
+      patterns:
+        - "react*"
+    remark:
+      applies-to: version-updates
+      patterns:
+        - "remark*"
+    sass:
+      applies-to: version-updates
+      patterns:
+        - "sass*"
+    storybook:
+      applies-to: version-updates
+      patterns:
+        - "*storybook*"
+    stylelint:
+      applies-to: version-updates
+      patterns:
+        - "*stylelint*"
+    typescript:
+      applies-to: version-updates
+      patterns:
+        - "ts*"
+        - "*types*"
+    vite:
+      applies-to: version-updates
+      patterns:
+        - "*vite*"
+    vue:
+      applies-to: version-updates
+      patterns:
+        - "*vue?(/)*"
+      exclude-patterns:
+        - "vuetify"
+        - "*vuepress*"
+        - "vue-tsc"
+    vuepress:
+      applies-to: version-updates
+      patterns:
+        - "*vuepress*"  
 - package-ecosystem: docker
   open-pull-requests-limit: 99
   directory: "/admin"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,6 +38,56 @@ updates:
     day: "saturday"
     timezone: "Europe/Berlin"
     time: "03:00"
+  groups:
+    eslint:
+      applies-to: version-updates
+      patterns:
+        - "*eslint*"
+    pinia:
+      applies-to: version-updates
+      patterns:
+        - "*pinia*"
+    react:
+      applies-to: version-updates
+      patterns:
+        - "react*"
+    remark:
+      applies-to: version-updates
+      patterns:
+        - "remark*"
+    sass:
+      applies-to: version-updates
+      patterns:
+        - "sass*"
+    storybook:
+      applies-to: version-updates
+      patterns:
+        - "*storybook*"
+    stylelint:
+      applies-to: version-updates
+      patterns:
+        - "*stylelint*"
+    typescript:
+      applies-to: version-updates
+      patterns:
+        - "ts*"
+        - "*types*"
+    vite:
+      applies-to: version-updates
+      patterns:
+        - "*vite*"
+    vue:
+      applies-to: version-updates
+      patterns:
+        - "*vue?(/)*"
+      exclude-patterns:
+        - "vuetify"
+        - "*vuepress*"
+        - "vue-tsc"
+    vuepress:
+      applies-to: version-updates
+      patterns:
+        - "*vuepress*"
 - package-ecosystem: docker
   open-pull-requests-limit: 99
   directory: "/presenter"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -128,6 +128,56 @@ updates:
     day: "saturday"
     timezone: "Europe/Berlin"
     time: "03:00"
+  groups:
+    eslint:
+      applies-to: version-updates
+      patterns:
+        - "*eslint*"
+    pinia:
+      applies-to: version-updates
+      patterns:
+        - "*pinia*"
+    react:
+      applies-to: version-updates
+      patterns:
+        - "react*"
+    remark:
+      applies-to: version-updates
+      patterns:
+        - "remark*"
+    sass:
+      applies-to: version-updates
+      patterns:
+        - "sass*"
+    storybook:
+      applies-to: version-updates
+      patterns:
+        - "*storybook*"
+    stylelint:
+      applies-to: version-updates
+      patterns:
+        - "*stylelint*"
+    typescript:
+      applies-to: version-updates
+      patterns:
+        - "ts*"
+        - "*types*"
+    vite:
+      applies-to: version-updates
+      patterns:
+        - "*vite*"
+    vue:
+      applies-to: version-updates
+      patterns:
+        - "*vue?(/)*"
+      exclude-patterns:
+        - "vuetify"
+        - "*vuepress*"
+        - "vue-tsc"
+    vuepress:
+      applies-to: version-updates
+      patterns:
+        - "*vuepress*"
 - package-ecosystem: docker
   open-pull-requests-limit: 99
   directory: "/frontend"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -98,6 +98,26 @@ updates:
     day: "saturday"
     timezone: "Europe/Berlin"
     time: "03:00"
+  groups:
+    eslint:
+      applies-to: version-updates
+      patterns:
+        - "*eslint*"
+      exclude-patterns:
+        - "eslint-plugin-n"
+        - "eslint"
+    prisma:
+      applies-to: version-updates
+      patterns:
+        - "*prisma*"
+    remark:
+      applies-to: version-updates
+      patterns:
+        - "remark*"
+    vuepress:
+      applies-to: version-updates
+      patterns:
+        - "*vuepress*"
 - package-ecosystem: docker
   open-pull-requests-limit: 999
   directory: "/backend"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
 - package-ecosystem: "github-actions"
-  open-pull-requests-limit: 999
+  open-pull-requests-limit: 99
   directory: "/"
   rebase-strategy: "disabled"
   schedule:
@@ -10,7 +10,7 @@ updates:
     timezone: "Europe/Berlin"
     time: "03:00"
 - package-ecosystem: npm
-  open-pull-requests-limit: 999
+  open-pull-requests-limit: 99
   directory: "/"
   rebase-strategy: "disabled"
   schedule:
@@ -19,7 +19,7 @@ updates:
     timezone: "Europe/Berlin"
     time: "03:00"
 - package-ecosystem: docker
-  open-pull-requests-limit: 999
+  open-pull-requests-limit: 99
   directory: "/"
   rebase-strategy: "disabled"
   schedule:
@@ -30,7 +30,7 @@ updates:
 
 # presenter
 - package-ecosystem: npm
-  open-pull-requests-limit: 999
+  open-pull-requests-limit: 99
   directory: "/presenter"
   rebase-strategy: "disabled"
   schedule:
@@ -39,7 +39,7 @@ updates:
     timezone: "Europe/Berlin"
     time: "03:00"
 - package-ecosystem: docker
-  open-pull-requests-limit: 999
+  open-pull-requests-limit: 99
   directory: "/presenter"
   rebase-strategy: "disabled"
   schedule:
@@ -50,7 +50,7 @@ updates:
 
 # admin
 - package-ecosystem: npm
-  open-pull-requests-limit: 999
+  open-pull-requests-limit: 99
   directory: "/admin"
   rebase-strategy: "disabled"
   schedule:
@@ -59,7 +59,7 @@ updates:
     timezone: "Europe/Berlin"
     time: "03:00"
 - package-ecosystem: docker
-  open-pull-requests-limit: 999
+  open-pull-requests-limit: 99
   directory: "/admin"
   rebase-strategy: "disabled"
   schedule:
@@ -70,7 +70,7 @@ updates:
 
 # frontend
 - package-ecosystem: npm
-  open-pull-requests-limit: 999
+  open-pull-requests-limit: 99
   directory: "/frontend"
   rebase-strategy: "disabled"
   schedule:
@@ -79,7 +79,7 @@ updates:
     timezone: "Europe/Berlin"
     time: "03:00"
 - package-ecosystem: docker
-  open-pull-requests-limit: 999
+  open-pull-requests-limit: 99
   directory: "/frontend"
   rebase-strategy: "disabled"
   schedule:
@@ -90,7 +90,7 @@ updates:
 
 # backend
 - package-ecosystem: npm
-  open-pull-requests-limit: 999
+  open-pull-requests-limit: 99
   directory: "/backend"
   rebase-strategy: "disabled"
   schedule:
@@ -119,7 +119,7 @@ updates:
       patterns:
         - "*vuepress*"
 - package-ecosystem: docker
-  open-pull-requests-limit: 999
+  open-pull-requests-limit: 99
   directory: "/backend"
   rebase-strategy: "disabled"
   schedule:


### PR DESCRIPTION
## 🍰 Pullrequest
To simplify maintenance and package updates for all four subdirectories (backend, admin, frontend, presenter), the automated package update PRs are bundled.
Therefor the [dependabot groups mechanism](https://github.blog/2023-08-24-a-faster-way-to-manage-version-updates-with-dependabot/) is utilized.

Examples of the package bump bundling can be seen in the boilerplate repos
- [IT4Change/boilerplate-backend](https://github.com/IT4Change/boilerplate-backend/pulls)
- [IT4Change/boilerplate-frontend](https://github.com/IT4Change/boilerplate-frontend/pulls)


