### PR TITLE
build(authentik): update postgres

### DIFF
--- a/authentik/docker-compose.yml
+++ b/authentik/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgresql:
-    image: docker.io/library/postgres:12-alpine
+    image: docker.io/library/postgres:16-alpine
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}"]


### PR DESCRIPTION
Motivation
----------
Side quest of #1373. Given that our current deployment does not execute
the checked in `docker-compose.yml` it should be safe to update this one.

The motivation for this change is that the documented
`docker-compose.yml` of authentik uses `v16`: https://goauthentik.io/docker-compose.yml

From: https://docs.goauthentik.io/docs/installation/docker-compose

How to test
-----------
1. `docker compose up`
2. Newer image will be downloaded

