### PR TITLE
build(docker): local deployment

### DIFF
--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -1,0 +1,30 @@
+FROM alpine:3.20.1
+
+RUN apk update
+RUN apk upgrade
+
+RUN apk add nginx openrc nodejs npm git mysql mysql-client webhook
+RUN npm install -g pm2
+RUN pm2 startup
+
+# comment out `skip-networking`
+RUN sed -e '/skip-networking/ s/^#*/#/' -i /etc/my.cnf.d/mariadb-server.cnf
+
+RUN rc-update add nginx boot
+RUN rc-update add pm2 boot
+RUN rc-update add mariadb boot
+
+RUN git clone --depth 1 https://github.com/dreammall-earth/dreammall.earth.git /var/www/localhost/htdocs/dreammall.earth
+WORKDIR /var/www/localhost/htdocs/dreammall.earth
+
+
+RUN cp -f deployment/nginx/default.conf /etc/nginx/http.d/default.conf
+RUN cp -f deployment/nginx/admin.conf deployment/nginx/frontend.conf /etc/nginx/http.d/
+
+RUN cp backend/.env.dist backend/.env
+RUN cp presenter/.env.dist presenter/.env
+RUN cp frontend/.env.dist frontend/.env
+
+COPY entrypoint.sh .
+ENTRYPOINT ["./entrypoint.sh"]
+EXPOSE 80

--- a/deployment/entrypoint.sh
+++ b/deployment/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+openrc reboot
+service nginx start
+service mariadb setup
+service mariadb start
+
+echo "
+CREATE USER 'dreammall'@'localhost' IDENTIFIED BY 'SECRET';
+GRANT ALL PRIVILEGES ON * . * TO 'dreammall'@'localhost';
+FLUSH PRIVILEGES;
+exit
+" | mysql
+
+cd /var/www/localhost/htdocs/dreammall.earth/
+
+./deployment/deploy.sh && exec "$@"


### PR DESCRIPTION
Motivation
----------
On the weekend we had a downtime on production because `nginx` configurations got out of sync with the code in newer releases.

To prevent this and further downtimes I suggest to check in our deployment configuration and make it *reproducible*.

This PR is an attempt to create a docker container that behaves as similar as possible to production and can be used as a sandbox for changes to our deployment configuration.

Read about infrastructure as code: https://en.wikipedia.org/wiki/Infrastructure_as_code

How to test
-----------
1. `cd deployment`
2. `docker build . --tag dreammall-deployment`
3. `docker run -it -p 8080:80 dreammall-deployment sh` .. and wait
4. Following services are running:
  * http://localhost:8080/
  * http://localhost:8080/api
  * http://localhost:8080/docs
5. Be amazed