### PR TITLE
fix(frontend): cleanup bottom menu classes

### DIFF
--- a/frontend/src/components/menu/BottomMenu.vue
+++ b/frontend/src/components/menu/BottomMenu.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="navigation-drawer-box d-md-none d-lg-none position-fixed mb-5 pb-5">
+  <div class="navigation-drawer-box d-md-none position-fixed mb-5 pb-5">
     <ListWithNavigationDrawer
       :drawer="drawer"
       :location="location"
@@ -7,7 +7,7 @@
     />
   </div>
   <div
-    class="bottom-menu d-flex w-100 position-fixed bottom-0 justify-space-around align-center py-2 bg-surface d-md-none d-lg-none"
+    class="bottom-menu d-flex w-100 position-fixed bottom-0 justify-space-around align-center py-2 bg-surface d-md-none"
   >
     <Circle class="camera-button" @click="toggleDrawer">
       <v-icon icon="$camera"></v-icon>

--- a/frontend/src/components/menu/__snapshots__/BottomMenu.test.ts.snap
+++ b/frontend/src/components/menu/__snapshots__/BottomMenu.test.ts.snap
@@ -10,7 +10,7 @@ exports[`BottomMenu > renders BottomMenu 1`] = `
     
     
     <div
-      class="navigation-drawer-box d-md-none d-lg-none position-fixed mb-5 pb-5"
+      class="navigation-drawer-box d-md-none position-fixed mb-5 pb-5"
       data-v-96a196cc=""
     >
       
@@ -130,7 +130,7 @@ exports[`BottomMenu > renders BottomMenu 1`] = `
       
     </div>
     <div
-      class="bottom-menu d-flex w-100 position-fixed bottom-0 justify-space-around align-center py-2 bg-surface d-md-none d-lg-none"
+      class="bottom-menu d-flex w-100 position-fixed bottom-0 justify-space-around align-center py-2 bg-surface d-md-none"
       data-v-96a196cc=""
     >
       <div

--- a/frontend/src/layouts/DefaultLayout.vue
+++ b/frontend/src/layouts/DefaultLayout.vue
@@ -14,7 +14,7 @@
         </v-col>
       </v-row>
     </v-container>
-    <BottomMenu class="d-md-none" />
+    <BottomMenu />
     <div id="teleported"></div>
   </v-main>
 </template>

--- a/frontend/src/layouts/__snapshots__/DefaultLayout.test.ts.snap
+++ b/frontend/src/layouts/__snapshots__/DefaultLayout.test.ts.snap
@@ -886,7 +886,7 @@ exports[`DefaultLayout > renders 1`] = `
       </div>
       
       <div
-        class="navigation-drawer-box d-md-none d-lg-none position-fixed mb-5 pb-5"
+        class="navigation-drawer-box d-md-none position-fixed mb-5 pb-5"
         data-v-96a196cc=""
       >
         
@@ -1006,7 +1006,7 @@ exports[`DefaultLayout > renders 1`] = `
         
       </div>
       <div
-        class="bottom-menu d-flex w-100 position-fixed bottom-0 justify-space-around align-center py-2 bg-surface d-md-none d-lg-none"
+        class="bottom-menu d-flex w-100 position-fixed bottom-0 justify-space-around align-center py-2 bg-surface d-md-none"
         data-v-96a196cc=""
       >
         <div

--- a/frontend/src/pages/index/__snapshots__/Page.test.ts.snap
+++ b/frontend/src/pages/index/__snapshots__/Page.test.ts.snap
@@ -1518,7 +1518,7 @@ exports[`IndexPage > without apollo error > renders 1`] = `
       </div>
       
       <div
-        class="navigation-drawer-box d-md-none d-lg-none position-fixed mb-5 pb-5"
+        class="navigation-drawer-box d-md-none position-fixed mb-5 pb-5"
         data-v-96a196cc=""
       >
         
@@ -1638,7 +1638,7 @@ exports[`IndexPage > without apollo error > renders 1`] = `
         
       </div>
       <div
-        class="bottom-menu d-flex w-100 position-fixed bottom-0 justify-space-around align-center py-2 bg-surface d-md-none d-lg-none"
+        class="bottom-menu d-flex w-100 position-fixed bottom-0 justify-space-around align-center py-2 bg-surface d-md-none"
         data-v-96a196cc=""
       >
         <div

--- a/frontend/src/pages/room/__snapshots__/Page.test.ts.snap
+++ b/frontend/src/pages/room/__snapshots__/Page.test.ts.snap
@@ -893,7 +893,7 @@ exports[`Room Page > renders 1`] = `
       </div>
       
       <div
-        class="navigation-drawer-box d-md-none d-lg-none position-fixed mb-5 pb-5"
+        class="navigation-drawer-box d-md-none position-fixed mb-5 pb-5"
         data-v-96a196cc=""
       >
         
@@ -1013,7 +1013,7 @@ exports[`Room Page > renders 1`] = `
         
       </div>
       <div
-        class="bottom-menu d-flex w-100 position-fixed bottom-0 justify-space-around align-center py-2 bg-surface d-md-none d-lg-none"
+        class="bottom-menu d-flex w-100 position-fixed bottom-0 justify-space-around align-center py-2 bg-surface d-md-none"
         data-v-96a196cc=""
       >
         <div


### PR DESCRIPTION
## 🍰 Pullrequest
Fixes this error message:

<img width="1488" alt="Screenshot 2024-07-07 at 13 33 01" src="https://github.com/dreammall-earth/dreammall.earth/assets/3285528/2434730c-801a-424d-b804-54f1310f6731">

Also removes unneeded `d-lg-none` after `d-md-none` as the former implies the latter.
