### PR TITLE
refactor(docker): use default file names

### DIFF
--- a/authentik/README.md
+++ b/authentik/README.md
@@ -58,7 +58,7 @@ Authentik e-mails can be checked locally via [Mailpit](https://mailpit.axllent.o
 In the `authentik/` directory start authentik and mailpit:
 
 ```bash
-docker-compose -f docker-compose.yml -f docker-compose.test.yml up
+docker-compose up
 ```
 
 ### Example

--- a/authentik/docker-compose.override.yml
+++ b/authentik/docker-compose.override.yml
@@ -16,6 +16,8 @@ services:
 
   authentik:
     <<: *x-mail-settings
+    depends_on:
+      - mailpit
 
   authentik-worker:
     <<: *x-mail-settings

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,7 +1,7 @@
 include:
   - path:
     - ./authentik/docker-compose.yml
-    - ./authentik/docker-compose.test.yml
+    - ./authentik/docker-compose.override.yml
 
 services:
   presenter:


### PR DESCRIPTION
Motivation
----------
Side quest of #1373. The motivation for the previous name was the fear that the `docker-compose.yml` of our repository was used in production.

I've learned that this is not the case. So let's simplify our code a little.

How to test
-----------
1. `cd authentik`
2. `docker compose up`
3. E.g. mailpit is running