### PR TITLE
fix(docker): remove backend-documentation

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -133,24 +133,6 @@ services:
       # bind the local folder to the docker to allow live reload
       - ./backend:/server
 
-  #######################################################
-  # BACKEND DOCUMENTATION ###############################
-  #######################################################
-  backend-documentation:
-    build:
-      context: ./backend
-      target: documentation
-    ports:
-      - 8084:8080
-    environment:
-      - NODE_ENV=development
-    volumes:
-      # This makes sure the docker container has its own node modules.
-      # Therefore it is possible to have a different node version on the host machine
-      #- backend_documentation_node_modules:/app/node_modules
-      # bind the local folder to the docker to allow live reload
-      - ./backend:/server
-
   ########################################################
   # DOCUMENTATION ########################################
   ########################################################


### PR DESCRIPTION
Motivation
----------
When you `docker compose build` on `origin/master` you get the following:
```
failed to solve: target stage "documentation" could not be found
```

This is an oversight from #1325.

How to test
-----------
1. `docker compose build`
2. Succeeds
