### PR TITLE
ci(workflow): replace vuepress deploy action

### DIFF
--- a/.github/workflows/deploy.docs.yml
+++ b/.github/workflows/deploy.docs.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@master
 
       - name: vuepress-deploy
-        uses: jenkey2011/vuepress-deploy@master
+        uses: IT4Change/vuepress-build-and-deploy@master
         env:
           ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           #TARGET_REPO: username/repo


### PR DESCRIPTION
## 🍰 Pullrequest
The Github Action [Vuepress deploy](https://github.com/marketplace/actions/vuepress-deploy) uses Node v16.
Our Vuepress Deployment requires Node v20 or higher.

The Action is replaced by [IT4C/Vuepress Build & Deploy](https://github.com/marketplace/actions/vuepress-build-deploy).

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
