### PR TITLE
refactor(docker): restart authentik via include

### DIFF
--- a/authentik/README.md
+++ b/authentik/README.md
@@ -51,11 +51,11 @@ If you want to publish changes to the database you can use the following command
 
 ## E-Mail testing
 
-Authentik e-mails can be checked locally via [Mailpit mailserver](https://mailpit.axllent.org/).
+Authentik e-mails can be checked locally via [Mailpit](https://mailpit.axllent.org/).
 
 ### Prepare and start
 
-In the `authentik/` directory start authentik and mailserver:
+In the `authentik/` directory start authentik and mailpit:
 
 ```bash
 docker-compose -f docker-compose.yml -f docker-compose.test.yml up

--- a/authentik/docker-compose.test.yml
+++ b/authentik/docker-compose.test.yml
@@ -1,6 +1,6 @@
 x-mail-settings: &x-mail-settings
   environment:
-    - AUTHENTIK_EMAIL__HOST=mailserver
+    - AUTHENTIK_EMAIL__HOST=mailpit
     - AUTHENTIK_EMAIL__PORT=1025
     - AUTHENTIK_EMAIL__USE_TLS=false
     - AUTHENTIK_EMAIL__USE_SSL=false
@@ -8,15 +8,14 @@ x-mail-settings: &x-mail-settings
     - AUTHENTIK_EMAIL__FROM=authentik@example.com
 
 services:
-  mailserver:
+  mailpit:
     image: axllent/mailpit
-    container_name: mailpit
-    restart: unless-stopped
     ports:
       - 8025:8025
       - 1025:1025
 
-  server:
+  authentik:
     <<: *x-mail-settings
-  worker:
+
+  authentik-worker:
     <<: *x-mail-settings

--- a/authentik/docker-compose.yml
+++ b/authentik/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       POSTGRES_DB: ${PG_DB:-authentik}
     env_file:
       - .env
+
   redis:
     image: docker.io/library/redis:alpine
     command: --save 60 1 --loglevel warning
@@ -28,7 +29,8 @@ services:
       timeout: 3s
     volumes:
       - redis:/data
-  server:
+
+  authentik:
     image: ${AUTHENTIK_IMAGE:-ghcr.io/goauthentik/server}:${AUTHENTIK_TAG:-latest}
     restart: unless-stopped
     command: server
@@ -51,7 +53,8 @@ services:
     depends_on:
       - postgresql
       - redis
-  worker:
+
+  authentik-worker:
     image: ${AUTHENTIK_IMAGE:-ghcr.io/goauthentik/server}:${AUTHENTIK_TAG:-latest}
     restart: unless-stopped
     command: worker

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,3 +1,8 @@
+include:
+  - path:
+    - ./authentik/docker-compose.yml
+    - ./authentik/docker-compose.test.yml
+
 services:
   presenter:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,6 @@
+include:
+  - ./authentik/docker-compose.yml
+
 services:
   database:
     image: mariadb:10.5


### PR DESCRIPTION
Motivation
----------
Today I learned: Docker compose v2 has
[include](https://docs.docker.com/compose/multiple-compose-files/include/).

How to test
-----------
1. `docker compose up` from the root folder
2. All services, including authentik, start

