### PR TITLE
build(other): test deployment locally

### DIFF
--- a/deployment/local-testing/.gitignore
+++ b/deployment/local-testing/.gitignore
@@ -1,0 +1,1 @@
+.vagrant

--- a/deployment/local-testing/README.md
+++ b/deployment/local-testing/README.md
@@ -1,0 +1,20 @@
+# Local test deployment
+
+Currently, we're deploying to a vServer. The following will set up virtual machines locally in order to test out the deployment before it hits `staging` or `production`.
+
+1. Install [Vagrant](https://www.vagrantup.com/) on your machine
+
+1. `cd deployment/local-testing`
+
+1. `vagrant up` .. and wait
+
+1. Following services are running:
+   - <http://localhost:8000/>
+   - <http://localhost:8000/api>
+   - <http://localhost:8000/docs>
+   - <http://localhost:8080/>
+   - <http://localhost:8082/>
+
+1. Be amazed
+
+In the future we might want to use [Ansible](https://www.ansible.com/) for provisioning. We could run our playbooks against this virtual machine, too.

--- a/deployment/local-testing/Vagrantfile
+++ b/deployment/local-testing/Vagrantfile
@@ -1,0 +1,13 @@
+# Defines our Vagrant environment
+#
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = 'generic/alpine319'
+  config.vm.provision :shell, path: "bootstrap.sh"
+  config.vm.synced_folder '.', '/vagrant', disabled: true
+  config.vm.network "forwarded_port", guest: 80, host: 8000
+  config.vm.network "forwarded_port", guest: 8080, host: 8080
+  config.vm.network "forwarded_port", guest: 8082, host: 8082
+end

--- a/deployment/local-testing/bootstrap.sh
+++ b/deployment/local-testing/bootstrap.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+apk update
+apk upgrade
+apk add nginx openrc nodejs npm git mysql mysql-client
+
+
+npm install pm2 -g
+pm2 startup
+
+rc-update add pm2 boot
+rc-update add nginx boot
+service nginx start
+
+
+service mariadb setup
+rc-update add mariadb boot
+sed -e '/skip-networking/ s/^#*/#/' -i /etc/my.cnf.d/mariadb-server.cnf
+service mariadb start
+
+
+cd /var/www/localhost/htdocs/
+git clone https://github.com/dreammall-earth/dreammall.earth.git
+cd dreammall.earth
+
+mkdir -p /etc/nginx/http.d
+cp -f ./deployment/nginx/default.conf /etc/nginx/http.d/default.conf
+cp ./deployment/nginx/frontend.conf /etc/nginx/http.d/frontend.conf
+cp ./deployment/nginx/admin.conf /etc/nginx/http.d/admin.conf
+
+service nginx restart
+
+mysql -e "CREATE USER 'dreammall'@'localhost' IDENTIFIED BY 'SECRET'; GRANT ALL PRIVILEGES ON * . * TO 'dreammall'@'localhost'; FLUSH PRIVILEGES;"
+
+cp backend/.env.dist backend/.env
+cp presenter/.env.dist presenter/.env
+cp frontend/.env.dist frontend/.env
+cp admin/.env.dist admin/.env
+
+deployment/deploy.sh


### PR DESCRIPTION
Context
-------
There was a similar PR #1263 attempting to do the same with docker. I was running into isolation issues with docker (setting hostname not allowed in the container and some system folders are read-only) and learned that for this use case, an actual hypervisor would be better and vagrant is a conventional tool to set up these virtual machines.

Motivation
----------
On the weekend we had a downtime on production because `nginx` configurations got out of sync with the code in newer releases.

To prevent this and further downtimes I suggest to check in our deployment configuration and make it *reproducible*.

This PR is an attempt to create a virtual machine that behaves as similar as possible to production and can be used as a sandbox for changes to our deployment configuration.

How to test
-----------
1. Install [Vagrant](https://www.vagrantup.com/) on your machine

1. `cd deployment/local-testing`

1. `vagrant up` .. and wait

1. Following services are running:
   - <http://localhost:8000/>
   - <http://localhost:8000/api>
   - <http://localhost:8000/docs>
   - <http://localhost:8080/>
   - <http://localhost:8082/>

1. Be amazed

In the future we might want to use [Ansible](https://www.ansible.com/) for provisioning. We could run our playbooks against this virtual machine, too.

