### PR TITLE
refactor(workflow): dry dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,7 @@
 version: 2
+
 updates:
+
 - package-ecosystem: "github-actions"
   open-pull-requests-limit: 99
   directory: "/"
@@ -9,299 +11,16 @@ updates:
     day: "saturday"
     timezone: "Europe/Berlin"
     time: "03:00"
-- package-ecosystem: npm
-  open-pull-requests-limit: 99
-  directory: "/"
-  rebase-strategy: "disabled"
-  schedule:
-    interval: weekly
-    day: "saturday"
-    timezone: "Europe/Berlin"
-    time: "03:00"
-  groups:
-    remark:
-      applies-to: version-updates
-      patterns:
-        - "remark*"
-    vuepress:
-      applies-to: version-updates
-      patterns:
-        - "*vuepress*"
-- package-ecosystem: docker
-  open-pull-requests-limit: 99
-  directory: "/"
-  rebase-strategy: "disabled"
-  schedule:
-    interval: weekly
-    day: "saturday"
-    timezone: "Europe/Berlin"
-    time: "03:00"
-
-# presenter
-- package-ecosystem: npm
-  open-pull-requests-limit: 99
-  directory: "/presenter"
-  rebase-strategy: "disabled"
-  schedule:
-    interval: weekly
-    day: "saturday"
-    timezone: "Europe/Berlin"
-    time: "03:00"
-  groups:
-    eslint:
-      applies-to: version-updates
-      patterns:
-        - "*eslint*"
-    pinia:
-      applies-to: version-updates
-      patterns:
-        - "*pinia*"
-    react:
-      applies-to: version-updates
-      patterns:
-        - "react*"
-    remark:
-      applies-to: version-updates
-      patterns:
-        - "remark*"
-    sass:
-      applies-to: version-updates
-      patterns:
-        - "sass*"
-    storybook:
-      applies-to: version-updates
-      patterns:
-        - "*storybook*"
-    stylelint:
-      applies-to: version-updates
-      patterns:
-        - "*stylelint*"
-    typescript:
-      applies-to: version-updates
-      patterns:
-        - "ts*"
-        - "*types*"
-    vite:
-      applies-to: version-updates
-      patterns:
-        - "*vite*"
-      exclude-patterns:
-        - "@vuepress/bundler-vite"
-        - "eslint-plugin-vitest"
-        - "vite-plugin-checker"
-    vue:
-      applies-to: version-updates
-      patterns:
-        - "*vue?(/)*"
-      exclude-patterns:
-        - "vuetify"
-        - "*vuepress*"
-        - "vue-tsc"
-    vuepress:
-      applies-to: version-updates
-      patterns:
-        - "*vuepress*"
-- package-ecosystem: docker
-  open-pull-requests-limit: 99
-  directory: "/presenter"
-  rebase-strategy: "disabled"
-  schedule:
-    interval: weekly
-    day: "saturday"
-    timezone: "Europe/Berlin"
-    time: "03:00"
-
-# admin
-- package-ecosystem: npm
-  open-pull-requests-limit: 99
-  directory: "/admin"
-  rebase-strategy: "disabled"
-  schedule:
-    interval: weekly
-    day: "saturday"
-    timezone: "Europe/Berlin"
-    time: "03:00"
-  groups:
-    eslint:
-      applies-to: version-updates
-      patterns:
-        - "*eslint*"
-    pinia:
-      applies-to: version-updates
-      patterns:
-        - "*pinia*"
-    react:
-      applies-to: version-updates
-      patterns:
-        - "react*"
-    remark:
-      applies-to: version-updates
-      patterns:
-        - "remark*"
-    sass:
-      applies-to: version-updates
-      patterns:
-        - "sass*"
-    storybook:
-      applies-to: version-updates
-      patterns:
-        - "*storybook*"
-    stylelint:
-      applies-to: version-updates
-      patterns:
-        - "*stylelint*"
-    typescript:
-      applies-to: version-updates
-      patterns:
-        - "ts*"
-        - "*types*"
-    vite:
-      applies-to: version-updates
-      patterns:
-        - "*vite*"
-      exclude-patterns:
-        - "@vuepress/bundler-vite"
-        - "eslint-plugin-vitest"
-        - "vite-plugin-checker"
-    vue:
-      applies-to: version-updates
-      patterns:
-        - "*vue?(/)*"
-      exclude-patterns:
-        - "vuetify"
-        - "*vuepress*"
-        - "vue-tsc"
-    vuepress:
-      applies-to: version-updates
-      patterns:
-        - "*vuepress*"  
-- package-ecosystem: docker
-  open-pull-requests-limit: 99
-  directory: "/admin"
-  rebase-strategy: "disabled"
-  schedule:
-    interval: weekly
-    day: "saturday"
-    timezone: "Europe/Berlin"
-    time: "03:00"
-
-# frontend
-- package-ecosystem: npm
-  open-pull-requests-limit: 99
-  directory: "/frontend"
-  rebase-strategy: "disabled"
-  schedule:
-    interval: weekly
-    day: "saturday"
-    timezone: "Europe/Berlin"
-    time: "03:00"
-  groups:
-    eslint:
-      applies-to: version-updates
-      patterns:
-        - "*eslint*"
-    pinia:
-      applies-to: version-updates
-      patterns:
-        - "*pinia*"
-    react:
-      applies-to: version-updates
-      patterns:
-        - "react*"
-    remark:
-      applies-to: version-updates
-      patterns:
-        - "remark*"
-    sass:
-      applies-to: version-updates
-      patterns:
-        - "sass*"
-    storybook:
-      applies-to: version-updates
-      patterns:
-        - "*storybook*"
-    stylelint:
-      applies-to: version-updates
-      patterns:
-        - "*stylelint*"
-    typescript:
-      applies-to: version-updates
-      patterns:
-        - "ts*"
-        - "*types*"
-    vite:
-      applies-to: version-updates
-      patterns:
-        - "*vite*"
-      exclude-patterns:
-        - "@vuepress/bundler-vite"
-        - "eslint-plugin-vitest"
-        - "vite-plugin-checker"
-    vue:
-      applies-to: version-updates
-      patterns:
-        - "*vue?(/)*"
-      exclude-patterns:
-        - "vuetify"
-        - "*vuepress*"
-        - "vue-tsc"
-    vuepress:
-      applies-to: version-updates
-      patterns:
-        - "*vuepress*"
-- package-ecosystem: docker
-  open-pull-requests-limit: 99
-  directory: "/frontend"
-  rebase-strategy: "disabled"
-  schedule:
-    interval: weekly
-    day: "saturday"
-    timezone: "Europe/Berlin"
-    time: "03:00"
-
-# backend
-- package-ecosystem: npm
-  open-pull-requests-limit: 99
-  directory: "/backend"
-  rebase-strategy: "disabled"
-  schedule:
-    interval: weekly
-    day: "saturday"
-    timezone: "Europe/Berlin"
-    time: "03:00"
-  groups:
-    eslint:
-      applies-to: version-updates
-      patterns:
-        - "*eslint*"
-      exclude-patterns:
-        - "eslint-plugin-n"
-        - "eslint"
-    prisma:
-      applies-to: version-updates
-      patterns:
-        - "*prisma*"
-    remark:
-      applies-to: version-updates
-      patterns:
-        - "remark*"
-    vuepress:
-      applies-to: version-updates
-      patterns:
-        - "*vuepress*"
-- package-ecosystem: docker
-  open-pull-requests-limit: 99
-  directory: "/backend"
-  rebase-strategy: "disabled"
-  schedule:
-    interval: weekly
-    day: "saturday"
-    timezone: "Europe/Berlin"
-    time: "03:00"
 
 - package-ecosystem: npm
   open-pull-requests-limit: 99
-  directory: "/tests"
+  directories:
+    - "/"
+    - "/admin"
+    - "/backend"
+    - "/frontend"
+    - "/presenter"
+    - "/tests"
   rebase-strategy: "disabled"
   schedule:
     interval: weekly
@@ -314,6 +33,18 @@ updates:
       patterns:
         - "*cypress*"
         - "*cucumber*"
+    remark:
+      applies-to: version-updates
+      patterns:
+        - "remark*"
+    vuepress:
+      applies-to: version-updates
+      patterns:
+        - "*vuepress*"
+    eslint:
+      applies-to: version-updates
+      patterns:
+        - "*eslint*"
     linting:
       applies-to: version-updates
       patterns:
@@ -323,12 +54,65 @@ updates:
         - "prettier"
       exclude-patterns:
         - "eslint"
+    prisma:
+      applies-to: version-updates
+      patterns:
+        - "*prisma*"
+    pinia:
+      applies-to: version-updates
+      patterns:
+        - "*pinia*"
+    react:
+      applies-to: version-updates
+      patterns:
+        - "react*"
+    sass:
+      applies-to: version-updates
+      patterns:
+        - "sass*"
+    storybook:
+      applies-to: version-updates
+      patterns:
+        - "*storybook*"
+    stylelint:
+      applies-to: version-updates
+      patterns:
+        - "*stylelint*"
     typescript:
       applies-to: version-updates
       patterns:
-        - "typescript"
         - "ts*"
-    vuepress:
+        - "*types*"
+    vite:
       applies-to: version-updates
       patterns:
+        - "*vite*"
+      exclude-patterns:
+        - "@vuepress/bundler-vite"
+        - "eslint-plugin-vitest"
+        - "vite-plugin-checker"
+    vue:
+      applies-to: version-updates
+      patterns:
+        - "*vue?(/)*"
+      exclude-patterns:
+        - "vuetify"
         - "*vuepress*"
+        - "vue-tsc"
+
+- package-ecosystem: docker
+  open-pull-requests-limit: 99
+  directories:
+    - "/"
+    - "/authentik"
+    - "/admin"
+    - "/backend"
+    - "/frontend"
+    - "/presenter"
+  rebase-strategy: "disabled"
+  schedule:
+    interval: weekly
+    day: "saturday"
+    timezone: "Europe/Berlin"
+    time: "03:00"
+


### PR DESCRIPTION
Motivation
----------
I was looking into configuration for dependabot to update the same package across multiple `package.json`s and found the [`directories` option](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#directories)

My goal is to update e.g. `vue` *across all subfolders* to the same version. You can check our PR list and see that the same dependency is updated separately for each folder, which is the culprit of our many dependanbot PRs.

Nevertheless, even if we don't see this behaviour, it's good to DRY our configuration files.

How to test
-----------
1. Merge this PR
2. See if dependabot updates the same package across several directories