### PR TITLE
refactor(docker): remove unused volumes

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -8,10 +8,6 @@ services:
     environment:
       - NODE_ENV=development
     volumes:
-      # This makes sure the docker container has its own node modules.
-      # Therefore it is possible to have a different node version on the host machine
-      #- presenter_node_modules:/app/node_modules
-      # bind the local folder to the docker to allow live reload
       - ./presenter:/app
 
   presenter-storybook:
@@ -23,10 +19,6 @@ services:
     environment:
       - NODE_ENV=development
     volumes:
-      # This makes sure the docker container has its own node modules.
-      # Therefore it is possible to have a different node version on the host machine
-      #- presenter_storybook_node_modules:/app/node_modules
-      # bind the local folder to the docker to allow live reload
       - ./presenter:/app
 
   frontend:
@@ -39,10 +31,6 @@ services:
       - NODE_ENV=development
       - PORT_HMR=24679
     volumes:
-      # This makes sure the docker container has its own node modules.
-      # Therefore it is possible to have a different node version on the host machine
-      #- frontend_node_modules:/app/node_modules
-      # bind the local folder to the docker to allow live reload
       - ./frontend:/app
 
   frontend-storybook:
@@ -54,10 +42,6 @@ services:
     environment:
       - NODE_ENV=development
     volumes:
-      # This makes sure the docker container has its own node modules.
-      # Therefore it is possible to have a different node version on the host machine
-      #- frontend_storybook_node_modules:/app/node_modules
-      # bind the local folder to the docker to allow live reload
       - ./frontend:/app
 
   admin:
@@ -70,10 +54,6 @@ services:
       - NODE_ENV=development
       - PORT_HMR=24680
     volumes:
-      # This makes sure the docker container has its own node modules.
-      # Therefore it is possible to have a different node version on the host machine
-      #- admin_node_modules:/app/node_modules
-      # bind the local folder to the docker to allow live reload
       - ./admin:/app
 
   admin-storybook:
@@ -85,10 +65,6 @@ services:
     environment:
       - NODE_ENV=development
     volumes:
-      # This makes sure the docker container has its own node modules.
-      # Therefore it is possible to have a different node version on the host machine
-      #- admin_storybook_node_modules:/app/node_modules
-      # bind the local folder to the docker to allow live reload
       - ./admin:/app
 
   backend:
@@ -98,10 +74,6 @@ services:
     environment:
       - NODE_ENV=development
     volumes:
-      # This makes sure the docker container has its own node modules.
-      # Therefore it is possible to have a different node version on the host machine
-      #- backend_node_modules:/server/node_modules
-      # bind the local folder to the docker to allow live reload
       - ./backend:/server
 
   documentation:
@@ -112,18 +84,4 @@ services:
     environment:
       - NODE_ENV=development
     volumes:
-      # This makes sure the docker container has its own node modules.
-      # Therefore it is possible to have a different node version on the host machine
-      #- documentation_node_modules:/app/node_modules
-      # bind the local folder to the docker to allow live reload
       - ./:/app
-
-volumes:
-  presenter_node_modules:
-  presenter_storybook_node_modules:
-  frontend_node_modules:
-  frontend_storybook_node_modules:
-  admin_node_modules:
-  admin_storybook_node_modules:
-  backend_node_modules:
-  documentation_node_modules:


### PR DESCRIPTION
Motivation
----------
These volumes are not in use, let's remove them. As the comment says,
the original intention was to have a different node version in the
container and the host.

This is something that we *don't* want. We want to use the same node
version *always*, see #1319.

How to test
-----------
1. Nothing to test, disabled code.

