### PR TITLE
fix(workflow): PR title needs pull_request_target

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,7 +1,7 @@
 name: pr
 
 on:
-  push:
+  pull_request_target:
     types:
       - opened
       - edited


### PR DESCRIPTION
Motivation
----------
The workflow to check semantic pull request titles will never start if not triggered on `pull_request_target`. It used to be like that, see here:
https://github.com/dreammall-earth/dreammall.earth/blame/7e674588b9ab03525a495637f2491c0313cae66a/.github/workflows/pr.yml#L4

In #1391 we accidently changed that one, too.

How to test
-----------
1. Merge this into master
2. PR title workflow will run again.