### PR TITLE
fix(frontend): broken lints on `master`

### DIFF
--- a/frontend/src/components/tablesDrawer/TableList.test.ts
+++ b/frontend/src/components/tablesDrawer/TableList.test.ts
@@ -1,5 +1,3 @@
-import { wrap } from 'module'
-
 import { flushPromises, mount } from '@vue/test-utils'
 import { setActivePinia, createPinia } from 'pinia'
 import { navigate } from 'vike/client/router'

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -1,8 +1,8 @@
 {
   "$vuetify": {
     "input:": {
-      "clear": "Löschen",
-    },
+      "clear": "Löschen"
+    }
   },
   "auth": {
     "content": "Logge ein...",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1,8 +1,8 @@
 {
   "$vuetify": {
     "input:": {
-      "clear": "Clear",
-    },
+      "clear": "Clear"
+    }
   },
   "auth": {
     "content": "Logging in...",


### PR DESCRIPTION
Motivation
----------
We have another situation in which a PR cannot recover a `main` which is consistently failing.

How to test
-----------
1. `node --version` (v20.12.1)
2. `cd frontend`
3. `npm install`
4. `npm run lint`
