### PR TITLE
fix(other): nginx configuration for websockets

### DIFF
--- a/deployment/nginx/default.conf
+++ b/deployment/nginx/default.conf
@@ -2,24 +2,7 @@ server {
   listen 80 default_server;
   listen [::]:80 default_server;
 
-  location / {
-      proxy_http_version 1.1;
-      proxy_set_header   Upgrade $http_upgrade;
-      proxy_set_header   Connection 'upgrade';
-      proxy_set_header   X-Forwarded-For $remote_addr;
-      proxy_set_header   X-Real-IP  $remote_addr;
-      proxy_set_header   Host $host;
-      proxy_buffers      4 512k;
-      proxy_buffer_size  256k;
-
-      proxy_pass         http://127.0.0.1:3001/;
-      proxy_redirect     off;
-
-      access_log /var/www/localhost/htdocs/dreammall.earth/log/nginx.access.presenter.log combined;
-      error_log /var/www/localhost/htdocs/dreammall.earth/log/nginx.error.presenter.log warn;
-  }
-
-  location /api {
+  location /api/ {
       proxy_http_version 1.1;
       proxy_set_header   Upgrade $http_upgrade;
       proxy_set_header   Connection 'upgrade';
@@ -57,5 +40,22 @@ server {
 
       access_log /var/www/localhost/htdocs/dreammall.earth/log/nginx.access.hooks.log combined;
       error_log /var/www/localhost/htdocs/dreammall.earth/log/nginx.error.hooks.log warn;
+  }
+
+  location / {
+      proxy_http_version 1.1;
+      proxy_set_header   Upgrade $http_upgrade;
+      proxy_set_header   Connection 'upgrade';
+      proxy_set_header   X-Forwarded-For $remote_addr;
+      proxy_set_header   X-Real-IP  $remote_addr;
+      proxy_set_header   Host $host;
+      proxy_buffers      4 512k;
+      proxy_buffer_size  256k;
+
+      proxy_pass         http://127.0.0.1:3001/;
+      proxy_redirect     off;
+
+      access_log /var/www/localhost/htdocs/dreammall.earth/log/nginx.access.presenter.log combined;
+      error_log /var/www/localhost/htdocs/dreammall.earth/log/nginx.error.presenter.log warn;
   }
 }


### PR DESCRIPTION
Motivation
----------
The websocket connection to the backend introduced in #1268 does not
work because of a unluckly nginx configuration on the vServer in
production/staging.

In #1402 I could reproduce the problem locally. After numerous
tries/errors with the nginx configuration I'm now pretty sure this will
enable websockets on production.

How to test
-----------
1. Ensure that the `frontend/.env` has the exact same values as the
   currently checked in `frontend/.env.dist`:
   ```
    # The trailing slash is important!
    PUBLIC_ENV__ENDPOINTS__GRAPHQL_URI=http://localhost:4000/
    # The *missing* trailing slash is important!
    PUBLIC_ENV__ENDPOINTS__WEBSOCKET_URI=ws://localhost:4000/subscriptions
   ```
2. (optional) If you had to change `.env` values, run a `deployment/deploy.sh`
3. Checkout this feature branch, copy `deployment/nginx/default.conf`
   into `/etc/nginx/http./default.conf`
4. `rc-service nginx restart`
5. Works :)

