### PR TITLE
fix(other): revert docs file exclusion from file filter and latest vuetify package update

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -10,17 +10,17 @@ presenter-test-lint-code: &presenter-test-lint-code
 presenter-test-unit-code: &presenter-test-unit-code
   - '.github/workflows/presenter.test.unit.code.yml'
   - '.github/file-filters.yml'
-  - 'presenter/!(.vuepress)/**/*!(.md)'
+  - 'presenter/**/*'
 
 presenter-test-build-code: &presenter-test-build-code
   - '.github/workflows/presenter.test.build.code.yml'
   - '.github/file-filters.yml'
-  - 'presenter/!(.vuepress)/**/*!(.md)'
+  - 'presenter/**/*'
 
 presenter-test-build-docker: &presenter-test-build-docker
   - '.github/workflows/presenter.test.build.docker.yml'
   - '.github/file-filters.yml'
-  - 'presenter/!(.vuepress)/**/*!(.md)'
+  - 'presenter/**/*'
 
 presenter-test-build-docs: &presenter-test-build-docs
   - '.github/workflows/presenter.test.build.docs.yml'
@@ -32,7 +32,7 @@ presenter-test-build-docs: &presenter-test-build-docs
 presenter-test-build-storybook: &presenter-test-build-storybook
   - '.github/workflows/presenter.test.build.storybook.yml'
   - '.github/file-filters.yml'
-  - 'presenter/!(.vuepress)/**/*!(.md)'
+  - 'presenter/**/*'
 
 # frontend
 frontend-test-lint-code: &frontend-test-lint-code
@@ -41,17 +41,17 @@ frontend-test-lint-code: &frontend-test-lint-code
 frontend-test-unit-code: &frontend-test-unit-code
   - '.github/workflows/frontend.test.unit.code.yml'
   - '.github/file-filters.yml'
-  - 'frontend/!(.vuepress)/**/*!(.md)'
+  - 'frontend/**/*'
 
 frontend-test-build-code: &frontend-test-build-code
   - '.github/workflows/frontend.test.build.code.yml'
   - '.github/file-filters.yml'
-  - 'frontend/!(.vuepress)/**/*!(.md)'
+  - 'frontend/**/*'
 
 frontend-test-build-docker: &frontend-test-build-docker
   - '.github/workflows/frontend.test.build.docker.yml'
   - '.github/file-filters.yml'
-  - 'frontend/!(.vuepress)/**/*!(.md)'
+  - 'frontend/**/*'
 
 frontend-test-build-docs: &frontend-test-build-docs
   - '.github/workflows/frontend.test.build.docs.yml'
@@ -63,7 +63,7 @@ frontend-test-build-docs: &frontend-test-build-docs
 frontend-test-build-storybook: &frontend-test-build-storybook
   - '.github/workflows/frontend.test.build.storybook.yml'
   - '.github/file-filters.yml'
-  - 'frontend/!(.vuepress)/**/*!(.md)'
+  - 'frontend/**/*'
 
 # admin
 admin-test-lint-code: &admin-test-lint-code
@@ -72,17 +72,17 @@ admin-test-lint-code: &admin-test-lint-code
 admin-test-unit-code: &admin-test-unit-code
   - '.github/workflows/admin.test.unit.code.yml'
   - '.github/file-filters.yml'
-  - 'admin/!(.vuepress)/**/*!(.md)'
+  - 'admin/**/*'
 
 admin-test-build-code: &admin-test-build-code
   - '.github/workflows/admin.test.build.code.yml'
   - '.github/file-filters.yml'
-  - 'admin/!(.vuepress)/**/*!(.md)'
+  - 'admin/**/*'
 
 admin-test-build-docker: &admin-test-build-docker
   - '.github/workflows/admin.test.build.docker.yml'
   - '.github/file-filters.yml'
-  - 'admin/!(.vuepress)/**/*!(.md)'
+  - 'admin/**/*'
 
 admin-test-build-docs: &admin-test-build-docs
   - '.github/workflows/admin.test.build.docs.yml'
@@ -94,7 +94,7 @@ admin-test-build-docs: &admin-test-build-docs
 admin-test-build-storybook: &admin-test-build-storybook
   - '.github/workflows/admin.test.build.storybook.yml'
   - '.github/file-filters.yml'
-  - 'admin/!(.vuepress)/**/*!(.md)'
+  - 'admin/**/*'
 
 # backend
 backend-test-lint-code: &backend-test-lint-code
@@ -103,17 +103,17 @@ backend-test-lint-code: &backend-test-lint-code
 backend-test-unit-code: &backend-test-unit-code
   - '.github/workflows/backend.test.unit.code.yml'
   - '.github/file-filters.yml'
-  - 'backend/!(.vuepress)/**/*!(.md)'
+  - 'backend/**/*'
 
 backend-test-build-code: &backend-test-build-code
   - '.github/workflows/backend.test.build.code.yml'
   - '.github/file-filters.yml'
-  - 'backend/!(.vuepress)/**/*!(.md)'
+  - 'backend/**/*'
 
 backend-test-build-docker: &backend-test-build-docker
   - '.github/workflows/backend.test.build.docker.yml'
   - '.github/file-filters.yml'
-  - 'backend/!(.vuepress)/**/*!(.md)'
+  - 'backend/**/*'
 
 backend-test-build-docs: &backend-test-build-docs
   - 'backend/.github/workflows/backend.test.build.docs.yml'

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -32,7 +32,7 @@
         "vite": "^5.2.12",
         "vue": "3.4.27",
         "vue-i18n": "^9.13.1",
-        "vuetify": "^3.6.8"
+        "vuetify": "^3.5.15"
       },
       "devDependencies": {
         "@eslint-community/eslint-plugin-eslint-comments": "^4.3.0",
@@ -28255,9 +28255,9 @@
       }
     },
     "node_modules/vuetify": {
-      "version": "3.6.8",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.6.8.tgz",
-      "integrity": "sha512-j0v0iTeSVRj2ZEM9Q8HxejHxmxrQLYQSalhH82hfcraORaiDoqf1XV05N3P5ERXkKiJjJc/LfxFAUUvYSldxeg==",
+      "version": "3.5.16",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.5.16.tgz",
+      "integrity": "sha512-jyApfATreFMkgjvK0bL7ntZnr+p9TU73+4E3kX6fIvUitdAP9fltG7yj+v3k14HLqZRSNhTL1GhQ95DFx631zw==",
       "engines": {
         "node": "^12.20 || >=14.13"
       },

--- a/admin/package.json
+++ b/admin/package.json
@@ -84,7 +84,7 @@
     "vite": "^5.2.12",
     "vue": "3.4.27",
     "vue-i18n": "^9.13.1",
-    "vuetify": "^3.6.8"
+    "vuetify": "^3.5.15"
   },
   "devDependencies": {
     "@eslint-community/eslint-plugin-eslint-comments": "^4.3.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -41,7 +41,7 @@
         "vite-svg-loader": "^5.1.0",
         "vue": "3.4.27",
         "vue-i18n": "^9.13.1",
-        "vuetify": "^3.6.8"
+        "vuetify": "^3.5.17"
       },
       "devDependencies": {
         "@eslint-community/eslint-plugin-eslint-comments": "^4.3.0",
@@ -28684,9 +28684,9 @@
       }
     },
     "node_modules/vuetify": {
-      "version": "3.6.8",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.6.8.tgz",
-      "integrity": "sha512-j0v0iTeSVRj2ZEM9Q8HxejHxmxrQLYQSalhH82hfcraORaiDoqf1XV05N3P5ERXkKiJjJc/LfxFAUUvYSldxeg==",
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.5.17.tgz",
+      "integrity": "sha512-/Veklxxyu/l63q7QQOqJZeZukIKI2sBxY7FKMDcNup2KSGMjyjT+oYXy1DOdl7wlU3c3fKGQMFHqVWb0HDsyDw==",
       "engines": {
         "node": "^12.20 || >=14.13"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -94,7 +94,7 @@
     "vite-svg-loader": "^5.1.0",
     "vue": "3.4.27",
     "vue-i18n": "^9.13.1",
-    "vuetify": "^3.6.8"
+    "vuetify": "^3.5.17"
   },
   "devDependencies": {
     "@eslint-community/eslint-plugin-eslint-comments": "^4.3.0",

--- a/presenter/package-lock.json
+++ b/presenter/package-lock.json
@@ -38,7 +38,7 @@
         "vite": "^5.2.12",
         "vue": "3.4.27",
         "vue-i18n": "^9.13.1",
-        "vuetify": "^3.6.8"
+        "vuetify": "^3.5.15"
       },
       "devDependencies": {
         "@eslint-community/eslint-plugin-eslint-comments": "^4.3.0",
@@ -24247,9 +24247,9 @@
       }
     },
     "node_modules/vuetify": {
-      "version": "3.6.8",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.6.8.tgz",
-      "integrity": "sha512-j0v0iTeSVRj2ZEM9Q8HxejHxmxrQLYQSalhH82hfcraORaiDoqf1XV05N3P5ERXkKiJjJc/LfxFAUUvYSldxeg==",
+      "version": "3.5.15",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.5.15.tgz",
+      "integrity": "sha512-4v+t3yjgZ5M4+YKRK2eOxymWU34/Sg8YP6Dqi4ZMYFjchiwijOns1WW4ywYlYXih0TSPVeAeQpCzztDu89nTyg==",
       "engines": {
         "node": "^12.20 || >=14.13"
       },

--- a/presenter/package.json
+++ b/presenter/package.json
@@ -90,7 +90,7 @@
     "vite": "^5.2.12",
     "vue": "3.4.27",
     "vue-i18n": "^9.13.1",
-    "vuetify": "^3.6.8"
+    "vuetify": "^3.5.15"
   },
   "devDependencies": {
     "@eslint-community/eslint-plugin-eslint-comments": "^4.3.0",


### PR DESCRIPTION
## 🍰 Pullrequest
The docs files exclusion in the file filter in #942 where to restrictive and caused package bump PRs to go through our checks,because of skipping essential testings.

### Todo
- [X] revert docs files exclusion in file filter
- [x] revert latest Vuetify packages bumps
