### PR TITLE
feat(other): env vars in local virtual machine

### DIFF
--- a/infrastructure/bootstrap.sh
+++ b/infrastructure/bootstrap.sh
@@ -33,4 +33,10 @@ cp $PROJECT_ROOT/presenter/.env.dist $PROJECT_ROOT/presenter/.env
 cp $PROJECT_ROOT/frontend/.env.dist $PROJECT_ROOT/frontend/.env
 cp $PROJECT_ROOT/admin/.env.dist $PROJECT_ROOT/admin/.env
 
+# The target ports here must match the port mappings of the Vagrant file
+sed -e 's/localhost:3001/localhost:8000/g' -i $PROJECT_ROOT/*/.env
+sed -e 's/localhost:4000/localhost:8000\/api/g' -i $PROJECT_ROOT/*/.env
+sed -e 's/localhost:3000/localhost:8080/g' -i $PROJECT_ROOT/*/.env
+sed -e 's/localhost:3002/localhost:8082/g' -i $PROJECT_ROOT/*/.env
+
 $PROJECT_ROOT/deployment/deploy.sh


### PR DESCRIPTION
Motivation
----------
I was able to reproduce our websockets error in a local virtual machine.
This will setup the `.env` files in the respective folders if we are in
a Vagrant box.

How to test
-----------
1. Follow the [Infrastructure README](./infrastructure/README.md) to
   setup a virtual machine locally
2. `cd authentik`
3. `docker compose up`
4. `docker compose exec -T postgresql psql authentik --username authentik < dump.sql`
5. Visit <http://localhost:9000/if/admin/#/core/providers> and configure
   the OAuth/OpenID Provider's "Redirect URIs/Origin" to:
   ```
   http://localhost:8080/.*
   ```
6. Step 5 will also avoid CORS issues so you can now visit
   <http://localhost:8080/> and try to sign in there
7. In the browser developer tools you see the websockets connection
   error



![image](https://github.com/dreammall-earth/dreammall.earth/assets/2110676/98326446-aafb-42fb-9479-4414b21e2bc7)


![image](https://github.com/dreammall-earth/dreammall.earth/assets/2110676/1f2da180-df30-4de9-b0d9-027e30b05ef9)
