### PR TITLE
feat(workflow): auto-assign PR author

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,1 @@
+addAssignees: author

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,6 +12,13 @@ permissions:
   statuses: write
 
 jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@v2.0.0
+        with:
+          configuration-path: '.github/auto-assign.yml'
+
   main:
     name: Validate PR title
     runs-on: ubuntu-latest


### PR DESCRIPTION
Motivation
----------
I've heard today that we want to assign each PR to its respective author, so the name appears in the PR list on the right side: https://github.com/dreammall-earth/dreammall.earth/pulls

I keep forgetting this, so I'd say let's drop the requirement or automate this.

Feel free to reject this PR in case we drop the requirement.

![image](https://github.com/dreammall-earth/dreammall.earth/assets/2110676/3d5cf324-973c-4c62-a974-529613f6c28b)



How to test
-----------
1. Merge this into `master`
2. See if new PRs get auto-assigned
