### PR TITLE
fix(workflow): change old ``docker-compose`` call to new ``docker compose``

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -79,7 +79,7 @@ jobs:
         with:
           node-version-file: './.tool-versions'
       - name: Backend | docker-compose database
-        run: docker-compose -f docker-compose.yml up --detach --no-deps database
+        run: docker compose -f docker-compose.yml up --detach --no-deps database
       - name: Backend | Unit
         run: npm install && cp src/auth/public.pem . && npm run db:migrate && npm run test:unit
         working-directory: ./backend


### PR DESCRIPTION
## 🍰 Pullrequest
The "Backend | docker-compose database" flow did not work anymore with the following error:

Run docker-compose -f docker-compose.yml up --detach --no-deps database The Compose file './docker-compose.yml' is invalid because: 'include' does not match any of the regexes: '^x-'

You might be seeing this error because you're using the wrong Compose file version. Either specify a supported version (e.g "2.2" or "3.3") and place your service definitions under the `services` key, or omit the `version` key and place your service definitions at the root of the file to use version 1. For more on the Compose file format versions, see https://docs.docker.com/compose/compose-file/ Error: Process completed with exit code 1.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
