### PR TITLE
refactor(docker): use default network

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,15 +1,4 @@
 services:
-  ########################################################
-  # DATABASE #############################################
-  ########################################################
-  database:
-    networks:
-      - internal-net
-      - external-net
-
-  ########################################################
-  # PRESENTER ############################################
-  ########################################################
   presenter:
     build:
       target: development
@@ -25,9 +14,6 @@ services:
       # bind the local folder to the docker to allow live reload
       - ./presenter:/app
 
-  #######################################################
-  # PRESENTER STORYBOOK #################################
-  #######################################################
   presenter-storybook:
     build:
       context: ./presenter
@@ -43,9 +29,6 @@ services:
       # bind the local folder to the docker to allow live reload
       - ./presenter:/app
 
-  ########################################################
-  # FRONTEND #############################################
-  ########################################################
   frontend:
     build:
       target: development
@@ -62,9 +45,6 @@ services:
       # bind the local folder to the docker to allow live reload
       - ./frontend:/app
 
-  #######################################################
-  # FRONTEND STORYBOOK ##################################
-  #######################################################
   frontend-storybook:
     build:
       context: ./frontend
@@ -80,9 +60,6 @@ services:
       # bind the local folder to the docker to allow live reload
       - ./frontend:/app
 
-  ########################################################
-  # ADMIN ################################################
-  ########################################################
   admin:
     build:
       target: development
@@ -99,9 +76,6 @@ services:
       # bind the local folder to the docker to allow live reload
       - ./admin:/app
 
-  #######################################################
-  # ADMIN STORYBOOK #####################################
-  #######################################################
   admin-storybook:
     build:
       context: ./admin
@@ -117,9 +91,6 @@ services:
       # bind the local folder to the docker to allow live reload
       - ./admin:/app
 
-  #######################################################
-  # BACKEND #############################################
-  #######################################################
   backend:
     build:
       context: ./backend
@@ -133,9 +104,6 @@ services:
       # bind the local folder to the docker to allow live reload
       - ./backend:/server
 
-  ########################################################
-  # DOCUMENTATION ########################################
-  ########################################################
   documentation:
     build:
       target: documentation

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,4 @@
 services:
-  ########################################################
-  # DATABASE #############################################
-  ########################################################
   database:
     build:
       context: ./database
@@ -10,81 +7,49 @@ services:
       - MARIADB_ALLOW_EMPTY_PASSWORD=1
       - MARIADB_ALLOW_EMPTY_ROOT_PASSWORD=1
       - MARIADB_USER=root
-    networks:
-      - internal-net
-      - external-net
     ports:
       - 3306:3306
     volumes:
       - db_vol:/var/lib/mysql
 
-  ########################################################
-  # PRESENTER ############################################
-  ########################################################
   presenter:
     build:
       context: ./presenter
       target: production
-    networks:
-      - external-net
-      - internal-net
     ports:
       - 3001:3000
     environment:
       - NODE_ENV=production
 
-  ########################################################
-  # FRONTEND #############################################
-  ########################################################
   frontend:
     build:
       context: ./frontend
       target: production
-    networks:
-      - external-net
-      - internal-net
     ports:
       - 3000:3000
     environment:
       - NODE_ENV=production
 
-  ########################################################
-  # ADMIN ################################################
-  ########################################################
   admin:
     build:
       context: ./admin
       target: production
-    networks:
-      - external-net
-      - internal-net
     ports:
       - 3002:3000
     environment:
       - NODE_ENV=production
 
-  #######################################################
-  # BACKEND #############################################
-  #######################################################
   backend:
     build:
       context: ./backend
       target: production
     depends_on:
       - database
-    networks:
-      - external-net
-      - internal-net
     ports:
       - 4000:4000
     environment:
       - DATABASE_URL=mysql://root:@database:3306/dreammall.earth
       - NODE_ENV=production
-
-networks:
-  external-net:
-  internal-net:
-    internal: true
 
 volumes:
   db_vol:


### PR DESCRIPTION
Motivation
----------

According to [docker compose docs](https://docs.docker.com/compose/compose-file/06-networks/):

> By default Compose sets up a single network for your app. Each container
> for a service joins the default network and is both reachable by other
> containers on that network, and discoverable by the service's name.

All our services are in the same network anyways, so let's remove this.

How to test
-----------
1. Nothing changes
