### PR TITLE
refactor(workflow): unify docker build workflows

### DIFF
--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -31,26 +31,6 @@ jobs:
         run: npm install && npm run build
         working-directory: ./admin
 
-  docker-production:
-    if: needs.files-changed.outputs.admin == 'true'
-    name: Build Docker Production - Admin
-    needs: files-changed
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Admin | Build Docker Production
-        run: docker compose -f docker-compose.yml build admin
-
-  docker-development:
-    if: needs.files-changed.outputs.admin == 'true'
-    name: Build Docker Development - Admin
-    needs: files-changed
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Admin | Build Docker Development
-        run: docker compose build admin admin-storybook
-
   storybook:
     if: needs.files-changed.outputs.admin == 'true'
     name: Build Storybook - Admin

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -32,26 +32,6 @@ jobs:
         run: npm install && npm run build
         working-directory: ./backend
 
-  docker-production:
-    if: needs.files-changed.outputs.backend == 'true'
-    name: Build Docker Production - Backend
-    needs: files-changed
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Backend | Build Docker Production
-        run: docker compose -f docker-compose.yml build backend
-
-  docker-development:
-    if: needs.files-changed.outputs.backend == 'true'
-    name: Build Docker Development - Backend
-    needs: files-changed
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Backend | Build Docker Development
-        run: docker compose build backend
-
   lint:
     if: needs.files-changed.outputs.backend == 'true'
     name: Lint - Backend

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,14 @@
+name: docker
+
+on: pull_request
+
+jobs:
+  docker-build:
+    name: Build Docker Images
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Root | Build Docker Images for Development
+        run: docker compose build
+      - name: Root | Build Docker Images for Production
+        run: docker compose -f docker-compose.yml build

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -32,26 +32,6 @@ jobs:
         run: npm install && npm run build
         working-directory: ./frontend
 
-  docker-production:
-    if: needs.files-changed.outputs.frontend == 'true'
-    name: Build Docker Production - Frontend
-    needs: files-changed
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Frontend | Build Docker Production
-        run: docker compose -f docker-compose.yml build frontend
-
-  docker-development:
-    if: needs.files-changed.outputs.frontend == 'true'
-    name: Build Docker Development - Frontend
-    needs: files-changed
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Frontend | Build Docker Development
-        run: docker compose build frontend frontend-storybook
-
   storybook:
     if: needs.files-changed.outputs.frontend == 'true'
     name: Build Storybook - Frontend

--- a/.github/workflows/presenter.yml
+++ b/.github/workflows/presenter.yml
@@ -32,26 +32,6 @@ jobs:
         run: npm install && npm run build
         working-directory: ./presenter
 
-  docker-production:
-    if: needs.files-changed.outputs.presenter == 'true'
-    name: Build Docker Production - Presenter
-    needs: files-changed
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Presenter | Build Docker Production
-        run: docker compose -f docker-compose.yml build presenter
-
-  docker-development:
-    if: needs.files-changed.outputs.presenter == 'true'
-    name: Build Docker Development - Presenter
-    needs: files-changed
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Presenter | Build Docker Development
-        run: docker compose build presenter presenter-storybook
-
   storybook:
     if: needs.files-changed.outputs.presenter == 'true'
     name: Build Storybook - Presenter


### PR DESCRIPTION
Motivation
----------
The motivation comes from this problem here:
https://github.com/dreammall-earth/dreammall.earth/pull/1383#issuecomment-2220051815

A previous change to the root `docker-compose.yml` was not caught by "Detect Files" job and thus merged into master. This caused the `master` to fail consistently because `docker-compose` (v1) was failing in a workflow that depends on the root `docker-compose` file.

Instead of re-configuring the "Detect Files" in all workflows, I think it would be best to [KISS](https://en.wikipedia.org/wiki/KISS_principle) here and unify the docker build workflows and *not* check the files changed. This means it would run on every pull request against `master`.

I will check how long it will take to build all docker images. Note that I combined the two jobs into one, to take advantage of docker's caching of multiple stages.

How to test
-----------
1. Carefully check the CI checks on this PR, including the time spent.

<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
