### PR TITLE
refactor(workflow): remove push target

### DIFF
--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -1,6 +1,6 @@
 name: admin
 
-on: [push,pull_request_target]
+on: pull_request_target
 
 jobs:
   files-changed:

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,6 +1,6 @@
 name: backend
 
-on: [push,pull_request_target]
+on: pull_request_target
 
 jobs:
   files-changed:

--- a/.github/workflows/e2e.run.tests.yml
+++ b/.github/workflows/e2e.run.tests.yml
@@ -1,6 +1,6 @@
 name: e2e:test:all test the application end to end
 
-on: [push,pull_request_target]
+on: pull_request_target
 
 jobs:
   e2e-tests:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,6 +1,6 @@
 name: e2e
 
-on: [push,pull_request_target]
+on: pull_request_target
 
 jobs:
   files-changed:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,6 +1,6 @@
 name: frontend
 
-on: [push,pull_request_target]
+on: pull_request_target
 
 jobs:
   files-changed:

--- a/.github/workflows/presenter.yml
+++ b/.github/workflows/presenter.yml
@@ -1,6 +1,6 @@
 name: presenter
 
-on: [push,pull_request_target]
+on: pull_request_target
 
 jobs:
   files-changed:

--- a/.github/workflows/root.yml
+++ b/.github/workflows/root.yml
@@ -1,6 +1,6 @@
 name: root
 
-on: [push,pull_request_target]
+on: pull_request_target
 
 jobs:
   files-changed:


### PR DESCRIPTION
Motivation
----------
We see a lot of jobs being triggered because of the `push` target (any branch). This is a waste of resources, it's better to trigger on a pull request only.

`pull_request` vs `pull_request_target`
---------------------------------------
I was reading [Github documentation](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target), quote:

> This event runs in the context of the base of the pull request, rather
> than in the context of the merge commit, as the pull_request event
does.

Then I was reading [Keeping your GitHub Actions and workflows secure](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/).

The bottom line here is that the combination of `pull_request_target` and explicit code checkout (e.g. `uses: actions/checkout@v4`) is a security risk.

The code of the workflow itself will be the one of `origin/master` but the code being checked out with `actions/checkout` is the one of the fork e.g. `malicious/main`.

If the workflow feeds a secret via `process.ENV` to a build script, then the attacker can read it because he is in control of the source code.

I was checking `git grep secrets` and the results are:
```
.github/workflows/admin.deploy.chromatic.yml:      CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN_ADMIN }}
.github/workflows/deploy.docs.yml:          ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
.github/workflows/frontend.deploy.chromatic.yml:      CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN_FRONTEND }}
.github/workflows/presenter.deploy.chromatic.yml:      CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN_PRESENTER }}
.github/workflows/release.yml:      #    github_token: ${{ secrets.GITHUB_TOKEN }}
.github/workflows/release.yml:          github_token: ${{ secrets.GITHUB_TOKEN }}
.github/workflows/release.yml:          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
.github/workflows/test.lint.pr.yml:          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
admin/README.md:In order to use the chromatic workflow you need to provide a `CHROMATIC_PROJECT_TOKEN` in the repository secrets.
frontend/README.md:In order to use the chromatic workflow you need to provide a `CHROMATIC_PROJECT_TOKEN` in the repository secrets.
presenter/README.md:In order to use the chromatic workflow you need to provide a `CHROMATIC_PROJECT_TOKEN` in the repository secrets.
```

We only have `GITHUB_TOKEN` and `CHROMATIC_PROJECT_TOKEN_**` exposed to any workflow. The workflows in question are all triggered by a push on `master` except `test.lint.pr`. The latter does not check out any code so it is safe.

That's why I think it's the best solution to use `pull_request_target` so that workflows also check PRs coming from forks.

tl;dr: Never use secrets on workflows with `pull_request_target`.

How to test
-----------
1. After merging this PR, each job is run only once, not twice

