### PR TITLE
feat(frontend): improve open tables drawer design

### DIFF
--- a/frontend/src/assets/scss/dark.module.scss
+++ b/frontend/src/assets/scss/dark.module.scss
@@ -12,7 +12,7 @@ $font-color: #222;
 $icon-color: #F5F5F5;
 $icon-background: rgb(61 71 83 / 85%);
 $bottom-menu-background: rgb(78 91 107 / 60%);
-$sidebar-background: rgb(61 71 83 / 60%);
+$sidebar-background: rgb(61 71 83 / 90%);
 $dropdown-background-color: #3D4753;
 
 :export {

--- a/frontend/src/components/menu/BottomMenu.vue
+++ b/frontend/src/components/menu/BottomMenu.vue
@@ -1,7 +1,5 @@
 <template>
-  <div class="navigation-drawer-box d-md-none position-fixed mb-5 pb-5">
-    <TablesDrawer v-model="isTablesDrawerVisible" location="bottom" />
-  </div>
+  <TablesDrawer v-model="isTablesDrawerVisible" class="d-md-none" location="bottom" />
   <div
     class="bottom-menu d-flex w-100 position-fixed bottom-0 justify-space-around align-center py-2 bg-surface d-md-none"
   >
@@ -33,7 +31,7 @@ const toggleDrawer = () => {
 .bottom-menu {
   bottom: 0;
   left: 0;
-  z-index: 1;
+  z-index: 3000;
   background: var(--v-bottom-menu-background) !important;
   backdrop-filter: blur(20px);
   border-radius: 30px 30px 0 0;
@@ -46,9 +44,5 @@ const toggleDrawer = () => {
 .create-button-mobile {
   z-index: 1;
   transform: translate(20px, 30px);
-}
-
-.navigation-drawer-box {
-  bottom: 65px;
 }
 </style>

--- a/frontend/src/components/menu/TopMenu.vue
+++ b/frontend/src/components/menu/TopMenu.vue
@@ -28,7 +28,11 @@
       </v-row>
     </v-app-bar>
   </div>
-  <TablesDrawer v-model="isTablesDrawerVisible" location="right" />
+  <TablesDrawer
+    v-if="!$vuetify.display.smAndDown"
+    v-model="isTablesDrawerVisible"
+    location="right"
+  />
 </template>
 
 <script lang="ts" setup>

--- a/frontend/src/components/menu/TopMenu.vue
+++ b/frontend/src/components/menu/TopMenu.vue
@@ -1,38 +1,32 @@
 <template>
-  <div class="top-menu mt-6 mt-sm-0">
-    <v-app-bar flat class="app-bar" height="70">
-      <v-row class="ma-1">
-        <v-col class="d-none d-md-flex align-center">
-          <a href="/" class="logo">
-            <LogoImage size="small" />
-          </a>
-        </v-col>
-        <v-col class="d-flex align-center justify-center">
-          <TabControl />
-        </v-col>
-        <v-col class="d-none d-md-flex align-center">
-          <v-row>
-            <v-col class="d-flex align-center">
-              <LightDarkSwitch class="d-none d-lg-flex" />
-            </v-col>
-            <v-col class="d-flex align-center justify-end">
-              <button @click="toggleDrawer">
-                <Circle>
-                  <v-icon icon="$camera"></v-icon>
-                </Circle>
-              </button>
-              <UserInfo class="ml-2" />
-            </v-col>
-          </v-row>
-        </v-col>
-      </v-row>
-    </v-app-bar>
-  </div>
-  <TablesDrawer
-    v-if="!$vuetify.display.smAndDown"
-    v-model="isTablesDrawerVisible"
-    location="right"
-  />
+  <v-app-bar flat class="app-bar" height="70">
+    <v-row class="ma-1">
+      <v-col class="d-none d-md-flex align-center">
+        <a href="/" class="logo">
+          <LogoImage size="small" />
+        </a>
+      </v-col>
+      <v-col class="d-flex align-center justify-center">
+        <TabControl />
+      </v-col>
+      <v-col class="d-none d-md-flex align-center">
+        <v-row>
+          <v-col class="d-flex align-center">
+            <LightDarkSwitch class="d-none d-lg-flex" />
+          </v-col>
+          <v-col class="d-flex align-center justify-end">
+            <button @click="toggleDrawer">
+              <Circle>
+                <v-icon icon="$camera"></v-icon>
+              </Circle>
+            </button>
+            <UserInfo class="ml-2" />
+          </v-col>
+        </v-row>
+      </v-col>
+    </v-row>
+  </v-app-bar>
+  <TablesDrawer v-model="isTablesDrawerVisible" class="hide-on-mobile" location="right" />
 </template>
 
 <script lang="ts" setup>
@@ -52,9 +46,9 @@ const toggleDrawer = () => {
 </script>
 
 <style scoped lang="scss">
+@import 'vuetify/lib/styles/settings/_variables';
+
 .app-bar {
-  position: sticky;
-  top: 0;
   background: transparent !important;
 }
 
@@ -62,9 +56,9 @@ const toggleDrawer = () => {
   width: 140px;
 }
 
-.top-menu {
-  position: sticky;
-  top: 0;
-  z-index: 1008;
+.hide-on-mobile {
+  @media #{map-get($display-breakpoints, 'md-and-down')} {
+    display: none;
+  }
 }
 </style>

--- a/frontend/src/components/menu/TopMenu.vue
+++ b/frontend/src/components/menu/TopMenu.vue
@@ -61,6 +61,6 @@ const toggleDrawer = () => {
 .top-menu {
   position: sticky;
   top: 0;
-  z-index: 1000;
+  z-index: 1008;
 }
 </style>

--- a/frontend/src/components/menu/__snapshots__/BottomMenu.test.ts.snap
+++ b/frontend/src/components/menu/__snapshots__/BottomMenu.test.ts.snap
@@ -9,199 +9,35 @@ exports[`BottomMenu > renders BottomMenu 1`] = `
   >
     
     
-    <div
-      class="navigation-drawer-box d-md-none position-fixed mb-5 pb-5"
-      data-v-96a196cc=""
+    
+    <nav
+      class="v-navigation-drawer v-navigation-drawer--bottom v-navigation-drawer--temporary v-theme--light v-navigation-drawer--mobile menu-drawer px-4 d-md-none"
+      data-v-cf2c9067=""
+      style="bottom: 0px; z-index: 1004; transform: translateY(110%); position: fixed; transition: none !important; left: 0px; width: calc(100% - 0px - 0px);"
     >
-      
-      <nav
-        class="v-navigation-drawer v-navigation-drawer--bottom v-navigation-drawer--temporary v-theme--light v-navigation-drawer--mobile menu-drawer"
-        data-v-cf2c9067=""
-        style="bottom: 0px; z-index: 1004; transform: translateY(110%); position: fixed; transition: none !important; left: 0px; width: calc(100% - 0px - 0px);"
+      <!---->
+      <!---->
+      <div
+        class="v-navigation-drawer__content"
       >
-        <!---->
-        <!---->
+        
         <div
-          class="v-navigation-drawer__content"
+          class="v-input v-input--horizontal v-input--center-affix v-input--density-compact v-theme--light v-locale--is-ltr v-text-field search"
+          data-v-cf2c9067=""
         >
-          
+          <!---->
           <div
-            class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-text-field mx-4 mt-4 search"
-            data-v-cf2c9067=""
-          >
-            <!---->
-            <div
-              class="v-input__control"
-            >
-              
-              <div
-                class="v-field v-field--appended v-field--center-affix v-field--prepended v-field--variant-solo v-theme--light v-field--rounded v-locale--is-ltr"
-              >
-                <div
-                  class="v-field__overlay"
-                />
-                <div
-                  class="v-field__loader"
-                >
-                  <div
-                    aria-hidden="true"
-                    aria-valuemax="100"
-                    aria-valuemin="0"
-                    class="v-progress-linear v-theme--light v-locale--is-ltr"
-                    role="progressbar"
-                    style="top: 0px; height: 0px; --v-progress-linear-height: 2px;"
-                  >
-                    <!---->
-                    <div
-                      class="v-progress-linear__background"
-                      style="width: 100%;"
-                    />
-                    <transition-stub
-                      appear="false"
-                      css="true"
-                      name="fade-transition"
-                      persisted="false"
-                    >
-                      <div
-                        class="v-progress-linear__indeterminate"
-                      >
-                        
-                        <div
-                          class="v-progress-linear__indeterminate long"
-                        />
-                        <div
-                          class="v-progress-linear__indeterminate short"
-                        />
-                        
-                      </div>
-                    </transition-stub>
-                    <!---->
-                  </div>
-                </div>
-                <div
-                  class="v-field__prepend-inner"
-                >
-                  <i
-                    aria-hidden="true"
-                    class="mdi-tune mdi v-icon notranslate v-theme--light v-icon--size-default"
-                  />
-                  <!---->
-                </div>
-                <div
-                  class="v-field__field"
-                  data-no-activator=""
-                >
-                  <label
-                    aria-hidden="true"
-                    class="v-label v-field-label v-field-label--floating"
-                    for="input-1"
-                  >
-                    <!---->
-                    
-                    $t('tablesDrawer.searchPlaceholder')
-                    
-                  </label>
-                  <label
-                    class="v-label v-field-label"
-                    for="input-1"
-                  >
-                    <!---->
-                    
-                    $t('tablesDrawer.searchPlaceholder')
-                    
-                  </label>
-                  
-                  
-                  <!---->
-                  <input
-                    aria-describedby="input-1-messages"
-                    class="v-field__input"
-                    id="input-1"
-                    size="1"
-                    type="text"
-                  />
-                  <!---->
-                  
-                  
-                </div>
-                <transition-stub
-                  appear="false"
-                  css="true"
-                  name="expand-x-transition"
-                  persisted="false"
-                >
-                  <div
-                    class="v-field__clearable"
-                    style="display: none;"
-                  >
-                    
-                    <i
-                      aria-hidden="false"
-                      aria-label="$vuetify.input.clear"
-                      class="mdi-close-circle mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable"
-                      role="button"
-                      tabindex="0"
-                    />
-                    
-                  </div>
-                </transition-stub>
-                <div
-                  class="v-field__append-inner"
-                >
-                  <!---->
-                  <!---->
-                </div>
-                <div
-                  class="v-field__outline"
-                >
-                  <!---->
-                  <!---->
-                </div>
-              </div>
-              
-            </div>
-            <!---->
-            <div
-              class="v-input__details"
-            >
-              <transition-group-stub
-                appear="false"
-                aria-live="polite"
-                class="v-messages"
-                css="true"
-                id="input-1-messages"
-                name="slide-y-transition"
-                persisted="false"
-                role="alert"
-                tag="div"
-              >
-                <!---->
-              </transition-group-stub>
-              <!---->
-            </div>
-          </div>
-          <div
-            class="v-list v-theme--light bg-transparent v-list--density-default v-list--one-line"
-            data-v-cf2c9067=""
-            role="listbox"
-            tabindex="0"
+            class="v-input__control"
           >
             
-            <h2
-              class="mx-4"
-              data-v-cf2c9067=""
-            >
-              $t('tablesDrawer.header')
-            </h2>
             <div
-              class="v-card v-theme--light v-card--density-default v-card--variant-elevated mx-auto"
-              data-v-cf2c9067=""
-              data-v-de37061b=""
-              style="width: 400px;"
+              class="v-field v-field--appended v-field--center-affix v-field--flat v-field--prepended v-field--variant-solo v-theme--light v-field--rounded v-locale--is-ltr"
             >
-              <!---->
               <div
-                class="v-card__loader"
+                class="v-field__overlay"
+              />
+              <div
+                class="v-field__loader"
               >
                 <div
                   aria-hidden="true"
@@ -238,45 +74,141 @@ exports[`BottomMenu > renders BottomMenu 1`] = `
                   <!---->
                 </div>
               </div>
-              <!---->
-              <!---->
-              
               <div
-                class="v-list v-theme--light bg-transparent v-list--density-default v-list--two-line"
-                data-v-de37061b=""
-                role="listbox"
-                tabindex="0"
+                class="v-field__prepend-inner"
               >
+                <i
+                  aria-hidden="true"
+                  class="mdi-tune mdi v-icon notranslate v-theme--light v-icon--size-default"
+                />
+                <!---->
+              </div>
+              <div
+                class="v-field__field"
+                data-no-activator=""
+              >
+                <label
+                  aria-hidden="true"
+                  class="v-label v-field-label v-field-label--floating"
+                  for="input-1"
+                >
+                  <!---->
+                  
+                  $t('tablesDrawer.searchPlaceholder')
+                  
+                </label>
+                <label
+                  class="v-label v-field-label"
+                  for="input-1"
+                >
+                  <!---->
+                  
+                  $t('tablesDrawer.searchPlaceholder')
+                  
+                </label>
                 
                 
+                <!---->
+                <input
+                  aria-describedby="input-1-messages"
+                  class="v-field__input"
+                  id="input-1"
+                  size="1"
+                  type="text"
+                />
+                <!---->
                 
                 
               </div>
-              
-              <!---->
-              
-              <!---->
-              <span
-                class="v-card__underlay"
-              />
-              
+              <transition-stub
+                appear="false"
+                css="true"
+                name="expand-x-transition"
+                persisted="false"
+              >
+                <div
+                  class="v-field__clearable"
+                  style="display: none;"
+                >
+                  
+                  <i
+                    aria-hidden="false"
+                    aria-label="$vuetify.input.clear"
+                    class="mdi-close-circle mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable"
+                    role="button"
+                    tabindex="0"
+                  />
+                  
+                </div>
+              </transition-stub>
+              <div
+                class="v-field__append-inner"
+              >
+                <!---->
+                <!---->
+              </div>
+              <div
+                class="v-field__outline"
+              >
+                <!---->
+                <!---->
+              </div>
             </div>
             
           </div>
+          <!---->
+          <div
+            class="v-input__details"
+          >
+            <transition-group-stub
+              appear="false"
+              aria-live="polite"
+              class="v-messages"
+              css="true"
+              id="input-1-messages"
+              name="slide-y-transition"
+              persisted="false"
+              role="alert"
+              tag="div"
+            >
+              <!---->
+            </transition-group-stub>
+            <!---->
+          </div>
+        </div>
+        <div
+          class="v-list v-theme--light bg-transparent v-list--density-default v-list--one-line"
+          data-v-cf2c9067=""
+          role="listbox"
+          tabindex="0"
+        >
+          
+          <h2
+            class="header mb-4"
+            data-v-cf2c9067=""
+          >
+            $t('tablesDrawer.header')
+          </h2>
+          <div
+            data-v-cf2c9067=""
+          >
+            $t('tablesDrawer.noTables')
+          </div>
           
         </div>
-        <!---->
-      </nav>
-      <transition-stub
-        appear="false"
-        css="true"
-        name="fade-transition"
-        persisted="false"
-      >
-        <!---->
-      </transition-stub>
-      
-    </div>
+        
+      </div>
+      <!---->
+    </nav>
+    <transition-stub
+      appear="false"
+      css="true"
+      name="fade-transition"
+      persisted="false"
+    >
+      <!---->
+    </transition-stub>
+    
     <div
       class="bottom-menu d-flex w-100 position-fixed bottom-0 justify-space-around align-center py-2 bg-surface d-md-none"
       data-v-96a196cc=""

--- a/frontend/src/components/menu/__snapshots__/BottomMenu.test.ts.snap
+++ b/frontend/src/components/menu/__snapshots__/BottomMenu.test.ts.snap
@@ -133,7 +133,7 @@ exports[`BottomMenu > renders BottomMenu 1`] = `
                   
                   <i
                     aria-hidden="false"
-                    aria-label="$vuetify.input.clear"
+                    aria-label="Löschen"
                     class="mdi-close-circle mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable"
                     role="button"
                     tabindex="0"

--- a/frontend/src/components/menu/__snapshots__/TopMenu.test.ts.snap
+++ b/frontend/src/components/menu/__snapshots__/TopMenu.test.ts.snap
@@ -750,7 +750,7 @@ exports[`TopMenu > renders 1`] = `
     </div>
     
     <nav
-      class="v-navigation-drawer v-navigation-drawer--right v-navigation-drawer--temporary v-theme--light v-navigation-drawer--mobile menu-drawer"
+      class="v-navigation-drawer v-navigation-drawer--right v-navigation-drawer--temporary v-theme--light v-navigation-drawer--mobile menu-drawer px-4"
       data-v-cf2c9067=""
       style="right: 0px; z-index: 1004; transform: translateX(110%); position: fixed; transition: none !important; height: calc(100% - 70px - 0px); top: 70px; bottom: 0px;"
     >
@@ -761,7 +761,7 @@ exports[`TopMenu > renders 1`] = `
       >
         
         <div
-          class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-text-field mx-4 mt-4 search"
+          class="v-input v-input--horizontal v-input--center-affix v-input--density-compact v-theme--light v-locale--is-ltr v-text-field search"
           data-v-cf2c9067=""
         >
           <!---->
@@ -770,7 +770,7 @@ exports[`TopMenu > renders 1`] = `
           >
             
             <div
-              class="v-field v-field--appended v-field--center-affix v-field--prepended v-field--variant-solo v-theme--light v-field--rounded v-locale--is-ltr"
+              class="v-field v-field--appended v-field--center-affix v-field--flat v-field--prepended v-field--variant-solo v-theme--light v-field--rounded v-locale--is-ltr"
             >
               <div
                 class="v-field__overlay"
@@ -923,78 +923,15 @@ exports[`TopMenu > renders 1`] = `
         >
           
           <h2
-            class="mx-4"
+            class="header mb-4"
             data-v-cf2c9067=""
           >
             $t('tablesDrawer.header')
           </h2>
           <div
-            class="v-card v-theme--light v-card--density-default v-card--variant-elevated mx-auto"
             data-v-cf2c9067=""
-            data-v-de37061b=""
-            style="width: 400px;"
           >
-            <!---->
-            <div
-              class="v-card__loader"
-            >
-              <div
-                aria-hidden="true"
-                aria-valuemax="100"
-                aria-valuemin="0"
-                class="v-progress-linear v-theme--light v-locale--is-ltr"
-                role="progressbar"
-                style="top: 0px; height: 0px; --v-progress-linear-height: 2px;"
-              >
-                <!---->
-                <div
-                  class="v-progress-linear__background"
-                  style="width: 100%;"
-                />
-                <transition-stub
-                  appear="false"
-                  css="true"
-                  name="fade-transition"
-                  persisted="false"
-                >
-                  <div
-                    class="v-progress-linear__indeterminate"
-                  >
-                    
-                    <div
-                      class="v-progress-linear__indeterminate long"
-                    />
-                    <div
-                      class="v-progress-linear__indeterminate short"
-                    />
-                    
-                  </div>
-                </transition-stub>
-                <!---->
-              </div>
-            </div>
-            <!---->
-            <!---->
-            
-            <div
-              class="v-list v-theme--light bg-transparent v-list--density-default v-list--two-line"
-              data-v-de37061b=""
-              role="listbox"
-              tabindex="0"
-            >
-              
-              
-              
-              
-            </div>
-            
-            <!---->
-            
-            <!---->
-            <span
-              class="v-card__underlay"
-            />
-            
+            $t('tablesDrawer.noTables')
           </div>
           
         </div>

--- a/frontend/src/components/menu/__snapshots__/TopMenu.test.ts.snap
+++ b/frontend/src/components/menu/__snapshots__/TopMenu.test.ts.snap
@@ -752,7 +752,7 @@ exports[`TopMenu > renders 1`] = `
     <nav
       class="v-navigation-drawer v-navigation-drawer--right v-navigation-drawer--temporary v-theme--light v-navigation-drawer--mobile menu-drawer px-4"
       data-v-cf2c9067=""
-      style="right: 0px; z-index: 1004; transform: translateX(110%); position: fixed; transition: none !important; height: calc(100% - 70px - 0px); top: 70px; bottom: 0px;"
+      style="right: 0px; z-index: 1004; transform: translateX(110%); position: fixed; height: calc(100% - 70px - 0px); top: 70px; bottom: 0px; transition: none !important;"
     >
       <!---->
       <!---->
@@ -872,7 +872,7 @@ exports[`TopMenu > renders 1`] = `
                   
                   <i
                     aria-hidden="false"
-                    aria-label="$vuetify.input.clear"
+                    aria-label="Löschen"
                     class="mdi-close-circle mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable"
                     role="button"
                     tabindex="0"

--- a/frontend/src/components/menu/__snapshots__/TopMenu.test.ts.snap
+++ b/frontend/src/components/menu/__snapshots__/TopMenu.test.ts.snap
@@ -9,750 +9,745 @@ exports[`TopMenu > renders 1`] = `
   >
     
     
-    <div
-      class="top-menu mt-6 mt-sm-0"
+    <header
+      class="v-toolbar v-toolbar--flat v-toolbar--density-default v-theme--light v-locale--is-ltr v-app-bar app-bar"
       data-v-e787b5f9=""
+      style="top: 0px; z-index: 1006; transform: translateY(0%); position: fixed; transition: none !important; left: 0px; width: calc(100% - 0px - 0px);"
     >
-      <header
-        class="v-toolbar v-toolbar--flat v-toolbar--density-default v-theme--light v-locale--is-ltr v-app-bar app-bar"
-        data-v-e787b5f9=""
-        style="top: 0px; z-index: 1006; transform: translateY(0%); position: fixed; transition: none !important; left: 0px; width: calc(100% - 0px - 0px);"
+      <!---->
+      
+      <div
+        class="v-toolbar__content"
+        style="height: 70px;"
       >
+        <!---->
         <!---->
         
         <div
-          class="v-toolbar__content"
-          style="height: 70px;"
+          class="v-row ma-1"
+          data-v-e787b5f9=""
         >
-          <!---->
-          <!---->
-          
           <div
-            class="v-row ma-1"
+            class="v-col d-none d-md-flex align-center"
             data-v-e787b5f9=""
           >
-            <div
-              class="v-col d-none d-md-flex align-center"
+            <a
+              class="logo"
               data-v-e787b5f9=""
+              href="/"
             >
-              <a
-                class="logo"
+              <div
+                class="v-responsive v-img v-img--booting w-100 logo-small"
                 data-v-e787b5f9=""
-                href="/"
+                data-v-f6be2607=""
               >
                 <div
-                  class="v-responsive v-img v-img--booting w-100 logo-small"
-                  data-v-e787b5f9=""
-                  data-v-f6be2607=""
-                >
-                  <div
-                    class="v-responsive__sizer"
-                  />
-                  
-                  
-                  <transition-stub
-                    appear="true"
-                    css="true"
-                    name="fade-transition"
-                    persisted="false"
-                  >
-                    <img
-                      class="v-img__img v-img__img--contain"
-                      src="/src/assets/dreammall-logo.svg"
-                      style="display: none;"
-                    />
-                  </transition-stub>
-                  <transition-stub
-                    appear="false"
-                    css="true"
-                    name="fade-transition"
-                    persisted="false"
-                  >
-                    <!---->
-                  </transition-stub>
-                  <!---->
-                  <!---->
-                  <!---->
-                  
-                  
-                  <!---->
-                </div>
-              </a>
-            </div>
-            <div
-              class="v-col d-flex align-center justify-center"
-              data-v-e787b5f9=""
-            >
-              <button
-                class="tab-control ma-auto border-sm text-font open"
-                data-v-d58c92bb=""
-                data-v-e787b5f9=""
-              >
-                <div
-                  class="marker"
-                  data-v-d58c92bb=""
-                  style="display: none; width: 0px; left: 0px;"
+                  class="v-responsive__sizer"
                 />
-                <div
-                  class="d-flex align-center justify-center h-100 w-100"
-                  data-v-d58c92bb=""
+                
+                
+                <transition-stub
+                  appear="true"
+                  css="true"
+                  name="fade-transition"
+                  persisted="false"
                 >
-                  
-                  <a
-                    class="item active"
-                    data-v-d58c92bb=""
-                  >
-                    <div
-                      class="icon d-flex justify-center align-center"
-                      data-v-d58c92bb=""
-                    >
-                      <i
-                        aria-hidden="true"
-                        class="v-icon notranslate v-theme--light v-icon--size-default w-100 world-cafe"
-                        data-v-d58c92bb=""
-                      >
-                        <svg
-                          fill="none"
-                          height="193"
-                          viewBox="0 0 138 193"
-                          width="138"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <g
-                            clip-path="url(#clip0_932_149)"
-                          >
-                            <path
-                              clip-rule="evenodd"
-                              d="M29.6 136.89C7.05 118.08 -2.7 92.78 0.64 66.02C3.97 39.35 29.88 -0.749964 56.89 0.0100358C106.62 20.82 -15.77 78.98 29.6 136.89Z"
-                              fill="url(#paint0_linear_932_149)"
-                              fill-rule="evenodd"
-                            />
-                            <path
-                              clip-rule="evenodd"
-                              d="M29.6 136.89C24.66 132.77 20.33 128.33 16.62 123.64C3.99 107.66 -1.48 88.69 0.339998 68.8C1.06 88.98 14.09 89.62 20.99 79.13V79.15C41.21 43.56 86.69 15.42 56.89 0.0100098C106.63 20.82 -15.77 78.98 29.6 136.89Z"
-                              fill="#2D0100"
-                              fill-rule="evenodd"
-                            />
-                            <path
-                              clip-rule="evenodd"
-                              d="M29.61 136.9C-15.79 78.98 106.67 20.8 56.87 0C60.92 0.11 64.99 1.14 69.02 3.27C77.12 7.55 81.67 16.94 81.29 28.86C80.18 64.11 50.09 75.76 39.88 103.39C36.49 112.58 36.08 121.65 38.65 130.61C39.38 133.13 38.47 135.74 36.36 137.21C34.25 138.68 31.58 138.56 29.6 136.91L29.61 136.9Z"
-                              fill="url(#paint1_linear_932_149)"
-                              fill-rule="evenodd"
-                            />
-                            <path
-                              clip-rule="evenodd"
-                              d="M29.61 136.9C-15.79 78.99 106.63 20.82 56.89 0.0100098C70.63 1.37001 77.6 14.24 75.77 26.29C70.7 59.76 29 71.47 28.59 110.64C28.49 119.81 31.09 128.67 36.37 137.21C34.26 138.68 31.59 138.56 29.61 136.91V136.9Z"
-                              fill="url(#paint2_linear_932_149)"
-                              fill-rule="evenodd"
-                            />
-                            <path
-                              clip-rule="evenodd"
-                              d="M108.38 12.96C130.93 31.77 140.68 57.06 137.34 83.82C134.01 110.49 108.1 150.59 81.09 149.83C31.36 129.02 153.75 70.86 108.38 12.96Z"
-                              fill="url(#paint3_linear_932_149)"
-                              fill-rule="evenodd"
-                            />
-                            <path
-                              clip-rule="evenodd"
-                              d="M108.38 12.96C113.32 17.08 117.65 21.52 121.36 26.21C133.99 42.18 139.46 61.15 137.64 81.04C136.92 60.86 123.89 60.22 116.99 70.71V70.69C96.77 106.28 51.29 134.43 81.09 149.83C31.36 129.02 153.75 70.86 108.38 12.96Z"
-                              fill="#2D0100"
-                              fill-rule="evenodd"
-                            />
-                            <path
-                              clip-rule="evenodd"
-                              d="M108.37 12.95C153.77 70.86 31.31 129.04 81.11 149.84C77.06 149.73 72.99 148.7 68.96 146.57C60.86 142.29 56.31 132.9 56.69 120.98C57.8 85.73 87.89 74.08 98.1 46.45C101.49 37.26 101.9 28.19 99.33 19.23C98.6 16.71 99.51 14.1 101.62 12.63C103.73 11.16 106.4 11.28 108.38 12.93L108.37 12.95Z"
-                              fill="url(#paint4_linear_932_149)"
-                              fill-rule="evenodd"
-                            />
-                            <path
-                              clip-rule="evenodd"
-                              d="M108.37 12.95C153.76 70.85 31.35 129.03 81.09 149.84C67.35 148.48 60.38 135.61 62.21 123.56C67.28 90.09 108.98 78.38 109.39 39.21C109.49 30.04 106.89 21.18 101.61 12.64C103.72 11.17 106.39 11.29 108.37 12.94V12.95Z"
-                              fill="url(#paint5_linear_932_149)"
-                              fill-rule="evenodd"
-                            />
-                            <path
-                              clip-rule="evenodd"
-                              d="M46.08 182.97C46.04 188.09 50.16 192.27 55.29 192.31C59.9 192.34 63.48 188.95 64.5 184.6C66.82 174.7 62.43 164.87 49.88 158.79C57.01 170.18 46.15 173.4 46.09 182.96L46.08 182.97Z"
-                              fill="url(#paint6_linear_932_149)"
-                              fill-rule="evenodd"
-                            />
-                            <path
-                              clip-rule="evenodd"
-                              d="M48.07 182.99C48.04 187.01 51.28 190.3 55.3 190.33C56.87 190.34 58.28 189.85 59.44 189C56.57 187.88 54.11 185.72 52.66 182.73C51.21 179.74 51.03 176.26 52.02 173.24C50.26 176.33 48.1 179.16 48.07 182.98V182.99Z"
-                              fill="url(#paint7_linear_932_149)"
-                              fill-rule="evenodd"
-                              opacity="0.5"
-                            />
-                          </g>
-                          <defs>
-                            <lineargradient
-                              gradientUnits="userSpaceOnUse"
-                              id="paint0_linear_932_149"
-                              x1="-16.8153"
-                              x2="61.3369"
-                              y1="116.566"
-                              y2="-41.9949"
-                            >
-                              <stop
-                                stop-color="#1C2A39"
-                              />
-                              <stop
-                                offset="1"
-                                stop-color="#7C8A99"
-                              />
-                            </lineargradient>
-                            <lineargradient
-                              gradientUnits="userSpaceOnUse"
-                              id="paint1_linear_932_149"
-                              x1="11.8868"
-                              x2="75.9494"
-                              y1="87.02"
-                              y2="-30.1607"
-                            >
-                              <stop
-                                stop-color="#7C8A99"
-                              />
-                              <stop
-                                offset="1"
-                                stop-color="#FEFEFE"
-                              />
-                            </lineargradient>
-                            <lineargradient
-                              gradientUnits="userSpaceOnUse"
-                              id="paint2_linear_932_149"
-                              x1="19.31"
-                              x2="76.06"
-                              y1="69.12"
-                              y2="69.12"
-                            >
-                              <stop
-                                stop-color="#1C2A39"
-                              />
-                              <stop
-                                offset="1"
-                                stop-color="#BCCAD9"
-                              />
-                            </lineargradient>
-                            <lineargradient
-                              gradientUnits="userSpaceOnUse"
-                              id="paint3_linear_932_149"
-                              x1="160.483"
-                              x2="82.3302"
-                              y1="32.9545"
-                              y2="191.516"
-                            >
-                              <stop
-                                stop-color="#1C2A39"
-                              />
-                              <stop
-                                offset="1"
-                                stop-color="#7C8A99"
-                              />
-                            </lineargradient>
-                            <lineargradient
-                              gradientUnits="userSpaceOnUse"
-                              id="paint4_linear_932_149"
-                              x1="131.78"
-                              x2="67.7184"
-                              y1="62.5008"
-                              y2="179.682"
-                            >
-                              <stop
-                                stop-color="#7C8A99"
-                              />
-                              <stop
-                                offset="1"
-                                stop-color="#FEFEFE"
-                              />
-                            </lineargradient>
-                            <lineargradient
-                              gradientUnits="userSpaceOnUse"
-                              id="paint5_linear_932_149"
-                              x1="118.66"
-                              x2="61.92"
-                              y1="80.73"
-                              y2="80.73"
-                            >
-                              <stop
-                                stop-color="#1C2A39"
-                              />
-                              <stop
-                                offset="1"
-                                stop-color="#BCCAD9"
-                              />
-                            </lineargradient>
-                            <lineargradient
-                              gradientUnits="userSpaceOnUse"
-                              id="paint6_linear_932_149"
-                              x1="66.33"
-                              x2="38.1302"
-                              y1="185.538"
-                              y2="166.541"
-                            >
-                              <stop
-                                stop-color="#1C2A39"
-                              />
-                              <stop
-                                offset="1"
-                                stop-color="#BCCAD9"
-                              />
-                            </lineargradient>
-                            <lineargradient
-                              gradientUnits="userSpaceOnUse"
-                              id="paint7_linear_932_149"
-                              x1="48.07"
-                              x2="59.43"
-                              y1="181.79"
-                              y2="181.79"
-                            >
-                              <stop
-                                stop-color="#1C2A39"
-                              />
-                              <stop
-                                offset="1"
-                                stop-color="#BCCAD9"
-                              />
-                            </lineargradient>
-                            <clippath
-                              id="clip0_932_149"
-                            >
-                              <rect
-                                fill="white"
-                                height="192.32"
-                                width="137.98"
-                              />
-                            </clippath>
-                          </defs>
-                        </svg>
-                      </i>
-                    </div>
-                     $t('menu.worldCafe')
-                  </a>
-                  <a
-                    class="item"
-                    data-v-d58c92bb=""
-                  >
-                    <div
-                      class="icon d-flex justify-center align-center"
-                      data-v-d58c92bb=""
-                    >
-                      <i
-                        aria-hidden="true"
-                        class="v-icon notranslate v-theme--light v-icon--size-default w-100 cockpit"
-                        data-v-d58c92bb=""
-                      >
-                        <svg
-                          fill="none"
-                          height="176"
-                          viewBox="0 0 199 176"
-                          width="199"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <g
-                            clip-path="url(#clip0_932_164)"
-                          >
-                            <path
-                              clip-rule="evenodd"
-                              d="M114.97 173.44C150.48 163.92 197.5 127.82 198.21 73.86C198.52 50.4 187.26 48.27 182.97 56.91C181.13 60.62 180.98 64.24 180.14 67.95C177.14 81.18 165.8 87 153.69 80.23C146.63 76.28 138.07 68.51 127.45 56.28C112.25 38.92 78 64.72 110.87 91.07C118 98.01 122.48 103.77 124.92 108.48C139.8 134.22 138.6 163.82 114.97 173.44ZM165.84 29.6C175.36 34.5 179.11 46.19 174.21 55.71C169.31 65.23 157.62 68.98 148.1 64.08C138.58 59.18 134.83 47.49 139.73 37.97C144.63 28.45 156.32 24.7 165.84 29.6Z"
-                              fill="#3D4753"
-                              fill-rule="evenodd"
-                            />
-                            <path
-                              clip-rule="evenodd"
-                              d="M185.89 118.69C193.31 105.64 197.99 90.61 198.21 73.86C198.52 50.4 187.26 48.27 182.97 56.91C181.13 60.62 180.98 64.24 180.14 67.95C177.14 81.18 165.8 87 153.69 80.23C146.63 76.28 138.07 68.51 127.45 56.28C112.25 38.92 78 64.72 110.87 91.07C118 98.01 122.48 103.77 124.92 108.48C127.09 112.22 128.91 116.05 130.37 119.89C148.68 128.16 169.03 127.17 185.89 118.69ZM165.84 29.6C175.36 34.5 179.11 46.19 174.21 55.71C169.31 65.23 157.62 68.98 148.1 64.08C138.58 59.18 134.83 47.49 139.73 37.97C144.63 28.45 156.32 24.7 165.84 29.6Z"
-                              fill="url(#paint0_linear_932_164)"
-                              fill-rule="evenodd"
-                            />
-                            <path
-                              clip-rule="evenodd"
-                              d="M164.66 83.03C161.24 83.23 157.51 82.35 153.7 80.22C146.64 76.27 138.08 68.5 127.46 56.27C112.26 38.91 78.01 64.71 110.88 91.06C118.01 98 122.49 103.76 124.93 108.47C139.81 134.21 138.61 163.81 114.98 173.43C152.26 161.24 170.74 117.56 164.67 83.03H164.66Z"
-                              fill="url(#paint1_linear_932_164)"
-                              fill-rule="evenodd"
-                            />
-                            <path
-                              clip-rule="evenodd"
-                              d="M126.63 112.63C135.3 139.02 62.87 143.52 78.27 167.93C83.66 176.47 98 177.98 114.97 173.43C138.6 163.81 139.8 134.21 124.92 108.47C125.32 109.24 125.66 109.98 125.95 110.69C126.22 111.36 126.45 112 126.63 112.62V112.63Z"
-                              fill="#3D4753"
-                              fill-rule="evenodd"
-                            />
-                            <path
-                              clip-rule="evenodd"
-                              d="M126.63 112.63C128.19 117.39 127.11 121.43 124.39 125.01C132.94 143.69 131.33 163.08 114.97 173.43C138.6 163.81 139.8 134.21 124.92 108.47C125.32 109.24 125.66 109.98 125.95 110.69C126.22 111.36 126.45 112 126.63 112.62V112.63Z"
-                              fill="#0E215E"
-                              fill-rule="evenodd"
-                            />
-                            <path
-                              clip-rule="evenodd"
-                              d="M175.13 49.4501C176.21 41.9201 172.51 34.2001 165.36 30.5201C156.35 25.8801 145.29 29.4301 140.65 38.4401C136.41 46.6901 139.02 56.6501 146.4 61.8401C145.13 57.9801 145.35 53.6301 147.35 49.7401C151.32 42.0301 160.79 38.9901 168.5 42.9601C171.42 44.4701 173.68 46.7601 175.13 49.4501Z"
-                              fill="url(#paint2_linear_932_164)"
-                              fill-rule="evenodd"
-                            />
-                            <path
-                              clip-rule="evenodd"
-                              d="M83.25 2.51001C47.74 12.04 0.710003 48.13 3.42075e-06 102.1C-0.309997 125.55 10.95 127.69 15.24 119.05C17.08 115.34 17.23 111.72 18.07 108.01C21.07 94.78 32.41 88.96 44.52 95.73C51.58 99.68 60.14 107.45 70.76 119.68C85.96 137.04 120.21 111.24 87.34 84.89C80.21 77.95 75.73 72.19 73.29 67.48C58.41 41.74 59.61 12.14 83.24 2.52001L83.25 2.51001ZM32.38 146.35C22.86 141.45 19.11 129.76 24.01 120.24C28.91 110.72 40.6 106.97 50.12 111.87C59.64 116.77 63.39 128.46 58.49 137.99C53.59 147.51 41.9 151.26 32.38 146.36V146.35Z"
-                              fill="url(#paint3_linear_932_164)"
-                              fill-rule="evenodd"
-                            />
-                            <path
-                              clip-rule="evenodd"
-                              d="M12.33 57.27C4.91 70.31 0.230003 85.34 3.42075e-06 102.1C-0.309997 125.55 10.95 127.69 15.24 119.05C17.08 115.34 17.23 111.72 18.07 108.01C21.07 94.78 32.41 88.96 44.52 95.73C51.58 99.68 60.14 107.45 70.76 119.68C85.96 137.04 120.21 111.24 87.34 84.89C80.21 77.95 75.73 72.19 73.29 67.48C71.12 63.74 69.3 59.91 67.84 56.07C49.53 47.8 29.18 48.79 12.32 57.27H12.33ZM32.38 146.36C22.86 141.46 19.11 129.77 24.01 120.25C28.91 110.73 40.6 106.98 50.12 111.88C59.64 116.78 63.39 128.47 58.49 138C53.59 147.52 41.9 151.27 32.38 146.37V146.36Z"
-                              fill="url(#paint4_linear_932_164)"
-                              fill-rule="evenodd"
-                            />
-                            <path
-                              clip-rule="evenodd"
-                              d="M33.56 92.92C36.98 92.72 40.71 93.6 44.52 95.73C51.58 99.68 60.14 107.45 70.76 119.68C85.96 137.04 120.21 111.24 87.34 84.89C80.21 77.95 75.73 72.19 73.29 67.48C58.41 41.74 59.61 12.14 83.24 2.52002C45.97 14.7 27.49 58.38 33.56 92.92Z"
-                              fill="url(#paint5_linear_932_164)"
-                              fill-rule="evenodd"
-                            />
-                            <path
-                              clip-rule="evenodd"
-                              d="M71.58 63.32C62.91 36.93 135.34 32.43 119.94 8.02001C114.55 -0.519989 100.21 -2.02999 83.24 2.52001C59.61 12.14 58.41 41.74 73.29 67.48C72.89 66.71 72.55 65.97 72.26 65.26C71.99 64.59 71.76 63.95 71.58 63.33V63.32Z"
-                              fill="url(#paint6_linear_932_164)"
-                              fill-rule="evenodd"
-                            />
-                            <path
-                              clip-rule="evenodd"
-                              d="M71.58 63.32C70.02 58.56 71.1 54.52 73.82 50.94C65.27 32.26 66.88 12.87 83.24 2.52002C59.61 12.14 58.41 41.74 73.29 67.48C72.89 66.71 72.55 65.97 72.26 65.26C71.99 64.59 71.76 63.95 71.58 63.33V63.32Z"
-                              fill="url(#paint7_linear_932_164)"
-                              fill-rule="evenodd"
-                            />
-                            <path
-                              clip-rule="evenodd"
-                              d="M23.09 126.5C22.01 134.03 25.71 141.75 32.86 145.43C41.87 150.07 52.93 146.52 57.57 137.51C61.81 129.26 59.2 119.3 51.82 114.11C53.09 117.97 52.87 122.32 50.87 126.21C46.9 133.92 37.43 136.96 29.72 132.99C26.8 131.48 24.54 129.19 23.09 126.5Z"
-                              fill="url(#paint8_linear_932_164)"
-                              fill-rule="evenodd"
-                            />
-                          </g>
-                          <defs>
-                            <lineargradient
-                              gradientUnits="userSpaceOnUse"
-                              id="paint0_linear_932_164"
-                              x1="97.08"
-                              x2="198.22"
-                              y1="76.52"
-                              y2="76.52"
-                            >
-                              <stop
-                                stop-color="#1C2A39"
-                              />
-                              <stop
-                                offset="1"
-                                stop-color="#7C8A99"
-                              />
-                            </lineargradient>
-                            <lineargradient
-                              gradientUnits="userSpaceOnUse"
-                              id="paint1_linear_932_164"
-                              x1="97.08"
-                              x2="165.79"
-                              y1="112.04"
-                              y2="112.04"
-                            >
-                              <stop
-                                stop-color="#1C2A39"
-                              />
-                              <stop
-                                offset="1"
-                                stop-color="#7C8A99"
-                              />
-                            </lineargradient>
-                            <lineargradient
-                              gradientUnits="userSpaceOnUse"
-                              id="paint2_linear_932_164"
-                              x1="138.61"
-                              x2="175.31"
-                              y1="45.1601"
-                              y2="45.1601"
-                            >
-                              <stop
-                                stop-color="#1C2A39"
-                              />
-                              <stop
-                                offset="1"
-                                stop-color="#7C8A99"
-                              />
-                            </lineargradient>
-                            <lineargradient
-                              gradientUnits="userSpaceOnUse"
-                              id="paint3_linear_932_164"
-                              x1="-21.8556"
-                              x2="51.1173"
-                              y1="117.802"
-                              y2="16.8919"
-                            >
-                              <stop
-                                stop-color="#1C2A39"
-                              />
-                              <stop
-                                offset="1"
-                                stop-color="#BCCAD9"
-                              />
-                            </lineargradient>
-                            <lineargradient
-                              gradientUnits="userSpaceOnUse"
-                              id="paint4_linear_932_164"
-                              x1="3.41999e-06"
-                              x2="101.14"
-                              y1="99.43"
-                              y2="99.43"
-                            >
-                              <stop
-                                stop-color="#7C8A99"
-                              />
-                              <stop
-                                offset="1"
-                                stop-color="#FEFEFE"
-                              />
-                            </lineargradient>
-                            <lineargradient
-                              gradientUnits="userSpaceOnUse"
-                              id="paint5_linear_932_164"
-                              x1="32.42"
-                              x2="1.00001"
-                              y1="63.92"
-                              y2="63.92"
-                            >
-                              <stop
-                                stop-color="#7C8A99"
-                              />
-                              <stop
-                                offset="1"
-                                stop-color="#FEFEFE"
-                              />
-                            </lineargradient>
-                            <lineargradient
-                              gradientUnits="userSpaceOnUse"
-                              id="paint6_linear_932_164"
-                              x1="34.9389"
-                              x2="87.84"
-                              y1="8.56541"
-                              y2="-25.5456"
-                            >
-                              <stop
-                                stop-color="#1C2A39"
-                              />
-                              <stop
-                                offset="1"
-                                stop-color="#BCCAD9"
-                              />
-                            </lineargradient>
-                            <lineargradient
-                              gradientUnits="userSpaceOnUse"
-                              id="paint7_linear_932_164"
-                              x1="63.53"
-                              x2="83.25"
-                              y1="34.99"
-                              y2="34.99"
-                            >
-                              <stop
-                                stop-color="#7C8A99"
-                              />
-                              <stop
-                                offset="1"
-                                stop-color="#FEFEFE"
-                              />
-                            </lineargradient>
-                            <lineargradient
-                              gradientUnits="userSpaceOnUse"
-                              id="paint8_linear_932_164"
-                              x1="22.9"
-                              x2="59.61"
-                              y1="130.79"
-                              y2="130.79"
-                            >
-                              <stop
-                                stop-color="#7C8A99"
-                              />
-                              <stop
-                                offset="1"
-                                stop-color="#FEFEFE"
-                              />
-                            </lineargradient>
-                            <clippath
-                              id="clip0_932_164"
-                            >
-                              <rect
-                                fill="white"
-                                height="175.95"
-                                width="198.22"
-                              />
-                            </clippath>
-                          </defs>
-                        </svg>
-                      </i>
-                    </div>
-                     $t('menu.cockpit')
-                  </a>
-                  
-                </div>
-              </button>
-            </div>
-            <div
-              class="v-col d-none d-md-flex align-center"
+                  <img
+                    class="v-img__img v-img__img--contain"
+                    src="/src/assets/dreammall-logo.svg"
+                    style="display: none;"
+                  />
+                </transition-stub>
+                <transition-stub
+                  appear="false"
+                  css="true"
+                  name="fade-transition"
+                  persisted="false"
+                >
+                  <!---->
+                </transition-stub>
+                <!---->
+                <!---->
+                <!---->
+                
+                
+                <!---->
+              </div>
+            </a>
+          </div>
+          <div
+            class="v-col d-flex align-center justify-center"
+            data-v-e787b5f9=""
+          >
+            <button
+              class="tab-control ma-auto border-sm text-font open"
+              data-v-d58c92bb=""
               data-v-e787b5f9=""
             >
               <div
-                class="v-row"
-                data-v-e787b5f9=""
+                class="marker"
+                data-v-d58c92bb=""
+                style="display: none; width: 0px; left: 0px;"
+              />
+              <div
+                class="d-flex align-center justify-center h-100 w-100"
+                data-v-d58c92bb=""
               >
-                <div
-                  class="v-col d-flex align-center"
-                  data-v-e787b5f9=""
+                
+                <a
+                  class="item active"
+                  data-v-d58c92bb=""
                 >
-                  <button
-                    class="d-flex align-center justify-center light-dark-switch d-none d-lg-flex"
-                    data-v-e787b5f9=""
+                  <div
+                    class="icon d-flex justify-center align-center"
+                    data-v-d58c92bb=""
                   >
-                    <svg
-                      fill="none"
-                      height="15"
-                      viewBox="0 0 28 15"
-                      width="28"
-                      xmlns="http://www.w3.org/2000/svg"
+                    <i
+                      aria-hidden="true"
+                      class="v-icon notranslate v-theme--light v-icon--size-default w-100 world-cafe"
+                      data-v-d58c92bb=""
                     >
-                      <path
-                        d="M7.63636 15C5.51515 15 3.71212 14.2708 2.22727 12.8125C0.742424 11.3542 0 9.58333 0 7.5C0 5.41667 0.742424 3.64583 2.22727 2.1875C3.71212 0.729167 5.51515 0 7.63636 0H20.3636C22.4848 0 24.2879 0.729167 25.7727 2.1875C27.2576 3.64583 28 5.41667 28 7.5C28 9.58333 27.2576 11.3542 25.7727 12.8125C24.2879 14.2708 22.4848 15 20.3636 15H7.63636ZM7.63636 12.5H20.3636C21.7636 12.5 22.9621 12.0104 23.9591 11.0312C24.9561 10.0521 25.4545 8.875 25.4545 7.5C25.4545 6.125 24.9561 4.94792 23.9591 3.96875C22.9621 2.98958 21.7636 2.5 20.3636 2.5H7.63636C6.23636 2.5 5.03788 2.98958 4.04091 3.96875C3.04394 4.94792 2.54545 6.125 2.54545 7.5C2.54545 8.875 3.04394 10.0521 4.04091 11.0312C5.03788 12.0104 6.23636 12.5 7.63636 12.5ZM7.63636 11.25C8.69697 11.25 9.59848 10.8854 10.3409 10.1562C11.0833 9.42708 11.4545 8.54167 11.4545 7.5C11.4545 6.45833 11.0833 5.57292 10.3409 4.84375C9.59848 4.11458 8.69697 3.75 7.63636 3.75C6.57576 3.75 5.67424 4.11458 4.93182 4.84375C4.18939 5.57292 3.81818 6.45833 3.81818 7.5C3.81818 8.54167 4.18939 9.42708 4.93182 10.1562C5.67424 10.8854 6.57576 11.25 7.63636 11.25Z"
-                        fill="currentColor"
-                      />
-                    </svg>
-                    <svg
-                      fill="none"
-                      height="15"
-                      style="display: none;"
-                      viewBox="0 0 28 15"
-                      width="28"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M7.63636 15C5.51515 15 3.71212 14.2708 2.22727 12.8125C0.742424 11.3542 0 9.58333 0 7.5C0 5.41667 0.742424 3.64583 2.22727 2.1875C3.71212 0.729167 5.51515 0 7.63636 0H20.3636C22.4848 0 24.2879 0.729167 25.7727 2.1875C27.2576 3.64583 28 5.41667 28 7.5C28 9.58333 27.2576 11.3542 25.7727 12.8125C24.2879 14.2708 22.4848 15 20.3636 15H7.63636ZM7.63636 12.5H20.3636C21.7636 12.5 22.9621 12.0104 23.9591 11.0312C24.9561 10.0521 25.4545 8.875 25.4545 7.5C25.4545 6.125 24.9561 4.94792 23.9591 3.96875C22.9621 2.98958 21.7636 2.5 20.3636 2.5H7.63636C6.23636 2.5 5.03788 2.98958 4.04091 3.96875C3.04394 4.94792 2.54545 6.125 2.54545 7.5C2.54545 8.875 3.04394 10.0521 4.04091 11.0312C5.03788 12.0104 6.23636 12.5 7.63636 12.5ZM20.3636 11.25C21.4242 11.25 22.3258 10.8854 23.0682 10.1562C23.8106 9.42708 24.1818 8.54167 24.1818 7.5C24.1818 6.45833 23.8106 5.57292 23.0682 4.84375C22.3258 4.11458 21.4242 3.75 20.3636 3.75C19.303 3.75 18.4015 4.11458 17.6591 4.84375C16.9167 5.57292 16.5455 6.45833 16.5455 7.5C16.5455 8.54167 16.9167 9.42708 17.6591 10.1562C18.4015 10.8854 19.303 11.25 20.3636 11.25Z"
-                        fill="currentColor"
-                      />
-                    </svg>
-                    <span
-                      class="ml-2"
-                    >
-                      $t('menu.theme.light') / $t('menu.theme.dark')
-                    </span>
-                  </button>
-                </div>
-                <div
-                  class="v-col d-flex align-center justify-end"
-                  data-v-e787b5f9=""
-                >
-                  <button
-                    data-v-e787b5f9=""
-                  >
-                    <div
-                      class="circle rounded-circle border-sm text-icon pa-2 d-flex justify-center align-center"
-                      data-v-39e8094e=""
-                      data-v-e787b5f9=""
-                    >
-                      
-                      <i
-                        aria-hidden="true"
-                        class="v-icon notranslate v-theme--light v-icon--size-default"
-                        data-v-e787b5f9=""
+                      <svg
+                        fill="none"
+                        height="193"
+                        viewBox="0 0 138 193"
+                        width="138"
+                        xmlns="http://www.w3.org/2000/svg"
                       >
-                        <svg
-                          fill="none"
-                          height="17"
-                          viewBox="0 0 21 17"
-                          width="21"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M7.68844 12.4824H9.66834V9.51172H12.6382V7.53125H9.66834V4.56055H7.68844V7.53125H4.71859V9.51172H7.68844V12.4824ZM2.73869 16.4434C2.19422 16.4434 1.72812 16.2494 1.34038 15.8616C0.952654 15.4738 0.758789 15.0075 0.758789 14.4629V2.58008C0.758789 2.03545 0.952654 1.56921 1.34038 1.18137C1.72812 0.79353 2.19422 0.599609 2.73869 0.599609H14.6181C15.1626 0.599609 15.6287 0.79353 16.0164 1.18137C16.4041 1.56921 16.598 2.03545 16.598 2.58008V7.03613L20.5578 3.0752V13.9678L16.598 10.0068V14.4629C16.598 15.0075 16.4041 15.4738 16.0164 15.8616C15.6287 16.2494 15.1626 16.4434 14.6181 16.4434H2.73869ZM2.73869 14.4629H14.6181V2.58008H2.73869V14.4629Z"
-                            fill="currentColor"
-                          />
-                        </svg>
-                      </i>
-                      
-                    </div>
-                  </button>
-                  
-                  
-                  <button
-                    aria-expanded="false"
-                    aria-haspopup="menu"
-                    aria-owns="v-menu-1"
-                    class="ml-2 user-info rounded-pill d-flex flex-row text-icon border-sm align-center justify-center"
-                    data-v-607bdd70=""
-                    targetref="[object Object]"
-                  >
-                    <div
-                      class="v-avatar v-theme--light v-avatar--density-default v-avatar--variant-flat avatar d-flex align-center text-font border-sm bg-primary"
-                      data-v-607bdd70=""
-                      style="width: 44px; height: 44px;"
-                    >
-                      
-                      
-                      <span
-                        data-v-607bdd70=""
-                      />
-                      
-                      
-                      
-                      <!---->
-                      <span
-                        class="v-avatar__underlay"
-                      />
-                      
-                    </div>
-                    <div
-                      class="d-flex flex-column justify-center text-right pa-1 pl-3 w-100"
-                      data-v-607bdd70=""
-                    >
-                      <i
-                        aria-hidden="true"
-                        class="v-icon notranslate v-theme--light v-icon--size-default ellipsis-icon"
-                        data-test="user-dropdown"
-                        data-v-607bdd70=""
-                      >
-                        <svg
-                          fill="none"
-                          height="4"
-                          viewBox="0 0 18 4"
-                          width="18"
-                          xmlns="http://www.w3.org/2000/svg"
+                        <g
+                          clip-path="url(#clip0_932_149)"
                         >
                           <path
                             clip-rule="evenodd"
-                            d="M2 0C3.10457 0 4 0.895431 4 2C4 3.10457 3.10457 4 2 4C0.895431 4 0 3.10457 0 2C0 0.895431 0.895431 0 2 0ZM9 0C10.1046 0 11 0.895431 11 2C11 3.10457 10.1046 4 9 4C7.89543 4 7 3.10457 7 2C7 0.895431 7.89543 0 9 0ZM18 2C18 0.895431 17.1046 0 16 0C14.8954 0 14 0.895431 14 2C14 3.10457 14.8954 4 16 4C17.1046 4 18 3.10457 18 2Z"
-                            fill="currentColor"
+                            d="M29.6 136.89C7.05 118.08 -2.7 92.78 0.64 66.02C3.97 39.35 29.88 -0.749964 56.89 0.0100358C106.62 20.82 -15.77 78.98 29.6 136.89Z"
+                            fill="url(#paint0_linear_932_149)"
                             fill-rule="evenodd"
                           />
-                        </svg>
-                      </i>
-                    </div>
-                  </button>
-                  
-                  <!---->
-                  
-                </div>
+                          <path
+                            clip-rule="evenodd"
+                            d="M29.6 136.89C24.66 132.77 20.33 128.33 16.62 123.64C3.99 107.66 -1.48 88.69 0.339998 68.8C1.06 88.98 14.09 89.62 20.99 79.13V79.15C41.21 43.56 86.69 15.42 56.89 0.0100098C106.63 20.82 -15.77 78.98 29.6 136.89Z"
+                            fill="#2D0100"
+                            fill-rule="evenodd"
+                          />
+                          <path
+                            clip-rule="evenodd"
+                            d="M29.61 136.9C-15.79 78.98 106.67 20.8 56.87 0C60.92 0.11 64.99 1.14 69.02 3.27C77.12 7.55 81.67 16.94 81.29 28.86C80.18 64.11 50.09 75.76 39.88 103.39C36.49 112.58 36.08 121.65 38.65 130.61C39.38 133.13 38.47 135.74 36.36 137.21C34.25 138.68 31.58 138.56 29.6 136.91L29.61 136.9Z"
+                            fill="url(#paint1_linear_932_149)"
+                            fill-rule="evenodd"
+                          />
+                          <path
+                            clip-rule="evenodd"
+                            d="M29.61 136.9C-15.79 78.99 106.63 20.82 56.89 0.0100098C70.63 1.37001 77.6 14.24 75.77 26.29C70.7 59.76 29 71.47 28.59 110.64C28.49 119.81 31.09 128.67 36.37 137.21C34.26 138.68 31.59 138.56 29.61 136.91V136.9Z"
+                            fill="url(#paint2_linear_932_149)"
+                            fill-rule="evenodd"
+                          />
+                          <path
+                            clip-rule="evenodd"
+                            d="M108.38 12.96C130.93 31.77 140.68 57.06 137.34 83.82C134.01 110.49 108.1 150.59 81.09 149.83C31.36 129.02 153.75 70.86 108.38 12.96Z"
+                            fill="url(#paint3_linear_932_149)"
+                            fill-rule="evenodd"
+                          />
+                          <path
+                            clip-rule="evenodd"
+                            d="M108.38 12.96C113.32 17.08 117.65 21.52 121.36 26.21C133.99 42.18 139.46 61.15 137.64 81.04C136.92 60.86 123.89 60.22 116.99 70.71V70.69C96.77 106.28 51.29 134.43 81.09 149.83C31.36 129.02 153.75 70.86 108.38 12.96Z"
+                            fill="#2D0100"
+                            fill-rule="evenodd"
+                          />
+                          <path
+                            clip-rule="evenodd"
+                            d="M108.37 12.95C153.77 70.86 31.31 129.04 81.11 149.84C77.06 149.73 72.99 148.7 68.96 146.57C60.86 142.29 56.31 132.9 56.69 120.98C57.8 85.73 87.89 74.08 98.1 46.45C101.49 37.26 101.9 28.19 99.33 19.23C98.6 16.71 99.51 14.1 101.62 12.63C103.73 11.16 106.4 11.28 108.38 12.93L108.37 12.95Z"
+                            fill="url(#paint4_linear_932_149)"
+                            fill-rule="evenodd"
+                          />
+                          <path
+                            clip-rule="evenodd"
+                            d="M108.37 12.95C153.76 70.85 31.35 129.03 81.09 149.84C67.35 148.48 60.38 135.61 62.21 123.56C67.28 90.09 108.98 78.38 109.39 39.21C109.49 30.04 106.89 21.18 101.61 12.64C103.72 11.17 106.39 11.29 108.37 12.94V12.95Z"
+                            fill="url(#paint5_linear_932_149)"
+                            fill-rule="evenodd"
+                          />
+                          <path
+                            clip-rule="evenodd"
+                            d="M46.08 182.97C46.04 188.09 50.16 192.27 55.29 192.31C59.9 192.34 63.48 188.95 64.5 184.6C66.82 174.7 62.43 164.87 49.88 158.79C57.01 170.18 46.15 173.4 46.09 182.96L46.08 182.97Z"
+                            fill="url(#paint6_linear_932_149)"
+                            fill-rule="evenodd"
+                          />
+                          <path
+                            clip-rule="evenodd"
+                            d="M48.07 182.99C48.04 187.01 51.28 190.3 55.3 190.33C56.87 190.34 58.28 189.85 59.44 189C56.57 187.88 54.11 185.72 52.66 182.73C51.21 179.74 51.03 176.26 52.02 173.24C50.26 176.33 48.1 179.16 48.07 182.98V182.99Z"
+                            fill="url(#paint7_linear_932_149)"
+                            fill-rule="evenodd"
+                            opacity="0.5"
+                          />
+                        </g>
+                        <defs>
+                          <lineargradient
+                            gradientUnits="userSpaceOnUse"
+                            id="paint0_linear_932_149"
+                            x1="-16.8153"
+                            x2="61.3369"
+                            y1="116.566"
+                            y2="-41.9949"
+                          >
+                            <stop
+                              stop-color="#1C2A39"
+                            />
+                            <stop
+                              offset="1"
+                              stop-color="#7C8A99"
+                            />
+                          </lineargradient>
+                          <lineargradient
+                            gradientUnits="userSpaceOnUse"
+                            id="paint1_linear_932_149"
+                            x1="11.8868"
+                            x2="75.9494"
+                            y1="87.02"
+                            y2="-30.1607"
+                          >
+                            <stop
+                              stop-color="#7C8A99"
+                            />
+                            <stop
+                              offset="1"
+                              stop-color="#FEFEFE"
+                            />
+                          </lineargradient>
+                          <lineargradient
+                            gradientUnits="userSpaceOnUse"
+                            id="paint2_linear_932_149"
+                            x1="19.31"
+                            x2="76.06"
+                            y1="69.12"
+                            y2="69.12"
+                          >
+                            <stop
+                              stop-color="#1C2A39"
+                            />
+                            <stop
+                              offset="1"
+                              stop-color="#BCCAD9"
+                            />
+                          </lineargradient>
+                          <lineargradient
+                            gradientUnits="userSpaceOnUse"
+                            id="paint3_linear_932_149"
+                            x1="160.483"
+                            x2="82.3302"
+                            y1="32.9545"
+                            y2="191.516"
+                          >
+                            <stop
+                              stop-color="#1C2A39"
+                            />
+                            <stop
+                              offset="1"
+                              stop-color="#7C8A99"
+                            />
+                          </lineargradient>
+                          <lineargradient
+                            gradientUnits="userSpaceOnUse"
+                            id="paint4_linear_932_149"
+                            x1="131.78"
+                            x2="67.7184"
+                            y1="62.5008"
+                            y2="179.682"
+                          >
+                            <stop
+                              stop-color="#7C8A99"
+                            />
+                            <stop
+                              offset="1"
+                              stop-color="#FEFEFE"
+                            />
+                          </lineargradient>
+                          <lineargradient
+                            gradientUnits="userSpaceOnUse"
+                            id="paint5_linear_932_149"
+                            x1="118.66"
+                            x2="61.92"
+                            y1="80.73"
+                            y2="80.73"
+                          >
+                            <stop
+                              stop-color="#1C2A39"
+                            />
+                            <stop
+                              offset="1"
+                              stop-color="#BCCAD9"
+                            />
+                          </lineargradient>
+                          <lineargradient
+                            gradientUnits="userSpaceOnUse"
+                            id="paint6_linear_932_149"
+                            x1="66.33"
+                            x2="38.1302"
+                            y1="185.538"
+                            y2="166.541"
+                          >
+                            <stop
+                              stop-color="#1C2A39"
+                            />
+                            <stop
+                              offset="1"
+                              stop-color="#BCCAD9"
+                            />
+                          </lineargradient>
+                          <lineargradient
+                            gradientUnits="userSpaceOnUse"
+                            id="paint7_linear_932_149"
+                            x1="48.07"
+                            x2="59.43"
+                            y1="181.79"
+                            y2="181.79"
+                          >
+                            <stop
+                              stop-color="#1C2A39"
+                            />
+                            <stop
+                              offset="1"
+                              stop-color="#BCCAD9"
+                            />
+                          </lineargradient>
+                          <clippath
+                            id="clip0_932_149"
+                          >
+                            <rect
+                              fill="white"
+                              height="192.32"
+                              width="137.98"
+                            />
+                          </clippath>
+                        </defs>
+                      </svg>
+                    </i>
+                  </div>
+                   $t('menu.worldCafe')
+                </a>
+                <a
+                  class="item"
+                  data-v-d58c92bb=""
+                >
+                  <div
+                    class="icon d-flex justify-center align-center"
+                    data-v-d58c92bb=""
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="v-icon notranslate v-theme--light v-icon--size-default w-100 cockpit"
+                      data-v-d58c92bb=""
+                    >
+                      <svg
+                        fill="none"
+                        height="176"
+                        viewBox="0 0 199 176"
+                        width="199"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <g
+                          clip-path="url(#clip0_932_164)"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M114.97 173.44C150.48 163.92 197.5 127.82 198.21 73.86C198.52 50.4 187.26 48.27 182.97 56.91C181.13 60.62 180.98 64.24 180.14 67.95C177.14 81.18 165.8 87 153.69 80.23C146.63 76.28 138.07 68.51 127.45 56.28C112.25 38.92 78 64.72 110.87 91.07C118 98.01 122.48 103.77 124.92 108.48C139.8 134.22 138.6 163.82 114.97 173.44ZM165.84 29.6C175.36 34.5 179.11 46.19 174.21 55.71C169.31 65.23 157.62 68.98 148.1 64.08C138.58 59.18 134.83 47.49 139.73 37.97C144.63 28.45 156.32 24.7 165.84 29.6Z"
+                            fill="#3D4753"
+                            fill-rule="evenodd"
+                          />
+                          <path
+                            clip-rule="evenodd"
+                            d="M185.89 118.69C193.31 105.64 197.99 90.61 198.21 73.86C198.52 50.4 187.26 48.27 182.97 56.91C181.13 60.62 180.98 64.24 180.14 67.95C177.14 81.18 165.8 87 153.69 80.23C146.63 76.28 138.07 68.51 127.45 56.28C112.25 38.92 78 64.72 110.87 91.07C118 98.01 122.48 103.77 124.92 108.48C127.09 112.22 128.91 116.05 130.37 119.89C148.68 128.16 169.03 127.17 185.89 118.69ZM165.84 29.6C175.36 34.5 179.11 46.19 174.21 55.71C169.31 65.23 157.62 68.98 148.1 64.08C138.58 59.18 134.83 47.49 139.73 37.97C144.63 28.45 156.32 24.7 165.84 29.6Z"
+                            fill="url(#paint0_linear_932_164)"
+                            fill-rule="evenodd"
+                          />
+                          <path
+                            clip-rule="evenodd"
+                            d="M164.66 83.03C161.24 83.23 157.51 82.35 153.7 80.22C146.64 76.27 138.08 68.5 127.46 56.27C112.26 38.91 78.01 64.71 110.88 91.06C118.01 98 122.49 103.76 124.93 108.47C139.81 134.21 138.61 163.81 114.98 173.43C152.26 161.24 170.74 117.56 164.67 83.03H164.66Z"
+                            fill="url(#paint1_linear_932_164)"
+                            fill-rule="evenodd"
+                          />
+                          <path
+                            clip-rule="evenodd"
+                            d="M126.63 112.63C135.3 139.02 62.87 143.52 78.27 167.93C83.66 176.47 98 177.98 114.97 173.43C138.6 163.81 139.8 134.21 124.92 108.47C125.32 109.24 125.66 109.98 125.95 110.69C126.22 111.36 126.45 112 126.63 112.62V112.63Z"
+                            fill="#3D4753"
+                            fill-rule="evenodd"
+                          />
+                          <path
+                            clip-rule="evenodd"
+                            d="M126.63 112.63C128.19 117.39 127.11 121.43 124.39 125.01C132.94 143.69 131.33 163.08 114.97 173.43C138.6 163.81 139.8 134.21 124.92 108.47C125.32 109.24 125.66 109.98 125.95 110.69C126.22 111.36 126.45 112 126.63 112.62V112.63Z"
+                            fill="#0E215E"
+                            fill-rule="evenodd"
+                          />
+                          <path
+                            clip-rule="evenodd"
+                            d="M175.13 49.4501C176.21 41.9201 172.51 34.2001 165.36 30.5201C156.35 25.8801 145.29 29.4301 140.65 38.4401C136.41 46.6901 139.02 56.6501 146.4 61.8401C145.13 57.9801 145.35 53.6301 147.35 49.7401C151.32 42.0301 160.79 38.9901 168.5 42.9601C171.42 44.4701 173.68 46.7601 175.13 49.4501Z"
+                            fill="url(#paint2_linear_932_164)"
+                            fill-rule="evenodd"
+                          />
+                          <path
+                            clip-rule="evenodd"
+                            d="M83.25 2.51001C47.74 12.04 0.710003 48.13 3.42075e-06 102.1C-0.309997 125.55 10.95 127.69 15.24 119.05C17.08 115.34 17.23 111.72 18.07 108.01C21.07 94.78 32.41 88.96 44.52 95.73C51.58 99.68 60.14 107.45 70.76 119.68C85.96 137.04 120.21 111.24 87.34 84.89C80.21 77.95 75.73 72.19 73.29 67.48C58.41 41.74 59.61 12.14 83.24 2.52001L83.25 2.51001ZM32.38 146.35C22.86 141.45 19.11 129.76 24.01 120.24C28.91 110.72 40.6 106.97 50.12 111.87C59.64 116.77 63.39 128.46 58.49 137.99C53.59 147.51 41.9 151.26 32.38 146.36V146.35Z"
+                            fill="url(#paint3_linear_932_164)"
+                            fill-rule="evenodd"
+                          />
+                          <path
+                            clip-rule="evenodd"
+                            d="M12.33 57.27C4.91 70.31 0.230003 85.34 3.42075e-06 102.1C-0.309997 125.55 10.95 127.69 15.24 119.05C17.08 115.34 17.23 111.72 18.07 108.01C21.07 94.78 32.41 88.96 44.52 95.73C51.58 99.68 60.14 107.45 70.76 119.68C85.96 137.04 120.21 111.24 87.34 84.89C80.21 77.95 75.73 72.19 73.29 67.48C71.12 63.74 69.3 59.91 67.84 56.07C49.53 47.8 29.18 48.79 12.32 57.27H12.33ZM32.38 146.36C22.86 141.46 19.11 129.77 24.01 120.25C28.91 110.73 40.6 106.98 50.12 111.88C59.64 116.78 63.39 128.47 58.49 138C53.59 147.52 41.9 151.27 32.38 146.37V146.36Z"
+                            fill="url(#paint4_linear_932_164)"
+                            fill-rule="evenodd"
+                          />
+                          <path
+                            clip-rule="evenodd"
+                            d="M33.56 92.92C36.98 92.72 40.71 93.6 44.52 95.73C51.58 99.68 60.14 107.45 70.76 119.68C85.96 137.04 120.21 111.24 87.34 84.89C80.21 77.95 75.73 72.19 73.29 67.48C58.41 41.74 59.61 12.14 83.24 2.52002C45.97 14.7 27.49 58.38 33.56 92.92Z"
+                            fill="url(#paint5_linear_932_164)"
+                            fill-rule="evenodd"
+                          />
+                          <path
+                            clip-rule="evenodd"
+                            d="M71.58 63.32C62.91 36.93 135.34 32.43 119.94 8.02001C114.55 -0.519989 100.21 -2.02999 83.24 2.52001C59.61 12.14 58.41 41.74 73.29 67.48C72.89 66.71 72.55 65.97 72.26 65.26C71.99 64.59 71.76 63.95 71.58 63.33V63.32Z"
+                            fill="url(#paint6_linear_932_164)"
+                            fill-rule="evenodd"
+                          />
+                          <path
+                            clip-rule="evenodd"
+                            d="M71.58 63.32C70.02 58.56 71.1 54.52 73.82 50.94C65.27 32.26 66.88 12.87 83.24 2.52002C59.61 12.14 58.41 41.74 73.29 67.48C72.89 66.71 72.55 65.97 72.26 65.26C71.99 64.59 71.76 63.95 71.58 63.33V63.32Z"
+                            fill="url(#paint7_linear_932_164)"
+                            fill-rule="evenodd"
+                          />
+                          <path
+                            clip-rule="evenodd"
+                            d="M23.09 126.5C22.01 134.03 25.71 141.75 32.86 145.43C41.87 150.07 52.93 146.52 57.57 137.51C61.81 129.26 59.2 119.3 51.82 114.11C53.09 117.97 52.87 122.32 50.87 126.21C46.9 133.92 37.43 136.96 29.72 132.99C26.8 131.48 24.54 129.19 23.09 126.5Z"
+                            fill="url(#paint8_linear_932_164)"
+                            fill-rule="evenodd"
+                          />
+                        </g>
+                        <defs>
+                          <lineargradient
+                            gradientUnits="userSpaceOnUse"
+                            id="paint0_linear_932_164"
+                            x1="97.08"
+                            x2="198.22"
+                            y1="76.52"
+                            y2="76.52"
+                          >
+                            <stop
+                              stop-color="#1C2A39"
+                            />
+                            <stop
+                              offset="1"
+                              stop-color="#7C8A99"
+                            />
+                          </lineargradient>
+                          <lineargradient
+                            gradientUnits="userSpaceOnUse"
+                            id="paint1_linear_932_164"
+                            x1="97.08"
+                            x2="165.79"
+                            y1="112.04"
+                            y2="112.04"
+                          >
+                            <stop
+                              stop-color="#1C2A39"
+                            />
+                            <stop
+                              offset="1"
+                              stop-color="#7C8A99"
+                            />
+                          </lineargradient>
+                          <lineargradient
+                            gradientUnits="userSpaceOnUse"
+                            id="paint2_linear_932_164"
+                            x1="138.61"
+                            x2="175.31"
+                            y1="45.1601"
+                            y2="45.1601"
+                          >
+                            <stop
+                              stop-color="#1C2A39"
+                            />
+                            <stop
+                              offset="1"
+                              stop-color="#7C8A99"
+                            />
+                          </lineargradient>
+                          <lineargradient
+                            gradientUnits="userSpaceOnUse"
+                            id="paint3_linear_932_164"
+                            x1="-21.8556"
+                            x2="51.1173"
+                            y1="117.802"
+                            y2="16.8919"
+                          >
+                            <stop
+                              stop-color="#1C2A39"
+                            />
+                            <stop
+                              offset="1"
+                              stop-color="#BCCAD9"
+                            />
+                          </lineargradient>
+                          <lineargradient
+                            gradientUnits="userSpaceOnUse"
+                            id="paint4_linear_932_164"
+                            x1="3.41999e-06"
+                            x2="101.14"
+                            y1="99.43"
+                            y2="99.43"
+                          >
+                            <stop
+                              stop-color="#7C8A99"
+                            />
+                            <stop
+                              offset="1"
+                              stop-color="#FEFEFE"
+                            />
+                          </lineargradient>
+                          <lineargradient
+                            gradientUnits="userSpaceOnUse"
+                            id="paint5_linear_932_164"
+                            x1="32.42"
+                            x2="1.00001"
+                            y1="63.92"
+                            y2="63.92"
+                          >
+                            <stop
+                              stop-color="#7C8A99"
+                            />
+                            <stop
+                              offset="1"
+                              stop-color="#FEFEFE"
+                            />
+                          </lineargradient>
+                          <lineargradient
+                            gradientUnits="userSpaceOnUse"
+                            id="paint6_linear_932_164"
+                            x1="34.9389"
+                            x2="87.84"
+                            y1="8.56541"
+                            y2="-25.5456"
+                          >
+                            <stop
+                              stop-color="#1C2A39"
+                            />
+                            <stop
+                              offset="1"
+                              stop-color="#BCCAD9"
+                            />
+                          </lineargradient>
+                          <lineargradient
+                            gradientUnits="userSpaceOnUse"
+                            id="paint7_linear_932_164"
+                            x1="63.53"
+                            x2="83.25"
+                            y1="34.99"
+                            y2="34.99"
+                          >
+                            <stop
+                              stop-color="#7C8A99"
+                            />
+                            <stop
+                              offset="1"
+                              stop-color="#FEFEFE"
+                            />
+                          </lineargradient>
+                          <lineargradient
+                            gradientUnits="userSpaceOnUse"
+                            id="paint8_linear_932_164"
+                            x1="22.9"
+                            x2="59.61"
+                            y1="130.79"
+                            y2="130.79"
+                          >
+                            <stop
+                              stop-color="#7C8A99"
+                            />
+                            <stop
+                              offset="1"
+                              stop-color="#FEFEFE"
+                            />
+                          </lineargradient>
+                          <clippath
+                            id="clip0_932_164"
+                          >
+                            <rect
+                              fill="white"
+                              height="175.95"
+                              width="198.22"
+                            />
+                          </clippath>
+                        </defs>
+                      </svg>
+                    </i>
+                  </div>
+                   $t('menu.cockpit')
+                </a>
+                
+              </div>
+            </button>
+          </div>
+          <div
+            class="v-col d-none d-md-flex align-center"
+            data-v-e787b5f9=""
+          >
+            <div
+              class="v-row"
+              data-v-e787b5f9=""
+            >
+              <div
+                class="v-col d-flex align-center"
+                data-v-e787b5f9=""
+              >
+                <button
+                  class="d-flex align-center justify-center light-dark-switch d-none d-lg-flex"
+                  data-v-e787b5f9=""
+                >
+                  <svg
+                    fill="none"
+                    height="15"
+                    viewBox="0 0 28 15"
+                    width="28"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M7.63636 15C5.51515 15 3.71212 14.2708 2.22727 12.8125C0.742424 11.3542 0 9.58333 0 7.5C0 5.41667 0.742424 3.64583 2.22727 2.1875C3.71212 0.729167 5.51515 0 7.63636 0H20.3636C22.4848 0 24.2879 0.729167 25.7727 2.1875C27.2576 3.64583 28 5.41667 28 7.5C28 9.58333 27.2576 11.3542 25.7727 12.8125C24.2879 14.2708 22.4848 15 20.3636 15H7.63636ZM7.63636 12.5H20.3636C21.7636 12.5 22.9621 12.0104 23.9591 11.0312C24.9561 10.0521 25.4545 8.875 25.4545 7.5C25.4545 6.125 24.9561 4.94792 23.9591 3.96875C22.9621 2.98958 21.7636 2.5 20.3636 2.5H7.63636C6.23636 2.5 5.03788 2.98958 4.04091 3.96875C3.04394 4.94792 2.54545 6.125 2.54545 7.5C2.54545 8.875 3.04394 10.0521 4.04091 11.0312C5.03788 12.0104 6.23636 12.5 7.63636 12.5ZM7.63636 11.25C8.69697 11.25 9.59848 10.8854 10.3409 10.1562C11.0833 9.42708 11.4545 8.54167 11.4545 7.5C11.4545 6.45833 11.0833 5.57292 10.3409 4.84375C9.59848 4.11458 8.69697 3.75 7.63636 3.75C6.57576 3.75 5.67424 4.11458 4.93182 4.84375C4.18939 5.57292 3.81818 6.45833 3.81818 7.5C3.81818 8.54167 4.18939 9.42708 4.93182 10.1562C5.67424 10.8854 6.57576 11.25 7.63636 11.25Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                  <svg
+                    fill="none"
+                    height="15"
+                    style="display: none;"
+                    viewBox="0 0 28 15"
+                    width="28"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M7.63636 15C5.51515 15 3.71212 14.2708 2.22727 12.8125C0.742424 11.3542 0 9.58333 0 7.5C0 5.41667 0.742424 3.64583 2.22727 2.1875C3.71212 0.729167 5.51515 0 7.63636 0H20.3636C22.4848 0 24.2879 0.729167 25.7727 2.1875C27.2576 3.64583 28 5.41667 28 7.5C28 9.58333 27.2576 11.3542 25.7727 12.8125C24.2879 14.2708 22.4848 15 20.3636 15H7.63636ZM7.63636 12.5H20.3636C21.7636 12.5 22.9621 12.0104 23.9591 11.0312C24.9561 10.0521 25.4545 8.875 25.4545 7.5C25.4545 6.125 24.9561 4.94792 23.9591 3.96875C22.9621 2.98958 21.7636 2.5 20.3636 2.5H7.63636C6.23636 2.5 5.03788 2.98958 4.04091 3.96875C3.04394 4.94792 2.54545 6.125 2.54545 7.5C2.54545 8.875 3.04394 10.0521 4.04091 11.0312C5.03788 12.0104 6.23636 12.5 7.63636 12.5ZM20.3636 11.25C21.4242 11.25 22.3258 10.8854 23.0682 10.1562C23.8106 9.42708 24.1818 8.54167 24.1818 7.5C24.1818 6.45833 23.8106 5.57292 23.0682 4.84375C22.3258 4.11458 21.4242 3.75 20.3636 3.75C19.303 3.75 18.4015 4.11458 17.6591 4.84375C16.9167 5.57292 16.5455 6.45833 16.5455 7.5C16.5455 8.54167 16.9167 9.42708 17.6591 10.1562C18.4015 10.8854 19.303 11.25 20.3636 11.25Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                  <span
+                    class="ml-2"
+                  >
+                    $t('menu.theme.light') / $t('menu.theme.dark')
+                  </span>
+                </button>
+              </div>
+              <div
+                class="v-col d-flex align-center justify-end"
+                data-v-e787b5f9=""
+              >
+                <button
+                  data-v-e787b5f9=""
+                >
+                  <div
+                    class="circle rounded-circle border-sm text-icon pa-2 d-flex justify-center align-center"
+                    data-v-39e8094e=""
+                    data-v-e787b5f9=""
+                  >
+                    
+                    <i
+                      aria-hidden="true"
+                      class="v-icon notranslate v-theme--light v-icon--size-default"
+                      data-v-e787b5f9=""
+                    >
+                      <svg
+                        fill="none"
+                        height="17"
+                        viewBox="0 0 21 17"
+                        width="21"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M7.68844 12.4824H9.66834V9.51172H12.6382V7.53125H9.66834V4.56055H7.68844V7.53125H4.71859V9.51172H7.68844V12.4824ZM2.73869 16.4434C2.19422 16.4434 1.72812 16.2494 1.34038 15.8616C0.952654 15.4738 0.758789 15.0075 0.758789 14.4629V2.58008C0.758789 2.03545 0.952654 1.56921 1.34038 1.18137C1.72812 0.79353 2.19422 0.599609 2.73869 0.599609H14.6181C15.1626 0.599609 15.6287 0.79353 16.0164 1.18137C16.4041 1.56921 16.598 2.03545 16.598 2.58008V7.03613L20.5578 3.0752V13.9678L16.598 10.0068V14.4629C16.598 15.0075 16.4041 15.4738 16.0164 15.8616C15.6287 16.2494 15.1626 16.4434 14.6181 16.4434H2.73869ZM2.73869 14.4629H14.6181V2.58008H2.73869V14.4629Z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                    </i>
+                    
+                  </div>
+                </button>
+                
+                
+                <button
+                  aria-expanded="false"
+                  aria-haspopup="menu"
+                  aria-owns="v-menu-1"
+                  class="ml-2 user-info rounded-pill d-flex flex-row text-icon border-sm align-center justify-center"
+                  data-v-607bdd70=""
+                  targetref="[object Object]"
+                >
+                  <div
+                    class="v-avatar v-theme--light v-avatar--density-default v-avatar--variant-flat avatar d-flex align-center text-font border-sm bg-primary"
+                    data-v-607bdd70=""
+                    style="width: 44px; height: 44px;"
+                  >
+                    
+                    
+                    <span
+                      data-v-607bdd70=""
+                    />
+                    
+                    
+                    
+                    <!---->
+                    <span
+                      class="v-avatar__underlay"
+                    />
+                    
+                  </div>
+                  <div
+                    class="d-flex flex-column justify-center text-right pa-1 pl-3 w-100"
+                    data-v-607bdd70=""
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="v-icon notranslate v-theme--light v-icon--size-default ellipsis-icon"
+                      data-test="user-dropdown"
+                      data-v-607bdd70=""
+                    >
+                      <svg
+                        fill="none"
+                        height="4"
+                        viewBox="0 0 18 4"
+                        width="18"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M2 0C3.10457 0 4 0.895431 4 2C4 3.10457 3.10457 4 2 4C0.895431 4 0 3.10457 0 2C0 0.895431 0.895431 0 2 0ZM9 0C10.1046 0 11 0.895431 11 2C11 3.10457 10.1046 4 9 4C7.89543 4 7 3.10457 7 2C7 0.895431 7.89543 0 9 0ZM18 2C18 0.895431 17.1046 0 16 0C14.8954 0 14 0.895431 14 2C14 3.10457 14.8954 4 16 4C17.1046 4 18 3.10457 18 2Z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </i>
+                  </div>
+                </button>
+                
+                <!---->
+                
               </div>
             </div>
           </div>
-          
-          <!---->
         </div>
         
-        
-        <transition-stub
-          appear="false"
-          css="true"
-          name="expand-transition"
-          persisted="false"
-        >
-          <!---->
-        </transition-stub>
-        
-      </header>
-    </div>
+        <!---->
+      </div>
+      
+      
+      <transition-stub
+        appear="false"
+        css="true"
+        name="expand-transition"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      
+    </header>
     
     <nav
-      class="v-navigation-drawer v-navigation-drawer--right v-navigation-drawer--temporary v-theme--light v-navigation-drawer--mobile menu-drawer px-4"
+      class="v-navigation-drawer v-navigation-drawer--right v-navigation-drawer--temporary v-theme--light v-navigation-drawer--mobile menu-drawer px-4 hide-on-mobile"
       data-v-cf2c9067=""
-      style="right: 0px; z-index: 1004; transform: translateX(110%); position: fixed; height: calc(100% - 70px - 0px); top: 70px; bottom: 0px; transition: none !important;"
+      style="right: 0px; z-index: 1004; transform: translateX(110%); position: fixed; transition: none !important; height: calc(100% - 70px - 0px); top: 70px; bottom: 0px;"
     >
       <!---->
       <!---->

--- a/frontend/src/components/tablesDrawer/TableList.test.ts
+++ b/frontend/src/components/tablesDrawer/TableList.test.ts
@@ -62,13 +62,9 @@ describe('TableList', () => {
     expect(wrapper.element).toMatchSnapshot()
   })
 
-  it('renders list', () => {
-    expect(wrapper.find('.v-list--density-default').exists()).toBe(true)
-  })
-
   it('sets active room', async () => {
     const setActiveRoomSpy = vi.spyOn(useActiveRoomStore(), 'setActiveRoom')
-    await wrapper.find('.table').trigger('click')
+    await wrapper.find('.table .action').trigger('click')
 
     expect(setActiveRoomSpy).toHaveBeenCalledWith(testTables[0].joinLink)
   })
@@ -76,7 +72,7 @@ describe('TableList', () => {
   describe('when a table is clicked', () => {
     beforeEach(async () => {
       wrapper = Wrapper()
-      await wrapper.find('.table').trigger('click')
+      await wrapper.find('.table .action').trigger('click')
       await flushPromises()
     })
 

--- a/frontend/src/components/tablesDrawer/TableList.vue
+++ b/frontend/src/components/tablesDrawer/TableList.vue
@@ -37,29 +37,29 @@ const openRoom = (link: string) => {
 
 <style scoped>
 .list {
-  list-style: none;
-  padding: 0;
   display: flex;
   flex-flow: column;
   gap: 8px;
+  padding: 0;
+  list-style: none;
 }
 
 .table {
   display: flex;
-  justify-content: center;
-  align-items: center;
   gap: 8px;
+  align-items: center;
+  justify-content: center;
 }
 
 .table-info {
   display: flex;
   flex-flow: column;
   justify-content: space-between;
-  padding: 8px 16px;
-  border-radius: 16px 0px 0px 16px;
-  height: 42px;
-  font-size: 13px;
   width: 100%;
+  height: 42px;
+  padding: 8px 16px;
+  font-size: 13px;
+  border-radius: 16px 0 0 16px;
 }
 
 .subtitle {
@@ -67,15 +67,15 @@ const openRoom = (link: string) => {
 }
 
 .action {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   width: 41px;
   min-width: 41px;
   height: 42px;
-  border-radius: 0px 16px 16px 0px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  background-color: #f09630;
   color: #fff;
+  background-color: #f09630;
+  border-radius: 0 16px 16px 0;
 }
 
 .icon {

--- a/frontend/src/components/tablesDrawer/TableList.vue
+++ b/frontend/src/components/tablesDrawer/TableList.vue
@@ -1,28 +1,17 @@
 <template>
-  <v-card class="mx-auto" width="400">
-    <v-list lines="two">
-      <v-list-item
-        v-for="(item, index) in items"
-        :key="index"
-        class="table"
-        :title="item.meetingName"
-        :subtitle="$t('rooms.participantCount', { count: item.participantCount })"
-        @click="openRoom(item.joinLink)"
-      >
-        <!--
-        <template v-if="item.prepend" #prepend>
-          <component :is="item.prepend" v-bind="item.prependProps" />
-        </template>
-        -->
-
-        <!--
-        <template v-if="item.append" #append>
-          <component :is="item.append" v-bind="item.appendProps" />
-        </template>
-        -->
-      </v-list-item>
-    </v-list>
-  </v-card>
+  <ul class="list">
+    <li v-for="item in items" :key="item.meetingID" class="table">
+      <div class="table-info bg-dropdown-background">
+        <span>{{ item.meetingName }}</span>
+        <span class="subtitle">
+          {{ $t('rooms.participantCount', { count: item.participantCount }) }}
+        </span>
+      </div>
+      <button class="action" @click="openRoom(item.joinLink)">
+        <v-icon class="icon" icon="$camera" />
+      </button>
+    </li>
+  </ul>
 </template>
 
 <script lang="ts" setup>
@@ -47,14 +36,49 @@ const openRoom = (link: string) => {
 </script>
 
 <style scoped>
+.list {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-flow: column;
+  gap: 8px;
+}
+
 .table {
   display: flex;
+  justify-content: center;
   align-items: center;
+  gap: 8px;
+}
+
+.table-info {
+  display: flex;
+  flex-flow: column;
   justify-content: space-between;
   padding: 8px 16px;
-  margin-bottom: 8px;
-  background-color: #fff;
-  border-radius: 8px;
-  box-shadow: 0 2px 4px rgb(0 0 0 / 10%);
+  border-radius: 16px 0px 0px 16px;
+  height: 42px;
+  font-size: 13px;
+  width: 100%;
+}
+
+.subtitle {
+  font-size: 10px;
+}
+
+.action {
+  width: 41px;
+  min-width: 41px;
+  height: 42px;
+  border-radius: 0px 16px 16px 0px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: #f09630;
+  color: #fff;
+}
+
+.icon {
+  transform: scale(0.8);
 }
 </style>

--- a/frontend/src/components/tablesDrawer/TableList.vue
+++ b/frontend/src/components/tablesDrawer/TableList.vue
@@ -2,7 +2,7 @@
   <ul class="list">
     <li v-for="item in items" :key="item.meetingID" class="table">
       <div class="table-info bg-dropdown-background">
-        <span>{{ item.meetingName }}</span>
+        <span class="name">{{ item.meetingName }}</span>
         <span class="subtitle">
           {{ $t('rooms.participantCount', { count: item.participantCount }) }}
         </span>
@@ -57,13 +57,18 @@ const openRoom = (link: string) => {
   justify-content: space-between;
   width: 100%;
   height: 42px;
-  padding: 8px 16px;
-  font-size: 13px;
+  padding: 5px 24px;
   border-radius: 16px 0 0 16px;
 }
 
+.name {
+  height: 18px;
+  font-size: 14px;
+  font-weight: bold;
+}
+
 .subtitle {
-  font-size: 10px;
+  font-size: 11px;
 }
 
 .action {

--- a/frontend/src/components/tablesDrawer/TablesDrawer.vue
+++ b/frontend/src/components/tablesDrawer/TablesDrawer.vue
@@ -81,6 +81,7 @@ const filteredItems = computed(() => {
   width: 308px;
   height: 100% !important;
   padding-top: 70px;
+  background: var(--v-sidebar-background) !important;
 }
 
 @media #{map-get($display-breakpoints, 'sm-and-down')} {
@@ -92,6 +93,12 @@ const filteredItems = computed(() => {
     border-radius: 30px 30px 0 0;
 
     --sides: 12px;
+  }
+}
+
+@media #{map-get($display-breakpoints, 'md-and-up')} {
+  .menu-drawer {
+    border-radius: 20px 0px 0px 20px;
   }
 }
 

--- a/frontend/src/components/tablesDrawer/TablesDrawer.vue
+++ b/frontend/src/components/tablesDrawer/TablesDrawer.vue
@@ -104,8 +104,12 @@ const filteredItems = computed(() => {
 
 .search {
   :deep(.v-input__control) {
-    border: 1px solid #3d4753;
+    border: 1px solid rgb(var(--v-theme-icon));
     border-radius: 20px;
+  }
+
+  :deep(.v-field--variant-solo) {
+    background-color: transparent !important;
   }
 }
 

--- a/frontend/src/components/tablesDrawer/TablesDrawer.vue
+++ b/frontend/src/components/tablesDrawer/TablesDrawer.vue
@@ -76,28 +76,29 @@ const filteredItems = computed(() => {
 @import 'vuetify/lib/styles/settings/_variables';
 
 .menu-drawer {
-  height: 100% !important;
   top: 0 !important;
   z-index: 1006 !important;
-  padding-top: 70px;
   width: 308px;
+  height: 100% !important;
+  padding-top: 70px;
 }
 
 @media #{map-get($display-breakpoints, 'sm-and-down')} {
   .menu-drawer {
-    z-index: 2000 !important;
-    padding-top: 20px;
-    --sides: 12px;
     left: var(--sides) !important;
+    z-index: 2000 !important;
     width: calc(100% - (2 * var(--sides))) !important;
-    border-radius: 30px 30px 0px 0px;
+    padding-top: 20px;
+    border-radius: 30px 30px 0 0;
+
+    --sides: 12px;
   }
 }
 
 .search {
   :deep(.v-input__control) {
-    border-radius: 20px;
     border: 1px solid #3d4753;
+    border-radius: 20px;
   }
 }
 

--- a/frontend/src/components/tablesDrawer/TablesDrawer.vue
+++ b/frontend/src/components/tablesDrawer/TablesDrawer.vue
@@ -1,17 +1,28 @@
 <template>
-  <v-navigation-drawer v-model="isVisible" :location="location" width="auto" class="menu-drawer">
+  <v-navigation-drawer
+    v-model="isVisible"
+    :location="location"
+    width="auto"
+    class="menu-drawer px-4"
+  >
     <v-text-field
       v-model="searchValue"
       :label="$t('tablesDrawer.searchPlaceholder')"
       prepend-inner-icon="mdi-tune"
       clearable
       rounded
+      flat
+      density="compact"
       variant="solo"
-      class="mx-4 mt-4 search"
+      class="search"
     ></v-text-field>
     <v-list>
-      <h2 class="mx-4">{{ $t('tablesDrawer.header') }}</h2>
-      <TableList :items="filteredItems" @open-room="closeDrawer" />
+      <h2 class="header mb-4">{{ $t('tablesDrawer.header') }}</h2>
+      <div v-if="!items.length">{{ $t('tablesDrawer.noTables') }}</div>
+      <div v-else-if="!filteredItems.length">
+        {{ $t('tablesDrawer.noResults') }}
+      </div>
+      <TableList v-else :items="filteredItems" @open-room="closeDrawer" />
     </v-list>
   </v-navigation-drawer>
 </template>
@@ -61,12 +72,33 @@ const filteredItems = computed(() => {
 })
 </script>
 
-<style scoped>
+<style scoped lang="scss">
+@import 'vuetify/lib/styles/settings/_variables';
+
 .menu-drawer {
-  z-index: 0 !important;
+  height: 100% !important;
+  top: 0 !important;
+  z-index: 1006 !important;
+  padding-top: 70px;
+  width: 308px;
+}
+
+@media #{map-get($display-breakpoints, 'sm-and-down')} {
+  .menu-drawer {
+    z-index: 2000 !important;
+    padding-top: 0;
+  }
 }
 
 .search {
-  border-radius: 25px;
+  :deep(.v-input__control) {
+    border-radius: 20px;
+    border: 1px solid #3d4753;
+  }
+}
+
+.header {
+  font-size: 14px;
+  text-transform: uppercase;
 }
 </style>

--- a/frontend/src/components/tablesDrawer/TablesDrawer.vue
+++ b/frontend/src/components/tablesDrawer/TablesDrawer.vue
@@ -86,7 +86,11 @@ const filteredItems = computed(() => {
 @media #{map-get($display-breakpoints, 'sm-and-down')} {
   .menu-drawer {
     z-index: 2000 !important;
-    padding-top: 0;
+    padding-top: 20px;
+    --sides: 12px;
+    left: var(--sides) !important;
+    width: calc(100% - (2 * var(--sides))) !important;
+    border-radius: 30px 30px 0px 0px;
   }
 }
 

--- a/frontend/src/components/tablesDrawer/TablesDrawer.vue
+++ b/frontend/src/components/tablesDrawer/TablesDrawer.vue
@@ -98,7 +98,7 @@ const filteredItems = computed(() => {
 
 @media #{map-get($display-breakpoints, 'md-and-up')} {
   .menu-drawer {
-    border-radius: 20px 0px 0px 20px;
+    border-radius: 20px 0 0 20px;
   }
 }
 

--- a/frontend/src/components/tablesDrawer/__snapshots__/TableList.test.ts.snap
+++ b/frontend/src/components/tablesDrawer/__snapshots__/TableList.test.ts.snap
@@ -22,6 +22,7 @@ exports[`TableList > renders correctly 1`] = `
           data-v-de37061b=""
         >
           <span
+            class="name"
             data-v-de37061b=""
           >
             my meeting
@@ -66,6 +67,7 @@ exports[`TableList > renders correctly 1`] = `
           data-v-de37061b=""
         >
           <span
+            class="name"
             data-v-de37061b=""
           >
             my meeting

--- a/frontend/src/components/tablesDrawer/__snapshots__/TableList.test.ts.snap
+++ b/frontend/src/components/tablesDrawer/__snapshots__/TableList.test.ts.snap
@@ -8,159 +8,101 @@ exports[`TableList > renders correctly 1`] = `
     class="v-application__wrap"
   >
     
-    <div
-      class="v-card v-theme--light v-card--density-default v-card--variant-elevated mx-auto"
+    <ul
+      class="list"
       data-v-de37061b=""
-      style="width: 400px;"
     >
-      <!---->
-      <div
-        class="v-card__loader"
-      >
-        <div
-          aria-hidden="true"
-          aria-valuemax="100"
-          aria-valuemin="0"
-          class="v-progress-linear v-theme--light v-locale--is-ltr"
-          role="progressbar"
-          style="top: 0px; height: 0px; --v-progress-linear-height: 2px;"
-        >
-          <!---->
-          <div
-            class="v-progress-linear__background"
-            style="width: 100%;"
-          />
-          <transition-stub
-            appear="false"
-            css="true"
-            name="fade-transition"
-            persisted="false"
-          >
-            <div
-              class="v-progress-linear__indeterminate"
-            >
-              
-              <div
-                class="v-progress-linear__indeterminate long"
-              />
-              <div
-                class="v-progress-linear__indeterminate short"
-              />
-              
-            </div>
-          </transition-stub>
-          <!---->
-        </div>
-      </div>
-      <!---->
-      <!---->
       
-      <div
-        class="v-list v-theme--light v-list--density-default v-list--two-line"
+      <li
+        class="table"
         data-v-de37061b=""
-        role="listbox"
-        tabindex="0"
       >
-        
-        
         <div
-          class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--two-line rounded-0 v-list-item--variant-text table"
+          class="table-info bg-dropdown-background"
           data-v-de37061b=""
-          tabindex="-2"
         >
-          
           <span
-            class="v-list-item__overlay"
-          />
-          <span
-            class="v-list-item__underlay"
-          />
-          
-          <!---->
-          <div
-            class="v-list-item__content"
-            data-no-activator=""
+            data-v-de37061b=""
           >
-            <div
-              class="v-list-item-title"
-            >
-              my meeting
-            </div>
-            <div
-              class="v-list-item-subtitle"
-            >
-              $t('rooms.participantCount')
-            </div>
-            
-            <!--
-        &lt;template v-if="item.prepend" #prepend&gt;
-          &lt;component :is="item.prepend" v-bind="item.prependProps" /&gt;
-        &lt;/template&gt;
-        -->
-            <!--
-        &lt;template v-if="item.append" #append&gt;
-          &lt;component :is="item.append" v-bind="item.appendProps" /&gt;
-        &lt;/template&gt;
-        -->
-            
-          </div>
-          <!---->
+            my meeting
+          </span>
+          <span
+            class="subtitle"
+            data-v-de37061b=""
+          >
+            $t('rooms.participantCount')
+          </span>
         </div>
+        <button
+          class="action"
+          data-v-de37061b=""
+        >
+          <i
+            aria-hidden="true"
+            class="v-icon notranslate v-theme--light v-icon--size-default icon"
+            data-v-de37061b=""
+          >
+            <svg
+              fill="none"
+              height="17"
+              viewBox="0 0 21 17"
+              width="21"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M7.68844 12.4824H9.66834V9.51172H12.6382V7.53125H9.66834V4.56055H7.68844V7.53125H4.71859V9.51172H7.68844V12.4824ZM2.73869 16.4434C2.19422 16.4434 1.72812 16.2494 1.34038 15.8616C0.952654 15.4738 0.758789 15.0075 0.758789 14.4629V2.58008C0.758789 2.03545 0.952654 1.56921 1.34038 1.18137C1.72812 0.79353 2.19422 0.599609 2.73869 0.599609H14.6181C15.1626 0.599609 15.6287 0.79353 16.0164 1.18137C16.4041 1.56921 16.598 2.03545 16.598 2.58008V7.03613L20.5578 3.0752V13.9678L16.598 10.0068V14.4629C16.598 15.0075 16.4041 15.4738 16.0164 15.8616C15.6287 16.2494 15.1626 16.4434 14.6181 16.4434H2.73869ZM2.73869 14.4629H14.6181V2.58008H2.73869V14.4629Z"
+                fill="currentColor"
+              />
+            </svg>
+          </i>
+        </button>
+      </li>
+      <li
+        class="table"
+        data-v-de37061b=""
+      >
         <div
-          class="v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--two-line rounded-0 v-list-item--variant-text table"
+          class="table-info bg-dropdown-background"
           data-v-de37061b=""
-          tabindex="-2"
         >
-          
           <span
-            class="v-list-item__overlay"
-          />
-          <span
-            class="v-list-item__underlay"
-          />
-          
-          <!---->
-          <div
-            class="v-list-item__content"
-            data-no-activator=""
+            data-v-de37061b=""
           >
-            <div
-              class="v-list-item-title"
-            >
-              my meeting
-            </div>
-            <div
-              class="v-list-item-subtitle"
-            >
-              $t('rooms.participantCount')
-            </div>
-            
-            <!--
-        &lt;template v-if="item.prepend" #prepend&gt;
-          &lt;component :is="item.prepend" v-bind="item.prependProps" /&gt;
-        &lt;/template&gt;
-        -->
-            <!--
-        &lt;template v-if="item.append" #append&gt;
-          &lt;component :is="item.append" v-bind="item.appendProps" /&gt;
-        &lt;/template&gt;
-        -->
-            
-          </div>
-          <!---->
+            my meeting
+          </span>
+          <span
+            class="subtitle"
+            data-v-de37061b=""
+          >
+            $t('rooms.participantCount')
+          </span>
         </div>
-        
-        
-      </div>
+        <button
+          class="action"
+          data-v-de37061b=""
+        >
+          <i
+            aria-hidden="true"
+            class="v-icon notranslate v-theme--light v-icon--size-default icon"
+            data-v-de37061b=""
+          >
+            <svg
+              fill="none"
+              height="17"
+              viewBox="0 0 21 17"
+              width="21"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M7.68844 12.4824H9.66834V9.51172H12.6382V7.53125H9.66834V4.56055H7.68844V7.53125H4.71859V9.51172H7.68844V12.4824ZM2.73869 16.4434C2.19422 16.4434 1.72812 16.2494 1.34038 15.8616C0.952654 15.4738 0.758789 15.0075 0.758789 14.4629V2.58008C0.758789 2.03545 0.952654 1.56921 1.34038 1.18137C1.72812 0.79353 2.19422 0.599609 2.73869 0.599609H14.6181C15.1626 0.599609 15.6287 0.79353 16.0164 1.18137C16.4041 1.56921 16.598 2.03545 16.598 2.58008V7.03613L20.5578 3.0752V13.9678L16.598 10.0068V14.4629C16.598 15.0075 16.4041 15.4738 16.0164 15.8616C15.6287 16.2494 15.1626 16.4434 14.6181 16.4434H2.73869ZM2.73869 14.4629H14.6181V2.58008H2.73869V14.4629Z"
+                fill="currentColor"
+              />
+            </svg>
+          </i>
+        </button>
+      </li>
       
-      <!---->
-      
-      <!---->
-      <span
-        class="v-card__underlay"
-      />
-      
-    </div>
+    </ul>
     
   </div>
 </div>

--- a/frontend/src/components/tablesDrawer/__snapshots__/TablesDrawer.test.ts.snap
+++ b/frontend/src/components/tablesDrawer/__snapshots__/TablesDrawer.test.ts.snap
@@ -10,7 +10,7 @@ exports[`TablesDrawer > renders correctly 1`] = `
     
     
     <nav
-      class="v-navigation-drawer v-navigation-drawer--right v-navigation-drawer--temporary v-theme--light v-navigation-drawer--mobile menu-drawer"
+      class="v-navigation-drawer v-navigation-drawer--right v-navigation-drawer--temporary v-theme--light v-navigation-drawer--mobile menu-drawer px-4"
       data-v-cf2c9067=""
       drawer="true"
       style="right: 0px; z-index: 1004; transform: translateX(110%); position: fixed; transition: none !important; height: calc(100% - 0px - 0px); top: 0px; bottom: 0px;"
@@ -22,7 +22,7 @@ exports[`TablesDrawer > renders correctly 1`] = `
       >
         
         <div
-          class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-text-field mx-4 mt-4 search"
+          class="v-input v-input--horizontal v-input--center-affix v-input--density-compact v-theme--light v-locale--is-ltr v-text-field search"
           data-v-cf2c9067=""
         >
           <!---->
@@ -31,7 +31,7 @@ exports[`TablesDrawer > renders correctly 1`] = `
           >
             
             <div
-              class="v-field v-field--appended v-field--center-affix v-field--prepended v-field--variant-solo v-theme--light v-field--rounded v-locale--is-ltr"
+              class="v-field v-field--appended v-field--center-affix v-field--flat v-field--prepended v-field--variant-solo v-theme--light v-field--rounded v-locale--is-ltr"
             >
               <div
                 class="v-field__overlay"
@@ -184,78 +184,15 @@ exports[`TablesDrawer > renders correctly 1`] = `
         >
           
           <h2
-            class="mx-4"
+            class="header mb-4"
             data-v-cf2c9067=""
           >
             $t('tablesDrawer.header')
           </h2>
           <div
-            class="v-card v-theme--light v-card--density-default v-card--variant-elevated mx-auto"
             data-v-cf2c9067=""
-            data-v-de37061b=""
-            style="width: 400px;"
           >
-            <!---->
-            <div
-              class="v-card__loader"
-            >
-              <div
-                aria-hidden="true"
-                aria-valuemax="100"
-                aria-valuemin="0"
-                class="v-progress-linear v-theme--light v-locale--is-ltr"
-                role="progressbar"
-                style="top: 0px; height: 0px; --v-progress-linear-height: 2px;"
-              >
-                <!---->
-                <div
-                  class="v-progress-linear__background"
-                  style="width: 100%;"
-                />
-                <transition-stub
-                  appear="false"
-                  css="true"
-                  name="fade-transition"
-                  persisted="false"
-                >
-                  <div
-                    class="v-progress-linear__indeterminate"
-                  >
-                    
-                    <div
-                      class="v-progress-linear__indeterminate long"
-                    />
-                    <div
-                      class="v-progress-linear__indeterminate short"
-                    />
-                    
-                  </div>
-                </transition-stub>
-                <!---->
-              </div>
-            </div>
-            <!---->
-            <!---->
-            
-            <div
-              class="v-list v-theme--light bg-transparent v-list--density-default v-list--two-line"
-              data-v-de37061b=""
-              role="listbox"
-              tabindex="0"
-            >
-              
-              
-              
-              
-            </div>
-            
-            <!---->
-            
-            <!---->
-            <span
-              class="v-card__underlay"
-            />
-            
+            $t('tablesDrawer.noTables')
           </div>
           
         </div>

--- a/frontend/src/components/tablesDrawer/__snapshots__/TablesDrawer.test.ts.snap
+++ b/frontend/src/components/tablesDrawer/__snapshots__/TablesDrawer.test.ts.snap
@@ -133,7 +133,7 @@ exports[`TablesDrawer > renders correctly 1`] = `
                   
                   <i
                     aria-hidden="false"
-                    aria-label="$vuetify.input.clear"
+                    aria-label="Löschen"
                     class="mdi-close-circle mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable"
                     role="button"
                     tabindex="0"

--- a/frontend/src/layouts/__snapshots__/DefaultLayout.test.ts.snap
+++ b/frontend/src/layouts/__snapshots__/DefaultLayout.test.ts.snap
@@ -15,970 +15,745 @@ exports[`DefaultLayout > renders 1`] = `
     >
       
       
-      <div
-        class="top-menu mt-6 mt-sm-0"
+      <header
+        class="v-toolbar v-toolbar--flat v-toolbar--density-default v-theme--light v-locale--is-ltr v-app-bar app-bar"
         data-v-e787b5f9=""
+        style="top: 0px; z-index: 1008; transform: translateY(0%); position: fixed; transition: none !important; left: 0px; width: calc(100% - 0px - 0px);"
       >
-        <header
-          class="v-toolbar v-toolbar--flat v-toolbar--density-default v-theme--light v-locale--is-ltr v-app-bar app-bar"
-          data-v-e787b5f9=""
-          style="top: 0px; z-index: 1008; transform: translateY(0%); position: fixed; transition: none !important; left: 0px; width: calc(100% - 0px - 0px);"
+        <!---->
+        
+        <div
+          class="v-toolbar__content"
+          style="height: 70px;"
         >
+          <!---->
           <!---->
           
           <div
-            class="v-toolbar__content"
-            style="height: 70px;"
+            class="v-row ma-1"
+            data-v-e787b5f9=""
           >
-            <!---->
-            <!---->
-            
             <div
-              class="v-row ma-1"
+              class="v-col d-none d-md-flex align-center"
               data-v-e787b5f9=""
             >
-              <div
-                class="v-col d-none d-md-flex align-center"
+              <a
+                class="logo"
                 data-v-e787b5f9=""
+                href="/"
               >
-                <a
-                  class="logo"
+                <div
+                  class="v-responsive v-img v-img--booting w-100 logo-small"
                   data-v-e787b5f9=""
-                  href="/"
+                  data-v-f6be2607=""
                 >
                   <div
-                    class="v-responsive v-img v-img--booting w-100 logo-small"
-                    data-v-e787b5f9=""
-                    data-v-f6be2607=""
-                  >
-                    <div
-                      class="v-responsive__sizer"
-                    />
-                    
-                    
-                    <transition-stub
-                      appear="true"
-                      css="true"
-                      name="fade-transition"
-                      persisted="false"
-                    >
-                      <img
-                        class="v-img__img v-img__img--contain"
-                        src="/src/assets/dreammall-logo.svg"
-                        style="display: none;"
-                      />
-                    </transition-stub>
-                    <transition-stub
-                      appear="false"
-                      css="true"
-                      name="fade-transition"
-                      persisted="false"
-                    >
-                      <!---->
-                    </transition-stub>
-                    <!---->
-                    <!---->
-                    <!---->
-                    
-                    
-                    <!---->
-                  </div>
-                </a>
-              </div>
-              <div
-                class="v-col d-flex align-center justify-center"
-                data-v-e787b5f9=""
-              >
-                <button
-                  class="tab-control ma-auto border-sm text-font open"
-                  data-v-d58c92bb=""
-                  data-v-e787b5f9=""
-                >
-                  <div
-                    class="marker"
-                    data-v-d58c92bb=""
-                    style="display: none; width: 0px; left: 0px;"
+                    class="v-responsive__sizer"
                   />
-                  <div
-                    class="d-flex align-center justify-center h-100 w-100"
-                    data-v-d58c92bb=""
+                  
+                  
+                  <transition-stub
+                    appear="true"
+                    css="true"
+                    name="fade-transition"
+                    persisted="false"
                   >
-                    
-                    <a
-                      class="item active"
-                      data-v-d58c92bb=""
-                    >
-                      <div
-                        class="icon d-flex justify-center align-center"
-                        data-v-d58c92bb=""
-                      >
-                        <i
-                          aria-hidden="true"
-                          class="v-icon notranslate v-theme--light v-icon--size-default w-100 world-cafe"
-                          data-v-d58c92bb=""
-                        >
-                          <svg
-                            fill="none"
-                            height="193"
-                            viewBox="0 0 138 193"
-                            width="138"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <g
-                              clip-path="url(#clip0_932_149)"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M29.6 136.89C7.05 118.08 -2.7 92.78 0.64 66.02C3.97 39.35 29.88 -0.749964 56.89 0.0100358C106.62 20.82 -15.77 78.98 29.6 136.89Z"
-                                fill="url(#paint0_linear_932_149)"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M29.6 136.89C24.66 132.77 20.33 128.33 16.62 123.64C3.99 107.66 -1.48 88.69 0.339998 68.8C1.06 88.98 14.09 89.62 20.99 79.13V79.15C41.21 43.56 86.69 15.42 56.89 0.0100098C106.63 20.82 -15.77 78.98 29.6 136.89Z"
-                                fill="#2D0100"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M29.61 136.9C-15.79 78.98 106.67 20.8 56.87 0C60.92 0.11 64.99 1.14 69.02 3.27C77.12 7.55 81.67 16.94 81.29 28.86C80.18 64.11 50.09 75.76 39.88 103.39C36.49 112.58 36.08 121.65 38.65 130.61C39.38 133.13 38.47 135.74 36.36 137.21C34.25 138.68 31.58 138.56 29.6 136.91L29.61 136.9Z"
-                                fill="url(#paint1_linear_932_149)"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M29.61 136.9C-15.79 78.99 106.63 20.82 56.89 0.0100098C70.63 1.37001 77.6 14.24 75.77 26.29C70.7 59.76 29 71.47 28.59 110.64C28.49 119.81 31.09 128.67 36.37 137.21C34.26 138.68 31.59 138.56 29.61 136.91V136.9Z"
-                                fill="url(#paint2_linear_932_149)"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M108.38 12.96C130.93 31.77 140.68 57.06 137.34 83.82C134.01 110.49 108.1 150.59 81.09 149.83C31.36 129.02 153.75 70.86 108.38 12.96Z"
-                                fill="url(#paint3_linear_932_149)"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M108.38 12.96C113.32 17.08 117.65 21.52 121.36 26.21C133.99 42.18 139.46 61.15 137.64 81.04C136.92 60.86 123.89 60.22 116.99 70.71V70.69C96.77 106.28 51.29 134.43 81.09 149.83C31.36 129.02 153.75 70.86 108.38 12.96Z"
-                                fill="#2D0100"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M108.37 12.95C153.77 70.86 31.31 129.04 81.11 149.84C77.06 149.73 72.99 148.7 68.96 146.57C60.86 142.29 56.31 132.9 56.69 120.98C57.8 85.73 87.89 74.08 98.1 46.45C101.49 37.26 101.9 28.19 99.33 19.23C98.6 16.71 99.51 14.1 101.62 12.63C103.73 11.16 106.4 11.28 108.38 12.93L108.37 12.95Z"
-                                fill="url(#paint4_linear_932_149)"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M108.37 12.95C153.76 70.85 31.35 129.03 81.09 149.84C67.35 148.48 60.38 135.61 62.21 123.56C67.28 90.09 108.98 78.38 109.39 39.21C109.49 30.04 106.89 21.18 101.61 12.64C103.72 11.17 106.39 11.29 108.37 12.94V12.95Z"
-                                fill="url(#paint5_linear_932_149)"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M46.08 182.97C46.04 188.09 50.16 192.27 55.29 192.31C59.9 192.34 63.48 188.95 64.5 184.6C66.82 174.7 62.43 164.87 49.88 158.79C57.01 170.18 46.15 173.4 46.09 182.96L46.08 182.97Z"
-                                fill="url(#paint6_linear_932_149)"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M48.07 182.99C48.04 187.01 51.28 190.3 55.3 190.33C56.87 190.34 58.28 189.85 59.44 189C56.57 187.88 54.11 185.72 52.66 182.73C51.21 179.74 51.03 176.26 52.02 173.24C50.26 176.33 48.1 179.16 48.07 182.98V182.99Z"
-                                fill="url(#paint7_linear_932_149)"
-                                fill-rule="evenodd"
-                                opacity="0.5"
-                              />
-                            </g>
-                            <defs>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint0_linear_932_149"
-                                x1="-16.8153"
-                                x2="61.3369"
-                                y1="116.566"
-                                y2="-41.9949"
-                              >
-                                <stop
-                                  stop-color="#1C2A39"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#7C8A99"
-                                />
-                              </lineargradient>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint1_linear_932_149"
-                                x1="11.8868"
-                                x2="75.9494"
-                                y1="87.02"
-                                y2="-30.1607"
-                              >
-                                <stop
-                                  stop-color="#7C8A99"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#FEFEFE"
-                                />
-                              </lineargradient>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint2_linear_932_149"
-                                x1="19.31"
-                                x2="76.06"
-                                y1="69.12"
-                                y2="69.12"
-                              >
-                                <stop
-                                  stop-color="#1C2A39"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#BCCAD9"
-                                />
-                              </lineargradient>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint3_linear_932_149"
-                                x1="160.483"
-                                x2="82.3302"
-                                y1="32.9545"
-                                y2="191.516"
-                              >
-                                <stop
-                                  stop-color="#1C2A39"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#7C8A99"
-                                />
-                              </lineargradient>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint4_linear_932_149"
-                                x1="131.78"
-                                x2="67.7184"
-                                y1="62.5008"
-                                y2="179.682"
-                              >
-                                <stop
-                                  stop-color="#7C8A99"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#FEFEFE"
-                                />
-                              </lineargradient>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint5_linear_932_149"
-                                x1="118.66"
-                                x2="61.92"
-                                y1="80.73"
-                                y2="80.73"
-                              >
-                                <stop
-                                  stop-color="#1C2A39"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#BCCAD9"
-                                />
-                              </lineargradient>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint6_linear_932_149"
-                                x1="66.33"
-                                x2="38.1302"
-                                y1="185.538"
-                                y2="166.541"
-                              >
-                                <stop
-                                  stop-color="#1C2A39"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#BCCAD9"
-                                />
-                              </lineargradient>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint7_linear_932_149"
-                                x1="48.07"
-                                x2="59.43"
-                                y1="181.79"
-                                y2="181.79"
-                              >
-                                <stop
-                                  stop-color="#1C2A39"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#BCCAD9"
-                                />
-                              </lineargradient>
-                              <clippath
-                                id="clip0_932_149"
-                              >
-                                <rect
-                                  fill="white"
-                                  height="192.32"
-                                  width="137.98"
-                                />
-                              </clippath>
-                            </defs>
-                          </svg>
-                        </i>
-                      </div>
-                       $t('menu.worldCafe')
-                    </a>
-                    <a
-                      class="item"
-                      data-v-d58c92bb=""
-                    >
-                      <div
-                        class="icon d-flex justify-center align-center"
-                        data-v-d58c92bb=""
-                      >
-                        <i
-                          aria-hidden="true"
-                          class="v-icon notranslate v-theme--light v-icon--size-default w-100 cockpit"
-                          data-v-d58c92bb=""
-                        >
-                          <svg
-                            fill="none"
-                            height="176"
-                            viewBox="0 0 199 176"
-                            width="199"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <g
-                              clip-path="url(#clip0_932_164)"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M114.97 173.44C150.48 163.92 197.5 127.82 198.21 73.86C198.52 50.4 187.26 48.27 182.97 56.91C181.13 60.62 180.98 64.24 180.14 67.95C177.14 81.18 165.8 87 153.69 80.23C146.63 76.28 138.07 68.51 127.45 56.28C112.25 38.92 78 64.72 110.87 91.07C118 98.01 122.48 103.77 124.92 108.48C139.8 134.22 138.6 163.82 114.97 173.44ZM165.84 29.6C175.36 34.5 179.11 46.19 174.21 55.71C169.31 65.23 157.62 68.98 148.1 64.08C138.58 59.18 134.83 47.49 139.73 37.97C144.63 28.45 156.32 24.7 165.84 29.6Z"
-                                fill="#3D4753"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M185.89 118.69C193.31 105.64 197.99 90.61 198.21 73.86C198.52 50.4 187.26 48.27 182.97 56.91C181.13 60.62 180.98 64.24 180.14 67.95C177.14 81.18 165.8 87 153.69 80.23C146.63 76.28 138.07 68.51 127.45 56.28C112.25 38.92 78 64.72 110.87 91.07C118 98.01 122.48 103.77 124.92 108.48C127.09 112.22 128.91 116.05 130.37 119.89C148.68 128.16 169.03 127.17 185.89 118.69ZM165.84 29.6C175.36 34.5 179.11 46.19 174.21 55.71C169.31 65.23 157.62 68.98 148.1 64.08C138.58 59.18 134.83 47.49 139.73 37.97C144.63 28.45 156.32 24.7 165.84 29.6Z"
-                                fill="url(#paint0_linear_932_164)"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M164.66 83.03C161.24 83.23 157.51 82.35 153.7 80.22C146.64 76.27 138.08 68.5 127.46 56.27C112.26 38.91 78.01 64.71 110.88 91.06C118.01 98 122.49 103.76 124.93 108.47C139.81 134.21 138.61 163.81 114.98 173.43C152.26 161.24 170.74 117.56 164.67 83.03H164.66Z"
-                                fill="url(#paint1_linear_932_164)"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M126.63 112.63C135.3 139.02 62.87 143.52 78.27 167.93C83.66 176.47 98 177.98 114.97 173.43C138.6 163.81 139.8 134.21 124.92 108.47C125.32 109.24 125.66 109.98 125.95 110.69C126.22 111.36 126.45 112 126.63 112.62V112.63Z"
-                                fill="#3D4753"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M126.63 112.63C128.19 117.39 127.11 121.43 124.39 125.01C132.94 143.69 131.33 163.08 114.97 173.43C138.6 163.81 139.8 134.21 124.92 108.47C125.32 109.24 125.66 109.98 125.95 110.69C126.22 111.36 126.45 112 126.63 112.62V112.63Z"
-                                fill="#0E215E"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M175.13 49.4501C176.21 41.9201 172.51 34.2001 165.36 30.5201C156.35 25.8801 145.29 29.4301 140.65 38.4401C136.41 46.6901 139.02 56.6501 146.4 61.8401C145.13 57.9801 145.35 53.6301 147.35 49.7401C151.32 42.0301 160.79 38.9901 168.5 42.9601C171.42 44.4701 173.68 46.7601 175.13 49.4501Z"
-                                fill="url(#paint2_linear_932_164)"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M83.25 2.51001C47.74 12.04 0.710003 48.13 3.42075e-06 102.1C-0.309997 125.55 10.95 127.69 15.24 119.05C17.08 115.34 17.23 111.72 18.07 108.01C21.07 94.78 32.41 88.96 44.52 95.73C51.58 99.68 60.14 107.45 70.76 119.68C85.96 137.04 120.21 111.24 87.34 84.89C80.21 77.95 75.73 72.19 73.29 67.48C58.41 41.74 59.61 12.14 83.24 2.52001L83.25 2.51001ZM32.38 146.35C22.86 141.45 19.11 129.76 24.01 120.24C28.91 110.72 40.6 106.97 50.12 111.87C59.64 116.77 63.39 128.46 58.49 137.99C53.59 147.51 41.9 151.26 32.38 146.36V146.35Z"
-                                fill="url(#paint3_linear_932_164)"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M12.33 57.27C4.91 70.31 0.230003 85.34 3.42075e-06 102.1C-0.309997 125.55 10.95 127.69 15.24 119.05C17.08 115.34 17.23 111.72 18.07 108.01C21.07 94.78 32.41 88.96 44.52 95.73C51.58 99.68 60.14 107.45 70.76 119.68C85.96 137.04 120.21 111.24 87.34 84.89C80.21 77.95 75.73 72.19 73.29 67.48C71.12 63.74 69.3 59.91 67.84 56.07C49.53 47.8 29.18 48.79 12.32 57.27H12.33ZM32.38 146.36C22.86 141.46 19.11 129.77 24.01 120.25C28.91 110.73 40.6 106.98 50.12 111.88C59.64 116.78 63.39 128.47 58.49 138C53.59 147.52 41.9 151.27 32.38 146.37V146.36Z"
-                                fill="url(#paint4_linear_932_164)"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M33.56 92.92C36.98 92.72 40.71 93.6 44.52 95.73C51.58 99.68 60.14 107.45 70.76 119.68C85.96 137.04 120.21 111.24 87.34 84.89C80.21 77.95 75.73 72.19 73.29 67.48C58.41 41.74 59.61 12.14 83.24 2.52002C45.97 14.7 27.49 58.38 33.56 92.92Z"
-                                fill="url(#paint5_linear_932_164)"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M71.58 63.32C62.91 36.93 135.34 32.43 119.94 8.02001C114.55 -0.519989 100.21 -2.02999 83.24 2.52001C59.61 12.14 58.41 41.74 73.29 67.48C72.89 66.71 72.55 65.97 72.26 65.26C71.99 64.59 71.76 63.95 71.58 63.33V63.32Z"
-                                fill="url(#paint6_linear_932_164)"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M71.58 63.32C70.02 58.56 71.1 54.52 73.82 50.94C65.27 32.26 66.88 12.87 83.24 2.52002C59.61 12.14 58.41 41.74 73.29 67.48C72.89 66.71 72.55 65.97 72.26 65.26C71.99 64.59 71.76 63.95 71.58 63.33V63.32Z"
-                                fill="url(#paint7_linear_932_164)"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M23.09 126.5C22.01 134.03 25.71 141.75 32.86 145.43C41.87 150.07 52.93 146.52 57.57 137.51C61.81 129.26 59.2 119.3 51.82 114.11C53.09 117.97 52.87 122.32 50.87 126.21C46.9 133.92 37.43 136.96 29.72 132.99C26.8 131.48 24.54 129.19 23.09 126.5Z"
-                                fill="url(#paint8_linear_932_164)"
-                                fill-rule="evenodd"
-                              />
-                            </g>
-                            <defs>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint0_linear_932_164"
-                                x1="97.08"
-                                x2="198.22"
-                                y1="76.52"
-                                y2="76.52"
-                              >
-                                <stop
-                                  stop-color="#1C2A39"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#7C8A99"
-                                />
-                              </lineargradient>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint1_linear_932_164"
-                                x1="97.08"
-                                x2="165.79"
-                                y1="112.04"
-                                y2="112.04"
-                              >
-                                <stop
-                                  stop-color="#1C2A39"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#7C8A99"
-                                />
-                              </lineargradient>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint2_linear_932_164"
-                                x1="138.61"
-                                x2="175.31"
-                                y1="45.1601"
-                                y2="45.1601"
-                              >
-                                <stop
-                                  stop-color="#1C2A39"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#7C8A99"
-                                />
-                              </lineargradient>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint3_linear_932_164"
-                                x1="-21.8556"
-                                x2="51.1173"
-                                y1="117.802"
-                                y2="16.8919"
-                              >
-                                <stop
-                                  stop-color="#1C2A39"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#BCCAD9"
-                                />
-                              </lineargradient>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint4_linear_932_164"
-                                x1="3.41999e-06"
-                                x2="101.14"
-                                y1="99.43"
-                                y2="99.43"
-                              >
-                                <stop
-                                  stop-color="#7C8A99"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#FEFEFE"
-                                />
-                              </lineargradient>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint5_linear_932_164"
-                                x1="32.42"
-                                x2="1.00001"
-                                y1="63.92"
-                                y2="63.92"
-                              >
-                                <stop
-                                  stop-color="#7C8A99"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#FEFEFE"
-                                />
-                              </lineargradient>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint6_linear_932_164"
-                                x1="34.9389"
-                                x2="87.84"
-                                y1="8.56541"
-                                y2="-25.5456"
-                              >
-                                <stop
-                                  stop-color="#1C2A39"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#BCCAD9"
-                                />
-                              </lineargradient>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint7_linear_932_164"
-                                x1="63.53"
-                                x2="83.25"
-                                y1="34.99"
-                                y2="34.99"
-                              >
-                                <stop
-                                  stop-color="#7C8A99"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#FEFEFE"
-                                />
-                              </lineargradient>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint8_linear_932_164"
-                                x1="22.9"
-                                x2="59.61"
-                                y1="130.79"
-                                y2="130.79"
-                              >
-                                <stop
-                                  stop-color="#7C8A99"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#FEFEFE"
-                                />
-                              </lineargradient>
-                              <clippath
-                                id="clip0_932_164"
-                              >
-                                <rect
-                                  fill="white"
-                                  height="175.95"
-                                  width="198.22"
-                                />
-                              </clippath>
-                            </defs>
-                          </svg>
-                        </i>
-                      </div>
-                       $t('menu.cockpit')
-                    </a>
-                    
-                  </div>
-                </button>
-              </div>
-              <div
-                class="v-col d-none d-md-flex align-center"
+                    <img
+                      class="v-img__img v-img__img--contain"
+                      src="/src/assets/dreammall-logo.svg"
+                      style="display: none;"
+                    />
+                  </transition-stub>
+                  <transition-stub
+                    appear="false"
+                    css="true"
+                    name="fade-transition"
+                    persisted="false"
+                  >
+                    <!---->
+                  </transition-stub>
+                  <!---->
+                  <!---->
+                  <!---->
+                  
+                  
+                  <!---->
+                </div>
+              </a>
+            </div>
+            <div
+              class="v-col d-flex align-center justify-center"
+              data-v-e787b5f9=""
+            >
+              <button
+                class="tab-control ma-auto border-sm text-font open"
+                data-v-d58c92bb=""
                 data-v-e787b5f9=""
               >
                 <div
-                  class="v-row"
-                  data-v-e787b5f9=""
+                  class="marker"
+                  data-v-d58c92bb=""
+                  style="display: none; width: 0px; left: 0px;"
+                />
+                <div
+                  class="d-flex align-center justify-center h-100 w-100"
+                  data-v-d58c92bb=""
                 >
-                  <div
-                    class="v-col d-flex align-center"
-                    data-v-e787b5f9=""
+                  
+                  <a
+                    class="item active"
+                    data-v-d58c92bb=""
                   >
-                    <button
-                      class="d-flex align-center justify-center light-dark-switch d-none d-lg-flex"
-                      data-v-e787b5f9=""
+                    <div
+                      class="icon d-flex justify-center align-center"
+                      data-v-d58c92bb=""
                     >
-                      <svg
-                        fill="none"
-                        height="15"
-                        viewBox="0 0 28 15"
-                        width="28"
-                        xmlns="http://www.w3.org/2000/svg"
+                      <i
+                        aria-hidden="true"
+                        class="v-icon notranslate v-theme--light v-icon--size-default w-100 world-cafe"
+                        data-v-d58c92bb=""
                       >
-                        <path
-                          d="M7.63636 15C5.51515 15 3.71212 14.2708 2.22727 12.8125C0.742424 11.3542 0 9.58333 0 7.5C0 5.41667 0.742424 3.64583 2.22727 2.1875C3.71212 0.729167 5.51515 0 7.63636 0H20.3636C22.4848 0 24.2879 0.729167 25.7727 2.1875C27.2576 3.64583 28 5.41667 28 7.5C28 9.58333 27.2576 11.3542 25.7727 12.8125C24.2879 14.2708 22.4848 15 20.3636 15H7.63636ZM7.63636 12.5H20.3636C21.7636 12.5 22.9621 12.0104 23.9591 11.0312C24.9561 10.0521 25.4545 8.875 25.4545 7.5C25.4545 6.125 24.9561 4.94792 23.9591 3.96875C22.9621 2.98958 21.7636 2.5 20.3636 2.5H7.63636C6.23636 2.5 5.03788 2.98958 4.04091 3.96875C3.04394 4.94792 2.54545 6.125 2.54545 7.5C2.54545 8.875 3.04394 10.0521 4.04091 11.0312C5.03788 12.0104 6.23636 12.5 7.63636 12.5ZM7.63636 11.25C8.69697 11.25 9.59848 10.8854 10.3409 10.1562C11.0833 9.42708 11.4545 8.54167 11.4545 7.5C11.4545 6.45833 11.0833 5.57292 10.3409 4.84375C9.59848 4.11458 8.69697 3.75 7.63636 3.75C6.57576 3.75 5.67424 4.11458 4.93182 4.84375C4.18939 5.57292 3.81818 6.45833 3.81818 7.5C3.81818 8.54167 4.18939 9.42708 4.93182 10.1562C5.67424 10.8854 6.57576 11.25 7.63636 11.25Z"
-                          fill="currentColor"
-                        />
-                      </svg>
-                      <svg
-                        fill="none"
-                        height="15"
-                        style="display: none;"
-                        viewBox="0 0 28 15"
-                        width="28"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M7.63636 15C5.51515 15 3.71212 14.2708 2.22727 12.8125C0.742424 11.3542 0 9.58333 0 7.5C0 5.41667 0.742424 3.64583 2.22727 2.1875C3.71212 0.729167 5.51515 0 7.63636 0H20.3636C22.4848 0 24.2879 0.729167 25.7727 2.1875C27.2576 3.64583 28 5.41667 28 7.5C28 9.58333 27.2576 11.3542 25.7727 12.8125C24.2879 14.2708 22.4848 15 20.3636 15H7.63636ZM7.63636 12.5H20.3636C21.7636 12.5 22.9621 12.0104 23.9591 11.0312C24.9561 10.0521 25.4545 8.875 25.4545 7.5C25.4545 6.125 24.9561 4.94792 23.9591 3.96875C22.9621 2.98958 21.7636 2.5 20.3636 2.5H7.63636C6.23636 2.5 5.03788 2.98958 4.04091 3.96875C3.04394 4.94792 2.54545 6.125 2.54545 7.5C2.54545 8.875 3.04394 10.0521 4.04091 11.0312C5.03788 12.0104 6.23636 12.5 7.63636 12.5ZM20.3636 11.25C21.4242 11.25 22.3258 10.8854 23.0682 10.1562C23.8106 9.42708 24.1818 8.54167 24.1818 7.5C24.1818 6.45833 23.8106 5.57292 23.0682 4.84375C22.3258 4.11458 21.4242 3.75 20.3636 3.75C19.303 3.75 18.4015 4.11458 17.6591 4.84375C16.9167 5.57292 16.5455 6.45833 16.5455 7.5C16.5455 8.54167 16.9167 9.42708 17.6591 10.1562C18.4015 10.8854 19.303 11.25 20.3636 11.25Z"
-                          fill="currentColor"
-                        />
-                      </svg>
-                      <span
-                        class="ml-2"
-                      >
-                        $t('menu.theme.light') / $t('menu.theme.dark')
-                      </span>
-                    </button>
-                  </div>
-                  <div
-                    class="v-col d-flex align-center justify-end"
-                    data-v-e787b5f9=""
-                  >
-                    <button
-                      data-v-e787b5f9=""
-                    >
-                      <div
-                        class="circle rounded-circle border-sm text-icon pa-2 d-flex justify-center align-center"
-                        data-v-39e8094e=""
-                        data-v-e787b5f9=""
-                      >
-                        
-                        <i
-                          aria-hidden="true"
-                          class="v-icon notranslate v-theme--light v-icon--size-default"
-                          data-v-e787b5f9=""
+                        <svg
+                          fill="none"
+                          height="193"
+                          viewBox="0 0 138 193"
+                          width="138"
+                          xmlns="http://www.w3.org/2000/svg"
                         >
-                          <svg
-                            fill="none"
-                            height="17"
-                            viewBox="0 0 21 17"
-                            width="21"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M7.68844 12.4824H9.66834V9.51172H12.6382V7.53125H9.66834V4.56055H7.68844V7.53125H4.71859V9.51172H7.68844V12.4824ZM2.73869 16.4434C2.19422 16.4434 1.72812 16.2494 1.34038 15.8616C0.952654 15.4738 0.758789 15.0075 0.758789 14.4629V2.58008C0.758789 2.03545 0.952654 1.56921 1.34038 1.18137C1.72812 0.79353 2.19422 0.599609 2.73869 0.599609H14.6181C15.1626 0.599609 15.6287 0.79353 16.0164 1.18137C16.4041 1.56921 16.598 2.03545 16.598 2.58008V7.03613L20.5578 3.0752V13.9678L16.598 10.0068V14.4629C16.598 15.0075 16.4041 15.4738 16.0164 15.8616C15.6287 16.2494 15.1626 16.4434 14.6181 16.4434H2.73869ZM2.73869 14.4629H14.6181V2.58008H2.73869V14.4629Z"
-                              fill="currentColor"
-                            />
-                          </svg>
-                        </i>
-                        
-                      </div>
-                    </button>
-                    
-                    
-                    <button
-                      aria-expanded="false"
-                      aria-haspopup="menu"
-                      aria-owns="v-menu-1"
-                      class="ml-2 user-info rounded-pill d-flex flex-row text-icon border-sm align-center justify-center"
-                      data-v-607bdd70=""
-                      targetref="[object Object]"
-                    >
-                      <div
-                        class="v-avatar v-theme--light v-avatar--density-default v-avatar--variant-flat avatar d-flex align-center text-font border-sm bg-primary"
-                        data-v-607bdd70=""
-                        style="width: 44px; height: 44px;"
-                      >
-                        
-                        
-                        <span
-                          data-v-607bdd70=""
-                        />
-                        
-                        
-                        
-                        <!---->
-                        <span
-                          class="v-avatar__underlay"
-                        />
-                        
-                      </div>
-                      <div
-                        class="d-flex flex-column justify-center text-right pa-1 pl-3 w-100"
-                        data-v-607bdd70=""
-                      >
-                        <i
-                          aria-hidden="true"
-                          class="v-icon notranslate v-theme--light v-icon--size-default ellipsis-icon"
-                          data-test="user-dropdown"
-                          data-v-607bdd70=""
-                        >
-                          <svg
-                            fill="none"
-                            height="4"
-                            viewBox="0 0 18 4"
-                            width="18"
-                            xmlns="http://www.w3.org/2000/svg"
+                          <g
+                            clip-path="url(#clip0_932_149)"
                           >
                             <path
                               clip-rule="evenodd"
-                              d="M2 0C3.10457 0 4 0.895431 4 2C4 3.10457 3.10457 4 2 4C0.895431 4 0 3.10457 0 2C0 0.895431 0.895431 0 2 0ZM9 0C10.1046 0 11 0.895431 11 2C11 3.10457 10.1046 4 9 4C7.89543 4 7 3.10457 7 2C7 0.895431 7.89543 0 9 0ZM18 2C18 0.895431 17.1046 0 16 0C14.8954 0 14 0.895431 14 2C14 3.10457 14.8954 4 16 4C17.1046 4 18 3.10457 18 2Z"
-                              fill="currentColor"
+                              d="M29.6 136.89C7.05 118.08 -2.7 92.78 0.64 66.02C3.97 39.35 29.88 -0.749964 56.89 0.0100358C106.62 20.82 -15.77 78.98 29.6 136.89Z"
+                              fill="url(#paint0_linear_932_149)"
                               fill-rule="evenodd"
                             />
-                          </svg>
-                        </i>
-                      </div>
-                    </button>
-                    
-                    <!---->
-                    
-                  </div>
-                </div>
-              </div>
-            </div>
-            
-            <!---->
-          </div>
-          
-          
-          <transition-stub
-            appear="false"
-            css="true"
-            name="expand-transition"
-            persisted="false"
-          >
-            <!---->
-          </transition-stub>
-          
-        </header>
-      </div>
-      
-      <nav
-        class="v-navigation-drawer v-navigation-drawer--right v-navigation-drawer--temporary v-theme--light v-navigation-drawer--mobile menu-drawer px-4"
-        data-v-cf2c9067=""
-        style="right: 0px; z-index: 1006; transform: translateX(110%); position: fixed; height: calc(100% - 70px - 0px); top: 70px; bottom: 0px; transition: none !important;"
-      >
-        <!---->
-        <!---->
-        <div
-          class="v-navigation-drawer__content"
-        >
-          
-          <div
-            class="v-input v-input--horizontal v-input--center-affix v-input--density-compact v-theme--light v-locale--is-ltr v-text-field search"
-            data-v-cf2c9067=""
-          >
-            <!---->
-            <div
-              class="v-input__control"
-            >
-              
-              <div
-                class="v-field v-field--appended v-field--center-affix v-field--flat v-field--prepended v-field--variant-solo v-theme--light v-field--rounded v-locale--is-ltr"
-              >
-                <div
-                  class="v-field__overlay"
-                />
-                <div
-                  class="v-field__loader"
-                >
-                  <div
-                    aria-hidden="true"
-                    aria-valuemax="100"
-                    aria-valuemin="0"
-                    class="v-progress-linear v-theme--light v-locale--is-ltr"
-                    role="progressbar"
-                    style="top: 0px; height: 0px; --v-progress-linear-height: 2px;"
+                            <path
+                              clip-rule="evenodd"
+                              d="M29.6 136.89C24.66 132.77 20.33 128.33 16.62 123.64C3.99 107.66 -1.48 88.69 0.339998 68.8C1.06 88.98 14.09 89.62 20.99 79.13V79.15C41.21 43.56 86.69 15.42 56.89 0.0100098C106.63 20.82 -15.77 78.98 29.6 136.89Z"
+                              fill="#2D0100"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M29.61 136.9C-15.79 78.98 106.67 20.8 56.87 0C60.92 0.11 64.99 1.14 69.02 3.27C77.12 7.55 81.67 16.94 81.29 28.86C80.18 64.11 50.09 75.76 39.88 103.39C36.49 112.58 36.08 121.65 38.65 130.61C39.38 133.13 38.47 135.74 36.36 137.21C34.25 138.68 31.58 138.56 29.6 136.91L29.61 136.9Z"
+                              fill="url(#paint1_linear_932_149)"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M29.61 136.9C-15.79 78.99 106.63 20.82 56.89 0.0100098C70.63 1.37001 77.6 14.24 75.77 26.29C70.7 59.76 29 71.47 28.59 110.64C28.49 119.81 31.09 128.67 36.37 137.21C34.26 138.68 31.59 138.56 29.61 136.91V136.9Z"
+                              fill="url(#paint2_linear_932_149)"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M108.38 12.96C130.93 31.77 140.68 57.06 137.34 83.82C134.01 110.49 108.1 150.59 81.09 149.83C31.36 129.02 153.75 70.86 108.38 12.96Z"
+                              fill="url(#paint3_linear_932_149)"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M108.38 12.96C113.32 17.08 117.65 21.52 121.36 26.21C133.99 42.18 139.46 61.15 137.64 81.04C136.92 60.86 123.89 60.22 116.99 70.71V70.69C96.77 106.28 51.29 134.43 81.09 149.83C31.36 129.02 153.75 70.86 108.38 12.96Z"
+                              fill="#2D0100"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M108.37 12.95C153.77 70.86 31.31 129.04 81.11 149.84C77.06 149.73 72.99 148.7 68.96 146.57C60.86 142.29 56.31 132.9 56.69 120.98C57.8 85.73 87.89 74.08 98.1 46.45C101.49 37.26 101.9 28.19 99.33 19.23C98.6 16.71 99.51 14.1 101.62 12.63C103.73 11.16 106.4 11.28 108.38 12.93L108.37 12.95Z"
+                              fill="url(#paint4_linear_932_149)"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M108.37 12.95C153.76 70.85 31.35 129.03 81.09 149.84C67.35 148.48 60.38 135.61 62.21 123.56C67.28 90.09 108.98 78.38 109.39 39.21C109.49 30.04 106.89 21.18 101.61 12.64C103.72 11.17 106.39 11.29 108.37 12.94V12.95Z"
+                              fill="url(#paint5_linear_932_149)"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M46.08 182.97C46.04 188.09 50.16 192.27 55.29 192.31C59.9 192.34 63.48 188.95 64.5 184.6C66.82 174.7 62.43 164.87 49.88 158.79C57.01 170.18 46.15 173.4 46.09 182.96L46.08 182.97Z"
+                              fill="url(#paint6_linear_932_149)"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M48.07 182.99C48.04 187.01 51.28 190.3 55.3 190.33C56.87 190.34 58.28 189.85 59.44 189C56.57 187.88 54.11 185.72 52.66 182.73C51.21 179.74 51.03 176.26 52.02 173.24C50.26 176.33 48.1 179.16 48.07 182.98V182.99Z"
+                              fill="url(#paint7_linear_932_149)"
+                              fill-rule="evenodd"
+                              opacity="0.5"
+                            />
+                          </g>
+                          <defs>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint0_linear_932_149"
+                              x1="-16.8153"
+                              x2="61.3369"
+                              y1="116.566"
+                              y2="-41.9949"
+                            >
+                              <stop
+                                stop-color="#1C2A39"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#7C8A99"
+                              />
+                            </lineargradient>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint1_linear_932_149"
+                              x1="11.8868"
+                              x2="75.9494"
+                              y1="87.02"
+                              y2="-30.1607"
+                            >
+                              <stop
+                                stop-color="#7C8A99"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#FEFEFE"
+                              />
+                            </lineargradient>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint2_linear_932_149"
+                              x1="19.31"
+                              x2="76.06"
+                              y1="69.12"
+                              y2="69.12"
+                            >
+                              <stop
+                                stop-color="#1C2A39"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#BCCAD9"
+                              />
+                            </lineargradient>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint3_linear_932_149"
+                              x1="160.483"
+                              x2="82.3302"
+                              y1="32.9545"
+                              y2="191.516"
+                            >
+                              <stop
+                                stop-color="#1C2A39"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#7C8A99"
+                              />
+                            </lineargradient>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint4_linear_932_149"
+                              x1="131.78"
+                              x2="67.7184"
+                              y1="62.5008"
+                              y2="179.682"
+                            >
+                              <stop
+                                stop-color="#7C8A99"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#FEFEFE"
+                              />
+                            </lineargradient>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint5_linear_932_149"
+                              x1="118.66"
+                              x2="61.92"
+                              y1="80.73"
+                              y2="80.73"
+                            >
+                              <stop
+                                stop-color="#1C2A39"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#BCCAD9"
+                              />
+                            </lineargradient>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint6_linear_932_149"
+                              x1="66.33"
+                              x2="38.1302"
+                              y1="185.538"
+                              y2="166.541"
+                            >
+                              <stop
+                                stop-color="#1C2A39"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#BCCAD9"
+                              />
+                            </lineargradient>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint7_linear_932_149"
+                              x1="48.07"
+                              x2="59.43"
+                              y1="181.79"
+                              y2="181.79"
+                            >
+                              <stop
+                                stop-color="#1C2A39"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#BCCAD9"
+                              />
+                            </lineargradient>
+                            <clippath
+                              id="clip0_932_149"
+                            >
+                              <rect
+                                fill="white"
+                                height="192.32"
+                                width="137.98"
+                              />
+                            </clippath>
+                          </defs>
+                        </svg>
+                      </i>
+                    </div>
+                     $t('menu.worldCafe')
+                  </a>
+                  <a
+                    class="item"
+                    data-v-d58c92bb=""
                   >
-                    <!---->
                     <div
-                      class="v-progress-linear__background"
-                      style="width: 100%;"
-                    />
-                    <transition-stub
-                      appear="false"
-                      css="true"
-                      name="fade-transition"
-                      persisted="false"
+                      class="icon d-flex justify-center align-center"
+                      data-v-d58c92bb=""
                     >
-                      <div
-                        class="v-progress-linear__indeterminate"
+                      <i
+                        aria-hidden="true"
+                        class="v-icon notranslate v-theme--light v-icon--size-default w-100 cockpit"
+                        data-v-d58c92bb=""
                       >
-                        
-                        <div
-                          class="v-progress-linear__indeterminate long"
-                        />
-                        <div
-                          class="v-progress-linear__indeterminate short"
-                        />
-                        
-                      </div>
-                    </transition-stub>
-                    <!---->
-                  </div>
+                        <svg
+                          fill="none"
+                          height="176"
+                          viewBox="0 0 199 176"
+                          width="199"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <g
+                            clip-path="url(#clip0_932_164)"
+                          >
+                            <path
+                              clip-rule="evenodd"
+                              d="M114.97 173.44C150.48 163.92 197.5 127.82 198.21 73.86C198.52 50.4 187.26 48.27 182.97 56.91C181.13 60.62 180.98 64.24 180.14 67.95C177.14 81.18 165.8 87 153.69 80.23C146.63 76.28 138.07 68.51 127.45 56.28C112.25 38.92 78 64.72 110.87 91.07C118 98.01 122.48 103.77 124.92 108.48C139.8 134.22 138.6 163.82 114.97 173.44ZM165.84 29.6C175.36 34.5 179.11 46.19 174.21 55.71C169.31 65.23 157.62 68.98 148.1 64.08C138.58 59.18 134.83 47.49 139.73 37.97C144.63 28.45 156.32 24.7 165.84 29.6Z"
+                              fill="#3D4753"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M185.89 118.69C193.31 105.64 197.99 90.61 198.21 73.86C198.52 50.4 187.26 48.27 182.97 56.91C181.13 60.62 180.98 64.24 180.14 67.95C177.14 81.18 165.8 87 153.69 80.23C146.63 76.28 138.07 68.51 127.45 56.28C112.25 38.92 78 64.72 110.87 91.07C118 98.01 122.48 103.77 124.92 108.48C127.09 112.22 128.91 116.05 130.37 119.89C148.68 128.16 169.03 127.17 185.89 118.69ZM165.84 29.6C175.36 34.5 179.11 46.19 174.21 55.71C169.31 65.23 157.62 68.98 148.1 64.08C138.58 59.18 134.83 47.49 139.73 37.97C144.63 28.45 156.32 24.7 165.84 29.6Z"
+                              fill="url(#paint0_linear_932_164)"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M164.66 83.03C161.24 83.23 157.51 82.35 153.7 80.22C146.64 76.27 138.08 68.5 127.46 56.27C112.26 38.91 78.01 64.71 110.88 91.06C118.01 98 122.49 103.76 124.93 108.47C139.81 134.21 138.61 163.81 114.98 173.43C152.26 161.24 170.74 117.56 164.67 83.03H164.66Z"
+                              fill="url(#paint1_linear_932_164)"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M126.63 112.63C135.3 139.02 62.87 143.52 78.27 167.93C83.66 176.47 98 177.98 114.97 173.43C138.6 163.81 139.8 134.21 124.92 108.47C125.32 109.24 125.66 109.98 125.95 110.69C126.22 111.36 126.45 112 126.63 112.62V112.63Z"
+                              fill="#3D4753"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M126.63 112.63C128.19 117.39 127.11 121.43 124.39 125.01C132.94 143.69 131.33 163.08 114.97 173.43C138.6 163.81 139.8 134.21 124.92 108.47C125.32 109.24 125.66 109.98 125.95 110.69C126.22 111.36 126.45 112 126.63 112.62V112.63Z"
+                              fill="#0E215E"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M175.13 49.4501C176.21 41.9201 172.51 34.2001 165.36 30.5201C156.35 25.8801 145.29 29.4301 140.65 38.4401C136.41 46.6901 139.02 56.6501 146.4 61.8401C145.13 57.9801 145.35 53.6301 147.35 49.7401C151.32 42.0301 160.79 38.9901 168.5 42.9601C171.42 44.4701 173.68 46.7601 175.13 49.4501Z"
+                              fill="url(#paint2_linear_932_164)"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M83.25 2.51001C47.74 12.04 0.710003 48.13 3.42075e-06 102.1C-0.309997 125.55 10.95 127.69 15.24 119.05C17.08 115.34 17.23 111.72 18.07 108.01C21.07 94.78 32.41 88.96 44.52 95.73C51.58 99.68 60.14 107.45 70.76 119.68C85.96 137.04 120.21 111.24 87.34 84.89C80.21 77.95 75.73 72.19 73.29 67.48C58.41 41.74 59.61 12.14 83.24 2.52001L83.25 2.51001ZM32.38 146.35C22.86 141.45 19.11 129.76 24.01 120.24C28.91 110.72 40.6 106.97 50.12 111.87C59.64 116.77 63.39 128.46 58.49 137.99C53.59 147.51 41.9 151.26 32.38 146.36V146.35Z"
+                              fill="url(#paint3_linear_932_164)"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M12.33 57.27C4.91 70.31 0.230003 85.34 3.42075e-06 102.1C-0.309997 125.55 10.95 127.69 15.24 119.05C17.08 115.34 17.23 111.72 18.07 108.01C21.07 94.78 32.41 88.96 44.52 95.73C51.58 99.68 60.14 107.45 70.76 119.68C85.96 137.04 120.21 111.24 87.34 84.89C80.21 77.95 75.73 72.19 73.29 67.48C71.12 63.74 69.3 59.91 67.84 56.07C49.53 47.8 29.18 48.79 12.32 57.27H12.33ZM32.38 146.36C22.86 141.46 19.11 129.77 24.01 120.25C28.91 110.73 40.6 106.98 50.12 111.88C59.64 116.78 63.39 128.47 58.49 138C53.59 147.52 41.9 151.27 32.38 146.37V146.36Z"
+                              fill="url(#paint4_linear_932_164)"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M33.56 92.92C36.98 92.72 40.71 93.6 44.52 95.73C51.58 99.68 60.14 107.45 70.76 119.68C85.96 137.04 120.21 111.24 87.34 84.89C80.21 77.95 75.73 72.19 73.29 67.48C58.41 41.74 59.61 12.14 83.24 2.52002C45.97 14.7 27.49 58.38 33.56 92.92Z"
+                              fill="url(#paint5_linear_932_164)"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M71.58 63.32C62.91 36.93 135.34 32.43 119.94 8.02001C114.55 -0.519989 100.21 -2.02999 83.24 2.52001C59.61 12.14 58.41 41.74 73.29 67.48C72.89 66.71 72.55 65.97 72.26 65.26C71.99 64.59 71.76 63.95 71.58 63.33V63.32Z"
+                              fill="url(#paint6_linear_932_164)"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M71.58 63.32C70.02 58.56 71.1 54.52 73.82 50.94C65.27 32.26 66.88 12.87 83.24 2.52002C59.61 12.14 58.41 41.74 73.29 67.48C72.89 66.71 72.55 65.97 72.26 65.26C71.99 64.59 71.76 63.95 71.58 63.33V63.32Z"
+                              fill="url(#paint7_linear_932_164)"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M23.09 126.5C22.01 134.03 25.71 141.75 32.86 145.43C41.87 150.07 52.93 146.52 57.57 137.51C61.81 129.26 59.2 119.3 51.82 114.11C53.09 117.97 52.87 122.32 50.87 126.21C46.9 133.92 37.43 136.96 29.72 132.99C26.8 131.48 24.54 129.19 23.09 126.5Z"
+                              fill="url(#paint8_linear_932_164)"
+                              fill-rule="evenodd"
+                            />
+                          </g>
+                          <defs>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint0_linear_932_164"
+                              x1="97.08"
+                              x2="198.22"
+                              y1="76.52"
+                              y2="76.52"
+                            >
+                              <stop
+                                stop-color="#1C2A39"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#7C8A99"
+                              />
+                            </lineargradient>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint1_linear_932_164"
+                              x1="97.08"
+                              x2="165.79"
+                              y1="112.04"
+                              y2="112.04"
+                            >
+                              <stop
+                                stop-color="#1C2A39"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#7C8A99"
+                              />
+                            </lineargradient>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint2_linear_932_164"
+                              x1="138.61"
+                              x2="175.31"
+                              y1="45.1601"
+                              y2="45.1601"
+                            >
+                              <stop
+                                stop-color="#1C2A39"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#7C8A99"
+                              />
+                            </lineargradient>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint3_linear_932_164"
+                              x1="-21.8556"
+                              x2="51.1173"
+                              y1="117.802"
+                              y2="16.8919"
+                            >
+                              <stop
+                                stop-color="#1C2A39"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#BCCAD9"
+                              />
+                            </lineargradient>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint4_linear_932_164"
+                              x1="3.41999e-06"
+                              x2="101.14"
+                              y1="99.43"
+                              y2="99.43"
+                            >
+                              <stop
+                                stop-color="#7C8A99"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#FEFEFE"
+                              />
+                            </lineargradient>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint5_linear_932_164"
+                              x1="32.42"
+                              x2="1.00001"
+                              y1="63.92"
+                              y2="63.92"
+                            >
+                              <stop
+                                stop-color="#7C8A99"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#FEFEFE"
+                              />
+                            </lineargradient>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint6_linear_932_164"
+                              x1="34.9389"
+                              x2="87.84"
+                              y1="8.56541"
+                              y2="-25.5456"
+                            >
+                              <stop
+                                stop-color="#1C2A39"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#BCCAD9"
+                              />
+                            </lineargradient>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint7_linear_932_164"
+                              x1="63.53"
+                              x2="83.25"
+                              y1="34.99"
+                              y2="34.99"
+                            >
+                              <stop
+                                stop-color="#7C8A99"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#FEFEFE"
+                              />
+                            </lineargradient>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint8_linear_932_164"
+                              x1="22.9"
+                              x2="59.61"
+                              y1="130.79"
+                              y2="130.79"
+                            >
+                              <stop
+                                stop-color="#7C8A99"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#FEFEFE"
+                              />
+                            </lineargradient>
+                            <clippath
+                              id="clip0_932_164"
+                            >
+                              <rect
+                                fill="white"
+                                height="175.95"
+                                width="198.22"
+                              />
+                            </clippath>
+                          </defs>
+                        </svg>
+                      </i>
+                    </div>
+                     $t('menu.cockpit')
+                  </a>
+                  
                 </div>
+              </button>
+            </div>
+            <div
+              class="v-col d-none d-md-flex align-center"
+              data-v-e787b5f9=""
+            >
+              <div
+                class="v-row"
+                data-v-e787b5f9=""
+              >
                 <div
-                  class="v-field__prepend-inner"
+                  class="v-col d-flex align-center"
+                  data-v-e787b5f9=""
                 >
-                  <i
-                    aria-hidden="true"
-                    class="mdi-tune mdi v-icon notranslate v-theme--light v-icon--size-default"
-                  />
-                  <!---->
-                </div>
-                <div
-                  class="v-field__field"
-                  data-no-activator=""
-                >
-                  <label
-                    aria-hidden="true"
-                    class="v-label v-field-label v-field-label--floating"
-                    for="input-7"
+                  <button
+                    class="d-flex align-center justify-center light-dark-switch d-none d-lg-flex"
+                    data-v-e787b5f9=""
                   >
-                    <!---->
-                    
-                    $t('tablesDrawer.searchPlaceholder')
-                    
-                  </label>
-                  <label
-                    class="v-label v-field-label"
-                    for="input-7"
-                  >
-                    <!---->
-                    
-                    $t('tablesDrawer.searchPlaceholder')
-                    
-                  </label>
-                  
-                  
-                  <!---->
-                  <input
-                    aria-describedby="input-7-messages"
-                    class="v-field__input"
-                    id="input-7"
-                    size="1"
-                    type="text"
-                  />
-                  <!---->
-                  
-                  
-                </div>
-                <transition-stub
-                  appear="false"
-                  css="true"
-                  name="expand-x-transition"
-                  persisted="false"
-                >
-                  <div
-                    class="v-field__clearable"
-                    style="display: none;"
-                  >
-                    
-                    <i
-                      aria-hidden="false"
-                      aria-label="Löschen"
-                      class="mdi-close-circle mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable"
-                      role="button"
-                      tabindex="0"
-                    />
-                    
-                  </div>
-                </transition-stub>
-                <div
-                  class="v-field__append-inner"
-                >
-                  <!---->
-                  <!---->
+                    <svg
+                      fill="none"
+                      height="15"
+                      viewBox="0 0 28 15"
+                      width="28"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M7.63636 15C5.51515 15 3.71212 14.2708 2.22727 12.8125C0.742424 11.3542 0 9.58333 0 7.5C0 5.41667 0.742424 3.64583 2.22727 2.1875C3.71212 0.729167 5.51515 0 7.63636 0H20.3636C22.4848 0 24.2879 0.729167 25.7727 2.1875C27.2576 3.64583 28 5.41667 28 7.5C28 9.58333 27.2576 11.3542 25.7727 12.8125C24.2879 14.2708 22.4848 15 20.3636 15H7.63636ZM7.63636 12.5H20.3636C21.7636 12.5 22.9621 12.0104 23.9591 11.0312C24.9561 10.0521 25.4545 8.875 25.4545 7.5C25.4545 6.125 24.9561 4.94792 23.9591 3.96875C22.9621 2.98958 21.7636 2.5 20.3636 2.5H7.63636C6.23636 2.5 5.03788 2.98958 4.04091 3.96875C3.04394 4.94792 2.54545 6.125 2.54545 7.5C2.54545 8.875 3.04394 10.0521 4.04091 11.0312C5.03788 12.0104 6.23636 12.5 7.63636 12.5ZM7.63636 11.25C8.69697 11.25 9.59848 10.8854 10.3409 10.1562C11.0833 9.42708 11.4545 8.54167 11.4545 7.5C11.4545 6.45833 11.0833 5.57292 10.3409 4.84375C9.59848 4.11458 8.69697 3.75 7.63636 3.75C6.57576 3.75 5.67424 4.11458 4.93182 4.84375C4.18939 5.57292 3.81818 6.45833 3.81818 7.5C3.81818 8.54167 4.18939 9.42708 4.93182 10.1562C5.67424 10.8854 6.57576 11.25 7.63636 11.25Z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                    <svg
+                      fill="none"
+                      height="15"
+                      style="display: none;"
+                      viewBox="0 0 28 15"
+                      width="28"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M7.63636 15C5.51515 15 3.71212 14.2708 2.22727 12.8125C0.742424 11.3542 0 9.58333 0 7.5C0 5.41667 0.742424 3.64583 2.22727 2.1875C3.71212 0.729167 5.51515 0 7.63636 0H20.3636C22.4848 0 24.2879 0.729167 25.7727 2.1875C27.2576 3.64583 28 5.41667 28 7.5C28 9.58333 27.2576 11.3542 25.7727 12.8125C24.2879 14.2708 22.4848 15 20.3636 15H7.63636ZM7.63636 12.5H20.3636C21.7636 12.5 22.9621 12.0104 23.9591 11.0312C24.9561 10.0521 25.4545 8.875 25.4545 7.5C25.4545 6.125 24.9561 4.94792 23.9591 3.96875C22.9621 2.98958 21.7636 2.5 20.3636 2.5H7.63636C6.23636 2.5 5.03788 2.98958 4.04091 3.96875C3.04394 4.94792 2.54545 6.125 2.54545 7.5C2.54545 8.875 3.04394 10.0521 4.04091 11.0312C5.03788 12.0104 6.23636 12.5 7.63636 12.5ZM20.3636 11.25C21.4242 11.25 22.3258 10.8854 23.0682 10.1562C23.8106 9.42708 24.1818 8.54167 24.1818 7.5C24.1818 6.45833 23.8106 5.57292 23.0682 4.84375C22.3258 4.11458 21.4242 3.75 20.3636 3.75C19.303 3.75 18.4015 4.11458 17.6591 4.84375C16.9167 5.57292 16.5455 6.45833 16.5455 7.5C16.5455 8.54167 16.9167 9.42708 17.6591 10.1562C18.4015 10.8854 19.303 11.25 20.3636 11.25Z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                    <span
+                      class="ml-2"
+                    >
+                      $t('menu.theme.light') / $t('menu.theme.dark')
+                    </span>
+                  </button>
                 </div>
                 <div
-                  class="v-field__outline"
+                  class="v-col d-flex align-center justify-end"
+                  data-v-e787b5f9=""
                 >
+                  <button
+                    data-v-e787b5f9=""
+                  >
+                    <div
+                      class="circle rounded-circle border-sm text-icon pa-2 d-flex justify-center align-center"
+                      data-v-39e8094e=""
+                      data-v-e787b5f9=""
+                    >
+                      
+                      <i
+                        aria-hidden="true"
+                        class="v-icon notranslate v-theme--light v-icon--size-default"
+                        data-v-e787b5f9=""
+                      >
+                        <svg
+                          fill="none"
+                          height="17"
+                          viewBox="0 0 21 17"
+                          width="21"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M7.68844 12.4824H9.66834V9.51172H12.6382V7.53125H9.66834V4.56055H7.68844V7.53125H4.71859V9.51172H7.68844V12.4824ZM2.73869 16.4434C2.19422 16.4434 1.72812 16.2494 1.34038 15.8616C0.952654 15.4738 0.758789 15.0075 0.758789 14.4629V2.58008C0.758789 2.03545 0.952654 1.56921 1.34038 1.18137C1.72812 0.79353 2.19422 0.599609 2.73869 0.599609H14.6181C15.1626 0.599609 15.6287 0.79353 16.0164 1.18137C16.4041 1.56921 16.598 2.03545 16.598 2.58008V7.03613L20.5578 3.0752V13.9678L16.598 10.0068V14.4629C16.598 15.0075 16.4041 15.4738 16.0164 15.8616C15.6287 16.2494 15.1626 16.4434 14.6181 16.4434H2.73869ZM2.73869 14.4629H14.6181V2.58008H2.73869V14.4629Z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                      </i>
+                      
+                    </div>
+                  </button>
+                  
+                  
+                  <button
+                    aria-expanded="false"
+                    aria-haspopup="menu"
+                    aria-owns="v-menu-1"
+                    class="ml-2 user-info rounded-pill d-flex flex-row text-icon border-sm align-center justify-center"
+                    data-v-607bdd70=""
+                    targetref="[object Object]"
+                  >
+                    <div
+                      class="v-avatar v-theme--light v-avatar--density-default v-avatar--variant-flat avatar d-flex align-center text-font border-sm bg-primary"
+                      data-v-607bdd70=""
+                      style="width: 44px; height: 44px;"
+                    >
+                      
+                      
+                      <span
+                        data-v-607bdd70=""
+                      />
+                      
+                      
+                      
+                      <!---->
+                      <span
+                        class="v-avatar__underlay"
+                      />
+                      
+                    </div>
+                    <div
+                      class="d-flex flex-column justify-center text-right pa-1 pl-3 w-100"
+                      data-v-607bdd70=""
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="v-icon notranslate v-theme--light v-icon--size-default ellipsis-icon"
+                        data-test="user-dropdown"
+                        data-v-607bdd70=""
+                      >
+                        <svg
+                          fill="none"
+                          height="4"
+                          viewBox="0 0 18 4"
+                          width="18"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M2 0C3.10457 0 4 0.895431 4 2C4 3.10457 3.10457 4 2 4C0.895431 4 0 3.10457 0 2C0 0.895431 0.895431 0 2 0ZM9 0C10.1046 0 11 0.895431 11 2C11 3.10457 10.1046 4 9 4C7.89543 4 7 3.10457 7 2C7 0.895431 7.89543 0 9 0ZM18 2C18 0.895431 17.1046 0 16 0C14.8954 0 14 0.895431 14 2C14 3.10457 14.8954 4 16 4C17.1046 4 18 3.10457 18 2Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </i>
+                    </div>
+                  </button>
+                  
                   <!---->
-                  <!---->
+                  
                 </div>
               </div>
-              
             </div>
-            <!---->
-            <div
-              class="v-input__details"
-            >
-              <transition-group-stub
-                appear="false"
-                aria-live="polite"
-                class="v-messages"
-                css="true"
-                id="input-7-messages"
-                name="slide-y-transition"
-                persisted="false"
-                role="alert"
-                tag="div"
-              >
-                <!---->
-              </transition-group-stub>
-              <!---->
-            </div>
-          </div>
-          <div
-            class="v-list v-theme--light bg-transparent v-list--density-default v-list--one-line"
-            data-v-cf2c9067=""
-            role="listbox"
-            tabindex="0"
-          >
-            
-            <h2
-              class="header mb-4"
-              data-v-cf2c9067=""
-            >
-              $t('tablesDrawer.header')
-            </h2>
-            <div
-              data-v-cf2c9067=""
-            >
-              $t('tablesDrawer.noTables')
-            </div>
-            
           </div>
           
+          <!---->
         </div>
-        <!---->
-      </nav>
-      <transition-stub
-        appear="false"
-        css="true"
-        name="fade-transition"
-        persisted="false"
-      >
-        <!---->
-      </transition-stub>
-      
-      
-      <div
-        class="v-container v-container--fluid v-locale--is-ltr page-container px-8"
-        data-v-75d0be1e=""
-      >
-        <div
-          class="v-row"
-          data-v-75d0be1e=""
+        
+        
+        <transition-stub
+          appear="false"
+          css="true"
+          name="expand-transition"
+          persisted="false"
         >
-          <!--v-if-->
-          <div
-            class="v-col pa-0 pa-sm-1 pt-0"
-            data-v-75d0be1e=""
-          >
-            
-            
-          </div>
-        </div>
-      </div>
-      
+          <!---->
+        </transition-stub>
+        
+      </header>
       
       <nav
-        class="v-navigation-drawer v-navigation-drawer--bottom v-navigation-drawer--temporary v-theme--light v-navigation-drawer--mobile menu-drawer px-4 d-md-none"
+        class="v-navigation-drawer v-navigation-drawer--right v-navigation-drawer--temporary v-theme--light v-navigation-drawer--mobile menu-drawer px-4 hide-on-mobile"
         data-v-cf2c9067=""
-        style="bottom: 0px; z-index: 1004; transform: translateY(110%); position: fixed; transition: none !important; left: 0px; width: calc(100% - 0px - 0px);"
+        style="right: 0px; z-index: 1006; transform: translateX(110%); position: fixed; transition: none !important; height: calc(100% - 70px - 0px); top: 70px; bottom: 0px;"
       >
         <!---->
         <!---->
@@ -1131,6 +906,226 @@ exports[`DefaultLayout > renders 1`] = `
                 class="v-messages"
                 css="true"
                 id="input-3-messages"
+                name="slide-y-transition"
+                persisted="false"
+                role="alert"
+                tag="div"
+              >
+                <!---->
+              </transition-group-stub>
+              <!---->
+            </div>
+          </div>
+          <div
+            class="v-list v-theme--light bg-transparent v-list--density-default v-list--one-line"
+            data-v-cf2c9067=""
+            role="listbox"
+            tabindex="0"
+          >
+            
+            <h2
+              class="header mb-4"
+              data-v-cf2c9067=""
+            >
+              $t('tablesDrawer.header')
+            </h2>
+            <div
+              data-v-cf2c9067=""
+            >
+              $t('tablesDrawer.noTables')
+            </div>
+            
+          </div>
+          
+        </div>
+        <!---->
+      </nav>
+      <transition-stub
+        appear="false"
+        css="true"
+        name="fade-transition"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      
+      
+      <div
+        class="v-container v-container--fluid v-locale--is-ltr page-container px-8"
+        data-v-75d0be1e=""
+      >
+        <div
+          class="v-row"
+          data-v-75d0be1e=""
+        >
+          <!--v-if-->
+          <div
+            class="v-col pa-0 pa-sm-1 pt-0"
+            data-v-75d0be1e=""
+          >
+            
+            
+          </div>
+        </div>
+      </div>
+      
+      
+      <nav
+        class="v-navigation-drawer v-navigation-drawer--bottom v-navigation-drawer--temporary v-theme--light v-navigation-drawer--mobile menu-drawer px-4 d-md-none"
+        data-v-cf2c9067=""
+        style="bottom: 0px; z-index: 1004; transform: translateY(110%); position: fixed; transition: none !important; left: 0px; width: calc(100% - 0px - 0px);"
+      >
+        <!---->
+        <!---->
+        <div
+          class="v-navigation-drawer__content"
+        >
+          
+          <div
+            class="v-input v-input--horizontal v-input--center-affix v-input--density-compact v-theme--light v-locale--is-ltr v-text-field search"
+            data-v-cf2c9067=""
+          >
+            <!---->
+            <div
+              class="v-input__control"
+            >
+              
+              <div
+                class="v-field v-field--appended v-field--center-affix v-field--flat v-field--prepended v-field--variant-solo v-theme--light v-field--rounded v-locale--is-ltr"
+              >
+                <div
+                  class="v-field__overlay"
+                />
+                <div
+                  class="v-field__loader"
+                >
+                  <div
+                    aria-hidden="true"
+                    aria-valuemax="100"
+                    aria-valuemin="0"
+                    class="v-progress-linear v-theme--light v-locale--is-ltr"
+                    role="progressbar"
+                    style="top: 0px; height: 0px; --v-progress-linear-height: 2px;"
+                  >
+                    <!---->
+                    <div
+                      class="v-progress-linear__background"
+                      style="width: 100%;"
+                    />
+                    <transition-stub
+                      appear="false"
+                      css="true"
+                      name="fade-transition"
+                      persisted="false"
+                    >
+                      <div
+                        class="v-progress-linear__indeterminate"
+                      >
+                        
+                        <div
+                          class="v-progress-linear__indeterminate long"
+                        />
+                        <div
+                          class="v-progress-linear__indeterminate short"
+                        />
+                        
+                      </div>
+                    </transition-stub>
+                    <!---->
+                  </div>
+                </div>
+                <div
+                  class="v-field__prepend-inner"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="mdi-tune mdi v-icon notranslate v-theme--light v-icon--size-default"
+                  />
+                  <!---->
+                </div>
+                <div
+                  class="v-field__field"
+                  data-no-activator=""
+                >
+                  <label
+                    aria-hidden="true"
+                    class="v-label v-field-label v-field-label--floating"
+                    for="input-6"
+                  >
+                    <!---->
+                    
+                    $t('tablesDrawer.searchPlaceholder')
+                    
+                  </label>
+                  <label
+                    class="v-label v-field-label"
+                    for="input-6"
+                  >
+                    <!---->
+                    
+                    $t('tablesDrawer.searchPlaceholder')
+                    
+                  </label>
+                  
+                  
+                  <!---->
+                  <input
+                    aria-describedby="input-6-messages"
+                    class="v-field__input"
+                    id="input-6"
+                    size="1"
+                    type="text"
+                  />
+                  <!---->
+                  
+                  
+                </div>
+                <transition-stub
+                  appear="false"
+                  css="true"
+                  name="expand-x-transition"
+                  persisted="false"
+                >
+                  <div
+                    class="v-field__clearable"
+                    style="display: none;"
+                  >
+                    
+                    <i
+                      aria-hidden="false"
+                      aria-label="Löschen"
+                      class="mdi-close-circle mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable"
+                      role="button"
+                      tabindex="0"
+                    />
+                    
+                  </div>
+                </transition-stub>
+                <div
+                  class="v-field__append-inner"
+                >
+                  <!---->
+                  <!---->
+                </div>
+                <div
+                  class="v-field__outline"
+                >
+                  <!---->
+                  <!---->
+                </div>
+              </div>
+              
+            </div>
+            <!---->
+            <div
+              class="v-input__details"
+            >
+              <transition-group-stub
+                appear="false"
+                aria-live="polite"
+                class="v-messages"
+                css="true"
+                id="input-6-messages"
                 name="slide-y-transition"
                 persisted="false"
                 role="alert"
@@ -1709,7 +1704,7 @@ exports[`DefaultLayout > renders 1`] = `
         <button
           aria-expanded="false"
           aria-haspopup="menu"
-          aria-owns="v-menu-5"
+          aria-owns="v-menu-8"
           class="user-info rounded-pill d-flex flex-row text-icon border-sm align-center justify-center"
           data-v-607bdd70=""
           targetref="[object Object]"

--- a/frontend/src/layouts/__snapshots__/DefaultLayout.test.ts.snap
+++ b/frontend/src/layouts/__snapshots__/DefaultLayout.test.ts.snap
@@ -756,7 +756,7 @@ exports[`DefaultLayout > renders 1`] = `
       </div>
       
       <nav
-        class="v-navigation-drawer v-navigation-drawer--right v-navigation-drawer--temporary v-theme--light v-navigation-drawer--mobile menu-drawer"
+        class="v-navigation-drawer v-navigation-drawer--right v-navigation-drawer--temporary v-theme--light v-navigation-drawer--mobile menu-drawer px-4"
         data-v-cf2c9067=""
         style="right: 0px; z-index: 1006; transform: translateX(110%); position: fixed; transition: none !important; height: calc(100% - 70px - 0px); top: 70px; bottom: 0px;"
       >
@@ -767,7 +767,7 @@ exports[`DefaultLayout > renders 1`] = `
         >
           
           <div
-            class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-text-field mx-4 mt-4 search"
+            class="v-input v-input--horizontal v-input--center-affix v-input--density-compact v-theme--light v-locale--is-ltr v-text-field search"
             data-v-cf2c9067=""
           >
             <!---->
@@ -776,7 +776,7 @@ exports[`DefaultLayout > renders 1`] = `
             >
               
               <div
-                class="v-field v-field--appended v-field--center-affix v-field--prepended v-field--variant-solo v-theme--light v-field--rounded v-locale--is-ltr"
+                class="v-field v-field--appended v-field--center-affix v-field--flat v-field--prepended v-field--variant-solo v-theme--light v-field--rounded v-locale--is-ltr"
               >
                 <div
                   class="v-field__overlay"
@@ -929,78 +929,15 @@ exports[`DefaultLayout > renders 1`] = `
           >
             
             <h2
-              class="mx-4"
+              class="header mb-4"
               data-v-cf2c9067=""
             >
               $t('tablesDrawer.header')
             </h2>
             <div
-              class="v-card v-theme--light v-card--density-default v-card--variant-elevated mx-auto"
               data-v-cf2c9067=""
-              data-v-de37061b=""
-              style="width: 400px;"
             >
-              <!---->
-              <div
-                class="v-card__loader"
-              >
-                <div
-                  aria-hidden="true"
-                  aria-valuemax="100"
-                  aria-valuemin="0"
-                  class="v-progress-linear v-theme--light v-locale--is-ltr"
-                  role="progressbar"
-                  style="top: 0px; height: 0px; --v-progress-linear-height: 2px;"
-                >
-                  <!---->
-                  <div
-                    class="v-progress-linear__background"
-                    style="width: 100%;"
-                  />
-                  <transition-stub
-                    appear="false"
-                    css="true"
-                    name="fade-transition"
-                    persisted="false"
-                  >
-                    <div
-                      class="v-progress-linear__indeterminate"
-                    >
-                      
-                      <div
-                        class="v-progress-linear__indeterminate long"
-                      />
-                      <div
-                        class="v-progress-linear__indeterminate short"
-                      />
-                      
-                    </div>
-                  </transition-stub>
-                  <!---->
-                </div>
-              </div>
-              <!---->
-              <!---->
-              
-              <div
-                class="v-list v-theme--light bg-transparent v-list--density-default v-list--two-line"
-                data-v-de37061b=""
-                role="listbox"
-                tabindex="0"
-              >
-                
-                
-                
-                
-              </div>
-              
-              <!---->
-              
-              <!---->
-              <span
-                class="v-card__underlay"
-              />
-              
+              $t('tablesDrawer.noTables')
             </div>
             
           </div>
@@ -1037,199 +974,35 @@ exports[`DefaultLayout > renders 1`] = `
         </div>
       </div>
       
-      <div
-        class="navigation-drawer-box d-md-none position-fixed mb-5 pb-5"
-        data-v-96a196cc=""
+      
+      <nav
+        class="v-navigation-drawer v-navigation-drawer--bottom v-navigation-drawer--temporary v-theme--light v-navigation-drawer--mobile menu-drawer px-4 d-md-none"
+        data-v-cf2c9067=""
+        style="bottom: 0px; z-index: 1004; transform: translateY(110%); position: fixed; transition: none !important; left: 0px; width: calc(100% - 0px - 0px);"
       >
-        
-        <nav
-          class="v-navigation-drawer v-navigation-drawer--bottom v-navigation-drawer--temporary v-theme--light v-navigation-drawer--mobile menu-drawer"
-          data-v-cf2c9067=""
-          style="bottom: 0px; z-index: 1004; transform: translateY(110%); position: fixed; transition: none !important; left: 0px; width: calc(100% - 0px - 0px);"
+        <!---->
+        <!---->
+        <div
+          class="v-navigation-drawer__content"
         >
-          <!---->
-          <!---->
+          
           <div
-            class="v-navigation-drawer__content"
+            class="v-input v-input--horizontal v-input--center-affix v-input--density-compact v-theme--light v-locale--is-ltr v-text-field search"
+            data-v-cf2c9067=""
           >
-            
+            <!---->
             <div
-              class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-text-field mx-4 mt-4 search"
-              data-v-cf2c9067=""
-            >
-              <!---->
-              <div
-                class="v-input__control"
-              >
-                
-                <div
-                  class="v-field v-field--appended v-field--center-affix v-field--prepended v-field--variant-solo v-theme--light v-field--rounded v-locale--is-ltr"
-                >
-                  <div
-                    class="v-field__overlay"
-                  />
-                  <div
-                    class="v-field__loader"
-                  >
-                    <div
-                      aria-hidden="true"
-                      aria-valuemax="100"
-                      aria-valuemin="0"
-                      class="v-progress-linear v-theme--light v-locale--is-ltr"
-                      role="progressbar"
-                      style="top: 0px; height: 0px; --v-progress-linear-height: 2px;"
-                    >
-                      <!---->
-                      <div
-                        class="v-progress-linear__background"
-                        style="width: 100%;"
-                      />
-                      <transition-stub
-                        appear="false"
-                        css="true"
-                        name="fade-transition"
-                        persisted="false"
-                      >
-                        <div
-                          class="v-progress-linear__indeterminate"
-                        >
-                          
-                          <div
-                            class="v-progress-linear__indeterminate long"
-                          />
-                          <div
-                            class="v-progress-linear__indeterminate short"
-                          />
-                          
-                        </div>
-                      </transition-stub>
-                      <!---->
-                    </div>
-                  </div>
-                  <div
-                    class="v-field__prepend-inner"
-                  >
-                    <i
-                      aria-hidden="true"
-                      class="mdi-tune mdi v-icon notranslate v-theme--light v-icon--size-default"
-                    />
-                    <!---->
-                  </div>
-                  <div
-                    class="v-field__field"
-                    data-no-activator=""
-                  >
-                    <label
-                      aria-hidden="true"
-                      class="v-label v-field-label v-field-label--floating"
-                      for="input-6"
-                    >
-                      <!---->
-                      
-                      $t('tablesDrawer.searchPlaceholder')
-                      
-                    </label>
-                    <label
-                      class="v-label v-field-label"
-                      for="input-6"
-                    >
-                      <!---->
-                      
-                      $t('tablesDrawer.searchPlaceholder')
-                      
-                    </label>
-                    
-                    
-                    <!---->
-                    <input
-                      aria-describedby="input-6-messages"
-                      class="v-field__input"
-                      id="input-6"
-                      size="1"
-                      type="text"
-                    />
-                    <!---->
-                    
-                    
-                  </div>
-                  <transition-stub
-                    appear="false"
-                    css="true"
-                    name="expand-x-transition"
-                    persisted="false"
-                  >
-                    <div
-                      class="v-field__clearable"
-                      style="display: none;"
-                    >
-                      
-                      <i
-                        aria-hidden="false"
-                        aria-label="$vuetify.input.clear"
-                        class="mdi-close-circle mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable"
-                        role="button"
-                        tabindex="0"
-                      />
-                      
-                    </div>
-                  </transition-stub>
-                  <div
-                    class="v-field__append-inner"
-                  >
-                    <!---->
-                    <!---->
-                  </div>
-                  <div
-                    class="v-field__outline"
-                  >
-                    <!---->
-                    <!---->
-                  </div>
-                </div>
-                
-              </div>
-              <!---->
-              <div
-                class="v-input__details"
-              >
-                <transition-group-stub
-                  appear="false"
-                  aria-live="polite"
-                  class="v-messages"
-                  css="true"
-                  id="input-6-messages"
-                  name="slide-y-transition"
-                  persisted="false"
-                  role="alert"
-                  tag="div"
-                >
-                  <!---->
-                </transition-group-stub>
-                <!---->
-              </div>
-            </div>
-            <div
-              class="v-list v-theme--light bg-transparent v-list--density-default v-list--one-line"
-              data-v-cf2c9067=""
-              role="listbox"
-              tabindex="0"
+              class="v-input__control"
             >
               
-              <h2
-                class="mx-4"
-                data-v-cf2c9067=""
-              >
-                $t('tablesDrawer.header')
-              </h2>
               <div
-                class="v-card v-theme--light v-card--density-default v-card--variant-elevated mx-auto"
-                data-v-cf2c9067=""
-                data-v-de37061b=""
-                style="width: 400px;"
+                class="v-field v-field--appended v-field--center-affix v-field--flat v-field--prepended v-field--variant-solo v-theme--light v-field--rounded v-locale--is-ltr"
               >
-                <!---->
                 <div
-                  class="v-card__loader"
+                  class="v-field__overlay"
+                />
+                <div
+                  class="v-field__loader"
                 >
                   <div
                     aria-hidden="true"
@@ -1266,45 +1039,141 @@ exports[`DefaultLayout > renders 1`] = `
                     <!---->
                   </div>
                 </div>
-                <!---->
-                <!---->
-                
                 <div
-                  class="v-list v-theme--light bg-transparent v-list--density-default v-list--two-line"
-                  data-v-de37061b=""
-                  role="listbox"
-                  tabindex="0"
+                  class="v-field__prepend-inner"
                 >
+                  <i
+                    aria-hidden="true"
+                    class="mdi-tune mdi v-icon notranslate v-theme--light v-icon--size-default"
+                  />
+                  <!---->
+                </div>
+                <div
+                  class="v-field__field"
+                  data-no-activator=""
+                >
+                  <label
+                    aria-hidden="true"
+                    class="v-label v-field-label v-field-label--floating"
+                    for="input-6"
+                  >
+                    <!---->
+                    
+                    $t('tablesDrawer.searchPlaceholder')
+                    
+                  </label>
+                  <label
+                    class="v-label v-field-label"
+                    for="input-6"
+                  >
+                    <!---->
+                    
+                    $t('tablesDrawer.searchPlaceholder')
+                    
+                  </label>
                   
                   
+                  <!---->
+                  <input
+                    aria-describedby="input-6-messages"
+                    class="v-field__input"
+                    id="input-6"
+                    size="1"
+                    type="text"
+                  />
+                  <!---->
                   
                   
                 </div>
-                
-                <!---->
-                
-                <!---->
-                <span
-                  class="v-card__underlay"
-                />
-                
+                <transition-stub
+                  appear="false"
+                  css="true"
+                  name="expand-x-transition"
+                  persisted="false"
+                >
+                  <div
+                    class="v-field__clearable"
+                    style="display: none;"
+                  >
+                    
+                    <i
+                      aria-hidden="false"
+                      aria-label="$vuetify.input.clear"
+                      class="mdi-close-circle mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable"
+                      role="button"
+                      tabindex="0"
+                    />
+                    
+                  </div>
+                </transition-stub>
+                <div
+                  class="v-field__append-inner"
+                >
+                  <!---->
+                  <!---->
+                </div>
+                <div
+                  class="v-field__outline"
+                >
+                  <!---->
+                  <!---->
+                </div>
               </div>
               
             </div>
+            <!---->
+            <div
+              class="v-input__details"
+            >
+              <transition-group-stub
+                appear="false"
+                aria-live="polite"
+                class="v-messages"
+                css="true"
+                id="input-6-messages"
+                name="slide-y-transition"
+                persisted="false"
+                role="alert"
+                tag="div"
+              >
+                <!---->
+              </transition-group-stub>
+              <!---->
+            </div>
+          </div>
+          <div
+            class="v-list v-theme--light bg-transparent v-list--density-default v-list--one-line"
+            data-v-cf2c9067=""
+            role="listbox"
+            tabindex="0"
+          >
+            
+            <h2
+              class="header mb-4"
+              data-v-cf2c9067=""
+            >
+              $t('tablesDrawer.header')
+            </h2>
+            <div
+              data-v-cf2c9067=""
+            >
+              $t('tablesDrawer.noTables')
+            </div>
             
           </div>
-          <!---->
-        </nav>
-        <transition-stub
-          appear="false"
-          css="true"
-          name="fade-transition"
-          persisted="false"
-        >
-          <!---->
-        </transition-stub>
-        
-      </div>
+          
+        </div>
+        <!---->
+      </nav>
+      <transition-stub
+        appear="false"
+        css="true"
+        name="fade-transition"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      
       <div
         class="bottom-menu d-flex w-100 position-fixed bottom-0 justify-space-around align-center py-2 bg-surface d-md-none"
         data-v-96a196cc=""

--- a/frontend/src/layouts/__snapshots__/DefaultLayout.test.ts.snap
+++ b/frontend/src/layouts/__snapshots__/DefaultLayout.test.ts.snap
@@ -758,7 +758,7 @@ exports[`DefaultLayout > renders 1`] = `
       <nav
         class="v-navigation-drawer v-navigation-drawer--right v-navigation-drawer--temporary v-theme--light v-navigation-drawer--mobile menu-drawer px-4"
         data-v-cf2c9067=""
-        style="right: 0px; z-index: 1006; transform: translateX(110%); position: fixed; transition: none !important; height: calc(100% - 70px - 0px); top: 70px; bottom: 0px;"
+        style="right: 0px; z-index: 1006; transform: translateX(110%); position: fixed; height: calc(100% - 70px - 0px); top: 70px; bottom: 0px; transition: none !important;"
       >
         <!---->
         <!---->
@@ -835,7 +835,7 @@ exports[`DefaultLayout > renders 1`] = `
                   <label
                     aria-hidden="true"
                     class="v-label v-field-label v-field-label--floating"
-                    for="input-3"
+                    for="input-7"
                   >
                     <!---->
                     
@@ -844,7 +844,7 @@ exports[`DefaultLayout > renders 1`] = `
                   </label>
                   <label
                     class="v-label v-field-label"
-                    for="input-3"
+                    for="input-7"
                   >
                     <!---->
                     
@@ -855,9 +855,9 @@ exports[`DefaultLayout > renders 1`] = `
                   
                   <!---->
                   <input
-                    aria-describedby="input-3-messages"
+                    aria-describedby="input-7-messages"
                     class="v-field__input"
-                    id="input-3"
+                    id="input-7"
                     size="1"
                     type="text"
                   />
@@ -878,7 +878,7 @@ exports[`DefaultLayout > renders 1`] = `
                     
                     <i
                       aria-hidden="false"
-                      aria-label="$vuetify.input.clear"
+                      aria-label="Löschen"
                       class="mdi-close-circle mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable"
                       role="button"
                       tabindex="0"
@@ -910,7 +910,7 @@ exports[`DefaultLayout > renders 1`] = `
                 aria-live="polite"
                 class="v-messages"
                 css="true"
-                id="input-3-messages"
+                id="input-7-messages"
                 name="slide-y-transition"
                 persisted="false"
                 role="alert"
@@ -1055,7 +1055,7 @@ exports[`DefaultLayout > renders 1`] = `
                   <label
                     aria-hidden="true"
                     class="v-label v-field-label v-field-label--floating"
-                    for="input-6"
+                    for="input-3"
                   >
                     <!---->
                     
@@ -1064,7 +1064,7 @@ exports[`DefaultLayout > renders 1`] = `
                   </label>
                   <label
                     class="v-label v-field-label"
-                    for="input-6"
+                    for="input-3"
                   >
                     <!---->
                     
@@ -1075,9 +1075,9 @@ exports[`DefaultLayout > renders 1`] = `
                   
                   <!---->
                   <input
-                    aria-describedby="input-6-messages"
+                    aria-describedby="input-3-messages"
                     class="v-field__input"
-                    id="input-6"
+                    id="input-3"
                     size="1"
                     type="text"
                   />
@@ -1098,7 +1098,7 @@ exports[`DefaultLayout > renders 1`] = `
                     
                     <i
                       aria-hidden="false"
-                      aria-label="$vuetify.input.clear"
+                      aria-label="Löschen"
                       class="mdi-close-circle mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable"
                       role="button"
                       tabindex="0"
@@ -1130,7 +1130,7 @@ exports[`DefaultLayout > renders 1`] = `
                 aria-live="polite"
                 class="v-messages"
                 css="true"
-                id="input-6-messages"
+                id="input-3-messages"
                 name="slide-y-transition"
                 persisted="false"
                 role="alert"
@@ -1709,7 +1709,7 @@ exports[`DefaultLayout > renders 1`] = `
         <button
           aria-expanded="false"
           aria-haspopup="menu"
-          aria-owns="v-menu-8"
+          aria-owns="v-menu-5"
           class="user-info rounded-pill d-flex flex-row text-icon border-sm align-center justify-center"
           data-v-607bdd70=""
           targetref="[object Object]"

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -1,6 +1,6 @@
 {
   "$vuetify": {
-    "input:": {
+    "input": {
       "clear": "Löschen"
     }
   },

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -53,8 +53,8 @@
   },
   "tablesDrawer": {
     "header": "Offene Tische",
-    "searchPlaceholder": "Offene Tische, Teilnehmer",
     "noResults": "Keine Ergebnisse gefunden",
-    "noTables": "Keine Tische verfügbar"
+    "noTables": "Keine Tische verfügbar",
+    "searchPlaceholder": "Offene Tische, Teilnehmer"
   }
 }

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -53,6 +53,8 @@
   },
   "tablesDrawer": {
     "header": "Offene Tische",
-    "searchPlaceholder": "Offene Tische, Teilnehmer"
+    "searchPlaceholder": "Offene Tische, Teilnehmer",
+    "noResults": "Keine Ergebnisse gefunden",
+    "noTables": "Keine Tische verfügbar"
   }
 }

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -53,8 +53,8 @@
   },
   "tablesDrawer": {
     "header": "Open Tables",
-    "searchPlaceholder": "Open tables, attendees",
     "noResults": "No results found",
-    "noTables": "No tables available"
+    "noTables": "No tables available",
+    "searchPlaceholder": "Open tables, attendees"
   }
 }

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1,6 +1,6 @@
 {
   "$vuetify": {
-    "input:": {
+    "input": {
       "clear": "Clear"
     }
   },

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -53,6 +53,8 @@
   },
   "tablesDrawer": {
     "header": "Open Tables",
-    "searchPlaceholder": "Open tables, attendees"
+    "searchPlaceholder": "Open tables, attendees",
+    "noResults": "No results found",
+    "noTables": "No tables available"
   }
 }

--- a/frontend/src/pages/index/__snapshots__/Page.test.ts.snap
+++ b/frontend/src/pages/index/__snapshots__/Page.test.ts.snap
@@ -756,7 +756,7 @@ exports[`IndexPage > without apollo error > renders 1`] = `
       </div>
       
       <nav
-        class="v-navigation-drawer v-navigation-drawer--right v-navigation-drawer--temporary v-theme--light v-navigation-drawer--mobile menu-drawer"
+        class="v-navigation-drawer v-navigation-drawer--right v-navigation-drawer--temporary v-theme--light v-navigation-drawer--mobile menu-drawer px-4"
         data-v-cf2c9067=""
         style="right: 0px; z-index: 1006; transform: translateX(110%); position: fixed; transition: none !important; height: calc(100% - 70px - 0px); top: 70px; bottom: 0px;"
       >
@@ -767,7 +767,7 @@ exports[`IndexPage > without apollo error > renders 1`] = `
         >
           
           <div
-            class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-text-field mx-4 mt-4 search"
+            class="v-input v-input--horizontal v-input--center-affix v-input--density-compact v-theme--light v-locale--is-ltr v-text-field search"
             data-v-cf2c9067=""
           >
             <!---->
@@ -776,7 +776,7 @@ exports[`IndexPage > without apollo error > renders 1`] = `
             >
               
               <div
-                class="v-field v-field--appended v-field--center-affix v-field--prepended v-field--variant-solo v-theme--light v-field--rounded v-locale--is-ltr"
+                class="v-field v-field--appended v-field--center-affix v-field--flat v-field--prepended v-field--variant-solo v-theme--light v-field--rounded v-locale--is-ltr"
               >
                 <div
                   class="v-field__overlay"
@@ -929,78 +929,15 @@ exports[`IndexPage > without apollo error > renders 1`] = `
           >
             
             <h2
-              class="mx-4"
+              class="header mb-4"
               data-v-cf2c9067=""
             >
               $t('tablesDrawer.header')
             </h2>
             <div
-              class="v-card v-theme--light v-card--density-default v-card--variant-elevated mx-auto"
               data-v-cf2c9067=""
-              data-v-de37061b=""
-              style="width: 400px;"
             >
-              <!---->
-              <div
-                class="v-card__loader"
-              >
-                <div
-                  aria-hidden="true"
-                  aria-valuemax="100"
-                  aria-valuemin="0"
-                  class="v-progress-linear v-theme--light v-locale--is-ltr"
-                  role="progressbar"
-                  style="top: 0px; height: 0px; --v-progress-linear-height: 2px;"
-                >
-                  <!---->
-                  <div
-                    class="v-progress-linear__background"
-                    style="width: 100%;"
-                  />
-                  <transition-stub
-                    appear="false"
-                    css="true"
-                    name="fade-transition"
-                    persisted="false"
-                  >
-                    <div
-                      class="v-progress-linear__indeterminate"
-                    >
-                      
-                      <div
-                        class="v-progress-linear__indeterminate long"
-                      />
-                      <div
-                        class="v-progress-linear__indeterminate short"
-                      />
-                      
-                    </div>
-                  </transition-stub>
-                  <!---->
-                </div>
-              </div>
-              <!---->
-              <!---->
-              
-              <div
-                class="v-list v-theme--light bg-transparent v-list--density-default v-list--two-line"
-                data-v-de37061b=""
-                role="listbox"
-                tabindex="0"
-              >
-                
-                
-                
-                
-              </div>
-              
-              <!---->
-              
-              <!---->
-              <span
-                class="v-card__underlay"
-              />
-              
+              $t('tablesDrawer.noTables')
             </div>
             
           </div>
@@ -1668,199 +1605,35 @@ exports[`IndexPage > without apollo error > renders 1`] = `
         </div>
       </div>
       
-      <div
-        class="navigation-drawer-box d-md-none position-fixed mb-5 pb-5"
-        data-v-96a196cc=""
+      
+      <nav
+        class="v-navigation-drawer v-navigation-drawer--bottom v-navigation-drawer--temporary v-theme--light v-navigation-drawer--mobile menu-drawer px-4 d-md-none"
+        data-v-cf2c9067=""
+        style="bottom: 0px; z-index: 1004; transform: translateY(110%); position: fixed; transition: none !important; left: 0px; width: calc(100% - 0px - 0px);"
       >
-        
-        <nav
-          class="v-navigation-drawer v-navigation-drawer--bottom v-navigation-drawer--temporary v-theme--light v-navigation-drawer--mobile menu-drawer"
-          data-v-cf2c9067=""
-          style="bottom: 0px; z-index: 1004; transform: translateY(110%); position: fixed; transition: none !important; left: 0px; width: calc(100% - 0px - 0px);"
+        <!---->
+        <!---->
+        <div
+          class="v-navigation-drawer__content"
         >
-          <!---->
-          <!---->
+          
           <div
-            class="v-navigation-drawer__content"
+            class="v-input v-input--horizontal v-input--center-affix v-input--density-compact v-theme--light v-locale--is-ltr v-text-field search"
+            data-v-cf2c9067=""
           >
-            
+            <!---->
             <div
-              class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-text-field mx-4 mt-4 search"
-              data-v-cf2c9067=""
-            >
-              <!---->
-              <div
-                class="v-input__control"
-              >
-                
-                <div
-                  class="v-field v-field--appended v-field--center-affix v-field--prepended v-field--variant-solo v-theme--light v-field--rounded v-locale--is-ltr"
-                >
-                  <div
-                    class="v-field__overlay"
-                  />
-                  <div
-                    class="v-field__loader"
-                  >
-                    <div
-                      aria-hidden="true"
-                      aria-valuemax="100"
-                      aria-valuemin="0"
-                      class="v-progress-linear v-theme--light v-locale--is-ltr"
-                      role="progressbar"
-                      style="top: 0px; height: 0px; --v-progress-linear-height: 2px;"
-                    >
-                      <!---->
-                      <div
-                        class="v-progress-linear__background"
-                        style="width: 100%;"
-                      />
-                      <transition-stub
-                        appear="false"
-                        css="true"
-                        name="fade-transition"
-                        persisted="false"
-                      >
-                        <div
-                          class="v-progress-linear__indeterminate"
-                        >
-                          
-                          <div
-                            class="v-progress-linear__indeterminate long"
-                          />
-                          <div
-                            class="v-progress-linear__indeterminate short"
-                          />
-                          
-                        </div>
-                      </transition-stub>
-                      <!---->
-                    </div>
-                  </div>
-                  <div
-                    class="v-field__prepend-inner"
-                  >
-                    <i
-                      aria-hidden="true"
-                      class="mdi-tune mdi v-icon notranslate v-theme--light v-icon--size-default"
-                    />
-                    <!---->
-                  </div>
-                  <div
-                    class="v-field__field"
-                    data-no-activator=""
-                  >
-                    <label
-                      aria-hidden="true"
-                      class="v-label v-field-label v-field-label--floating"
-                      for="input-6"
-                    >
-                      <!---->
-                      
-                      $t('tablesDrawer.searchPlaceholder')
-                      
-                    </label>
-                    <label
-                      class="v-label v-field-label"
-                      for="input-6"
-                    >
-                      <!---->
-                      
-                      $t('tablesDrawer.searchPlaceholder')
-                      
-                    </label>
-                    
-                    
-                    <!---->
-                    <input
-                      aria-describedby="input-6-messages"
-                      class="v-field__input"
-                      id="input-6"
-                      size="1"
-                      type="text"
-                    />
-                    <!---->
-                    
-                    
-                  </div>
-                  <transition-stub
-                    appear="false"
-                    css="true"
-                    name="expand-x-transition"
-                    persisted="false"
-                  >
-                    <div
-                      class="v-field__clearable"
-                      style="display: none;"
-                    >
-                      
-                      <i
-                        aria-hidden="false"
-                        aria-label="$vuetify.input.clear"
-                        class="mdi-close-circle mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable"
-                        role="button"
-                        tabindex="0"
-                      />
-                      
-                    </div>
-                  </transition-stub>
-                  <div
-                    class="v-field__append-inner"
-                  >
-                    <!---->
-                    <!---->
-                  </div>
-                  <div
-                    class="v-field__outline"
-                  >
-                    <!---->
-                    <!---->
-                  </div>
-                </div>
-                
-              </div>
-              <!---->
-              <div
-                class="v-input__details"
-              >
-                <transition-group-stub
-                  appear="false"
-                  aria-live="polite"
-                  class="v-messages"
-                  css="true"
-                  id="input-6-messages"
-                  name="slide-y-transition"
-                  persisted="false"
-                  role="alert"
-                  tag="div"
-                >
-                  <!---->
-                </transition-group-stub>
-                <!---->
-              </div>
-            </div>
-            <div
-              class="v-list v-theme--light bg-transparent v-list--density-default v-list--one-line"
-              data-v-cf2c9067=""
-              role="listbox"
-              tabindex="0"
+              class="v-input__control"
             >
               
-              <h2
-                class="mx-4"
-                data-v-cf2c9067=""
-              >
-                $t('tablesDrawer.header')
-              </h2>
               <div
-                class="v-card v-theme--light v-card--density-default v-card--variant-elevated mx-auto"
-                data-v-cf2c9067=""
-                data-v-de37061b=""
-                style="width: 400px;"
+                class="v-field v-field--appended v-field--center-affix v-field--flat v-field--prepended v-field--variant-solo v-theme--light v-field--rounded v-locale--is-ltr"
               >
-                <!---->
                 <div
-                  class="v-card__loader"
+                  class="v-field__overlay"
+                />
+                <div
+                  class="v-field__loader"
                 >
                   <div
                     aria-hidden="true"
@@ -1897,45 +1670,141 @@ exports[`IndexPage > without apollo error > renders 1`] = `
                     <!---->
                   </div>
                 </div>
-                <!---->
-                <!---->
-                
                 <div
-                  class="v-list v-theme--light bg-transparent v-list--density-default v-list--two-line"
-                  data-v-de37061b=""
-                  role="listbox"
-                  tabindex="0"
+                  class="v-field__prepend-inner"
                 >
+                  <i
+                    aria-hidden="true"
+                    class="mdi-tune mdi v-icon notranslate v-theme--light v-icon--size-default"
+                  />
+                  <!---->
+                </div>
+                <div
+                  class="v-field__field"
+                  data-no-activator=""
+                >
+                  <label
+                    aria-hidden="true"
+                    class="v-label v-field-label v-field-label--floating"
+                    for="input-6"
+                  >
+                    <!---->
+                    
+                    $t('tablesDrawer.searchPlaceholder')
+                    
+                  </label>
+                  <label
+                    class="v-label v-field-label"
+                    for="input-6"
+                  >
+                    <!---->
+                    
+                    $t('tablesDrawer.searchPlaceholder')
+                    
+                  </label>
                   
                   
+                  <!---->
+                  <input
+                    aria-describedby="input-6-messages"
+                    class="v-field__input"
+                    id="input-6"
+                    size="1"
+                    type="text"
+                  />
+                  <!---->
                   
                   
                 </div>
-                
-                <!---->
-                
-                <!---->
-                <span
-                  class="v-card__underlay"
-                />
-                
+                <transition-stub
+                  appear="false"
+                  css="true"
+                  name="expand-x-transition"
+                  persisted="false"
+                >
+                  <div
+                    class="v-field__clearable"
+                    style="display: none;"
+                  >
+                    
+                    <i
+                      aria-hidden="false"
+                      aria-label="$vuetify.input.clear"
+                      class="mdi-close-circle mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable"
+                      role="button"
+                      tabindex="0"
+                    />
+                    
+                  </div>
+                </transition-stub>
+                <div
+                  class="v-field__append-inner"
+                >
+                  <!---->
+                  <!---->
+                </div>
+                <div
+                  class="v-field__outline"
+                >
+                  <!---->
+                  <!---->
+                </div>
               </div>
               
             </div>
+            <!---->
+            <div
+              class="v-input__details"
+            >
+              <transition-group-stub
+                appear="false"
+                aria-live="polite"
+                class="v-messages"
+                css="true"
+                id="input-6-messages"
+                name="slide-y-transition"
+                persisted="false"
+                role="alert"
+                tag="div"
+              >
+                <!---->
+              </transition-group-stub>
+              <!---->
+            </div>
+          </div>
+          <div
+            class="v-list v-theme--light bg-transparent v-list--density-default v-list--one-line"
+            data-v-cf2c9067=""
+            role="listbox"
+            tabindex="0"
+          >
+            
+            <h2
+              class="header mb-4"
+              data-v-cf2c9067=""
+            >
+              $t('tablesDrawer.header')
+            </h2>
+            <div
+              data-v-cf2c9067=""
+            >
+              $t('tablesDrawer.noTables')
+            </div>
             
           </div>
-          <!---->
-        </nav>
-        <transition-stub
-          appear="false"
-          css="true"
-          name="fade-transition"
-          persisted="false"
-        >
-          <!---->
-        </transition-stub>
-        
-      </div>
+          
+        </div>
+        <!---->
+      </nav>
+      <transition-stub
+        appear="false"
+        css="true"
+        name="fade-transition"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      
       <div
         class="bottom-menu d-flex w-100 position-fixed bottom-0 justify-space-around align-center py-2 bg-surface d-md-none"
         data-v-96a196cc=""

--- a/frontend/src/pages/index/__snapshots__/Page.test.ts.snap
+++ b/frontend/src/pages/index/__snapshots__/Page.test.ts.snap
@@ -15,748 +15,743 @@ exports[`IndexPage > without apollo error > renders 1`] = `
     >
       
       
-      <div
-        class="top-menu mt-6 mt-sm-0"
+      <header
+        class="v-toolbar v-toolbar--flat v-toolbar--density-default v-theme--light v-locale--is-ltr v-app-bar app-bar"
         data-v-e787b5f9=""
+        style="top: 0px; z-index: 1008; transform: translateY(0%); position: fixed; transition: none !important; left: 0px; width: calc(100% - 0px - 0px);"
       >
-        <header
-          class="v-toolbar v-toolbar--flat v-toolbar--density-default v-theme--light v-locale--is-ltr v-app-bar app-bar"
-          data-v-e787b5f9=""
-          style="top: 0px; z-index: 1008; transform: translateY(0%); position: fixed; transition: none !important; left: 0px; width: calc(100% - 0px - 0px);"
+        <!---->
+        
+        <div
+          class="v-toolbar__content"
+          style="height: 70px;"
         >
+          <!---->
           <!---->
           
           <div
-            class="v-toolbar__content"
-            style="height: 70px;"
+            class="v-row ma-1"
+            data-v-e787b5f9=""
           >
-            <!---->
-            <!---->
-            
             <div
-              class="v-row ma-1"
+              class="v-col d-none d-md-flex align-center"
               data-v-e787b5f9=""
             >
-              <div
-                class="v-col d-none d-md-flex align-center"
+              <a
+                class="logo"
                 data-v-e787b5f9=""
+                href="/"
               >
-                <a
-                  class="logo"
+                <div
+                  class="v-responsive v-img v-img--booting w-100 logo-small"
                   data-v-e787b5f9=""
-                  href="/"
+                  data-v-f6be2607=""
                 >
                   <div
-                    class="v-responsive v-img v-img--booting w-100 logo-small"
-                    data-v-e787b5f9=""
-                    data-v-f6be2607=""
-                  >
-                    <div
-                      class="v-responsive__sizer"
-                    />
-                    
-                    
-                    <transition-stub
-                      appear="true"
-                      css="true"
-                      name="fade-transition"
-                      persisted="false"
-                    >
-                      <img
-                        class="v-img__img v-img__img--contain"
-                        src="/src/assets/dreammall-logo.svg"
-                        style="display: none;"
-                      />
-                    </transition-stub>
-                    <transition-stub
-                      appear="false"
-                      css="true"
-                      name="fade-transition"
-                      persisted="false"
-                    >
-                      <!---->
-                    </transition-stub>
-                    <!---->
-                    <!---->
-                    <!---->
-                    
-                    
-                    <!---->
-                  </div>
-                </a>
-              </div>
-              <div
-                class="v-col d-flex align-center justify-center"
-                data-v-e787b5f9=""
-              >
-                <button
-                  class="tab-control ma-auto border-sm text-font open"
-                  data-v-d58c92bb=""
-                  data-v-e787b5f9=""
-                >
-                  <div
-                    class="marker"
-                    data-v-d58c92bb=""
-                    style="display: none; width: 0px; left: 0px;"
+                    class="v-responsive__sizer"
                   />
-                  <div
-                    class="d-flex align-center justify-center h-100 w-100"
-                    data-v-d58c92bb=""
+                  
+                  
+                  <transition-stub
+                    appear="true"
+                    css="true"
+                    name="fade-transition"
+                    persisted="false"
                   >
-                    
-                    <a
-                      class="item active"
-                      data-v-d58c92bb=""
-                    >
-                      <div
-                        class="icon d-flex justify-center align-center"
-                        data-v-d58c92bb=""
-                      >
-                        <i
-                          aria-hidden="true"
-                          class="v-icon notranslate v-theme--light v-icon--size-default w-100 world-cafe"
-                          data-v-d58c92bb=""
-                        >
-                          <svg
-                            fill="none"
-                            height="193"
-                            viewBox="0 0 138 193"
-                            width="138"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <g
-                              clip-path="url(#clip0_932_149)"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M29.6 136.89C7.05 118.08 -2.7 92.78 0.64 66.02C3.97 39.35 29.88 -0.749964 56.89 0.0100358C106.62 20.82 -15.77 78.98 29.6 136.89Z"
-                                fill="url(#paint0_linear_932_149)"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M29.6 136.89C24.66 132.77 20.33 128.33 16.62 123.64C3.99 107.66 -1.48 88.69 0.339998 68.8C1.06 88.98 14.09 89.62 20.99 79.13V79.15C41.21 43.56 86.69 15.42 56.89 0.0100098C106.63 20.82 -15.77 78.98 29.6 136.89Z"
-                                fill="#2D0100"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M29.61 136.9C-15.79 78.98 106.67 20.8 56.87 0C60.92 0.11 64.99 1.14 69.02 3.27C77.12 7.55 81.67 16.94 81.29 28.86C80.18 64.11 50.09 75.76 39.88 103.39C36.49 112.58 36.08 121.65 38.65 130.61C39.38 133.13 38.47 135.74 36.36 137.21C34.25 138.68 31.58 138.56 29.6 136.91L29.61 136.9Z"
-                                fill="url(#paint1_linear_932_149)"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M29.61 136.9C-15.79 78.99 106.63 20.82 56.89 0.0100098C70.63 1.37001 77.6 14.24 75.77 26.29C70.7 59.76 29 71.47 28.59 110.64C28.49 119.81 31.09 128.67 36.37 137.21C34.26 138.68 31.59 138.56 29.61 136.91V136.9Z"
-                                fill="url(#paint2_linear_932_149)"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M108.38 12.96C130.93 31.77 140.68 57.06 137.34 83.82C134.01 110.49 108.1 150.59 81.09 149.83C31.36 129.02 153.75 70.86 108.38 12.96Z"
-                                fill="url(#paint3_linear_932_149)"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M108.38 12.96C113.32 17.08 117.65 21.52 121.36 26.21C133.99 42.18 139.46 61.15 137.64 81.04C136.92 60.86 123.89 60.22 116.99 70.71V70.69C96.77 106.28 51.29 134.43 81.09 149.83C31.36 129.02 153.75 70.86 108.38 12.96Z"
-                                fill="#2D0100"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M108.37 12.95C153.77 70.86 31.31 129.04 81.11 149.84C77.06 149.73 72.99 148.7 68.96 146.57C60.86 142.29 56.31 132.9 56.69 120.98C57.8 85.73 87.89 74.08 98.1 46.45C101.49 37.26 101.9 28.19 99.33 19.23C98.6 16.71 99.51 14.1 101.62 12.63C103.73 11.16 106.4 11.28 108.38 12.93L108.37 12.95Z"
-                                fill="url(#paint4_linear_932_149)"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M108.37 12.95C153.76 70.85 31.35 129.03 81.09 149.84C67.35 148.48 60.38 135.61 62.21 123.56C67.28 90.09 108.98 78.38 109.39 39.21C109.49 30.04 106.89 21.18 101.61 12.64C103.72 11.17 106.39 11.29 108.37 12.94V12.95Z"
-                                fill="url(#paint5_linear_932_149)"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M46.08 182.97C46.04 188.09 50.16 192.27 55.29 192.31C59.9 192.34 63.48 188.95 64.5 184.6C66.82 174.7 62.43 164.87 49.88 158.79C57.01 170.18 46.15 173.4 46.09 182.96L46.08 182.97Z"
-                                fill="url(#paint6_linear_932_149)"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M48.07 182.99C48.04 187.01 51.28 190.3 55.3 190.33C56.87 190.34 58.28 189.85 59.44 189C56.57 187.88 54.11 185.72 52.66 182.73C51.21 179.74 51.03 176.26 52.02 173.24C50.26 176.33 48.1 179.16 48.07 182.98V182.99Z"
-                                fill="url(#paint7_linear_932_149)"
-                                fill-rule="evenodd"
-                                opacity="0.5"
-                              />
-                            </g>
-                            <defs>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint0_linear_932_149"
-                                x1="-16.8153"
-                                x2="61.3369"
-                                y1="116.566"
-                                y2="-41.9949"
-                              >
-                                <stop
-                                  stop-color="#1C2A39"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#7C8A99"
-                                />
-                              </lineargradient>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint1_linear_932_149"
-                                x1="11.8868"
-                                x2="75.9494"
-                                y1="87.02"
-                                y2="-30.1607"
-                              >
-                                <stop
-                                  stop-color="#7C8A99"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#FEFEFE"
-                                />
-                              </lineargradient>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint2_linear_932_149"
-                                x1="19.31"
-                                x2="76.06"
-                                y1="69.12"
-                                y2="69.12"
-                              >
-                                <stop
-                                  stop-color="#1C2A39"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#BCCAD9"
-                                />
-                              </lineargradient>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint3_linear_932_149"
-                                x1="160.483"
-                                x2="82.3302"
-                                y1="32.9545"
-                                y2="191.516"
-                              >
-                                <stop
-                                  stop-color="#1C2A39"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#7C8A99"
-                                />
-                              </lineargradient>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint4_linear_932_149"
-                                x1="131.78"
-                                x2="67.7184"
-                                y1="62.5008"
-                                y2="179.682"
-                              >
-                                <stop
-                                  stop-color="#7C8A99"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#FEFEFE"
-                                />
-                              </lineargradient>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint5_linear_932_149"
-                                x1="118.66"
-                                x2="61.92"
-                                y1="80.73"
-                                y2="80.73"
-                              >
-                                <stop
-                                  stop-color="#1C2A39"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#BCCAD9"
-                                />
-                              </lineargradient>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint6_linear_932_149"
-                                x1="66.33"
-                                x2="38.1302"
-                                y1="185.538"
-                                y2="166.541"
-                              >
-                                <stop
-                                  stop-color="#1C2A39"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#BCCAD9"
-                                />
-                              </lineargradient>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint7_linear_932_149"
-                                x1="48.07"
-                                x2="59.43"
-                                y1="181.79"
-                                y2="181.79"
-                              >
-                                <stop
-                                  stop-color="#1C2A39"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#BCCAD9"
-                                />
-                              </lineargradient>
-                              <clippath
-                                id="clip0_932_149"
-                              >
-                                <rect
-                                  fill="white"
-                                  height="192.32"
-                                  width="137.98"
-                                />
-                              </clippath>
-                            </defs>
-                          </svg>
-                        </i>
-                      </div>
-                       $t('menu.worldCafe')
-                    </a>
-                    <a
-                      class="item"
-                      data-v-d58c92bb=""
-                    >
-                      <div
-                        class="icon d-flex justify-center align-center"
-                        data-v-d58c92bb=""
-                      >
-                        <i
-                          aria-hidden="true"
-                          class="v-icon notranslate v-theme--light v-icon--size-default w-100 cockpit"
-                          data-v-d58c92bb=""
-                        >
-                          <svg
-                            fill="none"
-                            height="176"
-                            viewBox="0 0 199 176"
-                            width="199"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <g
-                              clip-path="url(#clip0_932_164)"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M114.97 173.44C150.48 163.92 197.5 127.82 198.21 73.86C198.52 50.4 187.26 48.27 182.97 56.91C181.13 60.62 180.98 64.24 180.14 67.95C177.14 81.18 165.8 87 153.69 80.23C146.63 76.28 138.07 68.51 127.45 56.28C112.25 38.92 78 64.72 110.87 91.07C118 98.01 122.48 103.77 124.92 108.48C139.8 134.22 138.6 163.82 114.97 173.44ZM165.84 29.6C175.36 34.5 179.11 46.19 174.21 55.71C169.31 65.23 157.62 68.98 148.1 64.08C138.58 59.18 134.83 47.49 139.73 37.97C144.63 28.45 156.32 24.7 165.84 29.6Z"
-                                fill="#3D4753"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M185.89 118.69C193.31 105.64 197.99 90.61 198.21 73.86C198.52 50.4 187.26 48.27 182.97 56.91C181.13 60.62 180.98 64.24 180.14 67.95C177.14 81.18 165.8 87 153.69 80.23C146.63 76.28 138.07 68.51 127.45 56.28C112.25 38.92 78 64.72 110.87 91.07C118 98.01 122.48 103.77 124.92 108.48C127.09 112.22 128.91 116.05 130.37 119.89C148.68 128.16 169.03 127.17 185.89 118.69ZM165.84 29.6C175.36 34.5 179.11 46.19 174.21 55.71C169.31 65.23 157.62 68.98 148.1 64.08C138.58 59.18 134.83 47.49 139.73 37.97C144.63 28.45 156.32 24.7 165.84 29.6Z"
-                                fill="url(#paint0_linear_932_164)"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M164.66 83.03C161.24 83.23 157.51 82.35 153.7 80.22C146.64 76.27 138.08 68.5 127.46 56.27C112.26 38.91 78.01 64.71 110.88 91.06C118.01 98 122.49 103.76 124.93 108.47C139.81 134.21 138.61 163.81 114.98 173.43C152.26 161.24 170.74 117.56 164.67 83.03H164.66Z"
-                                fill="url(#paint1_linear_932_164)"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M126.63 112.63C135.3 139.02 62.87 143.52 78.27 167.93C83.66 176.47 98 177.98 114.97 173.43C138.6 163.81 139.8 134.21 124.92 108.47C125.32 109.24 125.66 109.98 125.95 110.69C126.22 111.36 126.45 112 126.63 112.62V112.63Z"
-                                fill="#3D4753"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M126.63 112.63C128.19 117.39 127.11 121.43 124.39 125.01C132.94 143.69 131.33 163.08 114.97 173.43C138.6 163.81 139.8 134.21 124.92 108.47C125.32 109.24 125.66 109.98 125.95 110.69C126.22 111.36 126.45 112 126.63 112.62V112.63Z"
-                                fill="#0E215E"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M175.13 49.4501C176.21 41.9201 172.51 34.2001 165.36 30.5201C156.35 25.8801 145.29 29.4301 140.65 38.4401C136.41 46.6901 139.02 56.6501 146.4 61.8401C145.13 57.9801 145.35 53.6301 147.35 49.7401C151.32 42.0301 160.79 38.9901 168.5 42.9601C171.42 44.4701 173.68 46.7601 175.13 49.4501Z"
-                                fill="url(#paint2_linear_932_164)"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M83.25 2.51001C47.74 12.04 0.710003 48.13 3.42075e-06 102.1C-0.309997 125.55 10.95 127.69 15.24 119.05C17.08 115.34 17.23 111.72 18.07 108.01C21.07 94.78 32.41 88.96 44.52 95.73C51.58 99.68 60.14 107.45 70.76 119.68C85.96 137.04 120.21 111.24 87.34 84.89C80.21 77.95 75.73 72.19 73.29 67.48C58.41 41.74 59.61 12.14 83.24 2.52001L83.25 2.51001ZM32.38 146.35C22.86 141.45 19.11 129.76 24.01 120.24C28.91 110.72 40.6 106.97 50.12 111.87C59.64 116.77 63.39 128.46 58.49 137.99C53.59 147.51 41.9 151.26 32.38 146.36V146.35Z"
-                                fill="url(#paint3_linear_932_164)"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M12.33 57.27C4.91 70.31 0.230003 85.34 3.42075e-06 102.1C-0.309997 125.55 10.95 127.69 15.24 119.05C17.08 115.34 17.23 111.72 18.07 108.01C21.07 94.78 32.41 88.96 44.52 95.73C51.58 99.68 60.14 107.45 70.76 119.68C85.96 137.04 120.21 111.24 87.34 84.89C80.21 77.95 75.73 72.19 73.29 67.48C71.12 63.74 69.3 59.91 67.84 56.07C49.53 47.8 29.18 48.79 12.32 57.27H12.33ZM32.38 146.36C22.86 141.46 19.11 129.77 24.01 120.25C28.91 110.73 40.6 106.98 50.12 111.88C59.64 116.78 63.39 128.47 58.49 138C53.59 147.52 41.9 151.27 32.38 146.37V146.36Z"
-                                fill="url(#paint4_linear_932_164)"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M33.56 92.92C36.98 92.72 40.71 93.6 44.52 95.73C51.58 99.68 60.14 107.45 70.76 119.68C85.96 137.04 120.21 111.24 87.34 84.89C80.21 77.95 75.73 72.19 73.29 67.48C58.41 41.74 59.61 12.14 83.24 2.52002C45.97 14.7 27.49 58.38 33.56 92.92Z"
-                                fill="url(#paint5_linear_932_164)"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M71.58 63.32C62.91 36.93 135.34 32.43 119.94 8.02001C114.55 -0.519989 100.21 -2.02999 83.24 2.52001C59.61 12.14 58.41 41.74 73.29 67.48C72.89 66.71 72.55 65.97 72.26 65.26C71.99 64.59 71.76 63.95 71.58 63.33V63.32Z"
-                                fill="url(#paint6_linear_932_164)"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M71.58 63.32C70.02 58.56 71.1 54.52 73.82 50.94C65.27 32.26 66.88 12.87 83.24 2.52002C59.61 12.14 58.41 41.74 73.29 67.48C72.89 66.71 72.55 65.97 72.26 65.26C71.99 64.59 71.76 63.95 71.58 63.33V63.32Z"
-                                fill="url(#paint7_linear_932_164)"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M23.09 126.5C22.01 134.03 25.71 141.75 32.86 145.43C41.87 150.07 52.93 146.52 57.57 137.51C61.81 129.26 59.2 119.3 51.82 114.11C53.09 117.97 52.87 122.32 50.87 126.21C46.9 133.92 37.43 136.96 29.72 132.99C26.8 131.48 24.54 129.19 23.09 126.5Z"
-                                fill="url(#paint8_linear_932_164)"
-                                fill-rule="evenodd"
-                              />
-                            </g>
-                            <defs>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint0_linear_932_164"
-                                x1="97.08"
-                                x2="198.22"
-                                y1="76.52"
-                                y2="76.52"
-                              >
-                                <stop
-                                  stop-color="#1C2A39"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#7C8A99"
-                                />
-                              </lineargradient>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint1_linear_932_164"
-                                x1="97.08"
-                                x2="165.79"
-                                y1="112.04"
-                                y2="112.04"
-                              >
-                                <stop
-                                  stop-color="#1C2A39"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#7C8A99"
-                                />
-                              </lineargradient>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint2_linear_932_164"
-                                x1="138.61"
-                                x2="175.31"
-                                y1="45.1601"
-                                y2="45.1601"
-                              >
-                                <stop
-                                  stop-color="#1C2A39"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#7C8A99"
-                                />
-                              </lineargradient>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint3_linear_932_164"
-                                x1="-21.8556"
-                                x2="51.1173"
-                                y1="117.802"
-                                y2="16.8919"
-                              >
-                                <stop
-                                  stop-color="#1C2A39"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#BCCAD9"
-                                />
-                              </lineargradient>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint4_linear_932_164"
-                                x1="3.41999e-06"
-                                x2="101.14"
-                                y1="99.43"
-                                y2="99.43"
-                              >
-                                <stop
-                                  stop-color="#7C8A99"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#FEFEFE"
-                                />
-                              </lineargradient>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint5_linear_932_164"
-                                x1="32.42"
-                                x2="1.00001"
-                                y1="63.92"
-                                y2="63.92"
-                              >
-                                <stop
-                                  stop-color="#7C8A99"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#FEFEFE"
-                                />
-                              </lineargradient>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint6_linear_932_164"
-                                x1="34.9389"
-                                x2="87.84"
-                                y1="8.56541"
-                                y2="-25.5456"
-                              >
-                                <stop
-                                  stop-color="#1C2A39"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#BCCAD9"
-                                />
-                              </lineargradient>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint7_linear_932_164"
-                                x1="63.53"
-                                x2="83.25"
-                                y1="34.99"
-                                y2="34.99"
-                              >
-                                <stop
-                                  stop-color="#7C8A99"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#FEFEFE"
-                                />
-                              </lineargradient>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint8_linear_932_164"
-                                x1="22.9"
-                                x2="59.61"
-                                y1="130.79"
-                                y2="130.79"
-                              >
-                                <stop
-                                  stop-color="#7C8A99"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#FEFEFE"
-                                />
-                              </lineargradient>
-                              <clippath
-                                id="clip0_932_164"
-                              >
-                                <rect
-                                  fill="white"
-                                  height="175.95"
-                                  width="198.22"
-                                />
-                              </clippath>
-                            </defs>
-                          </svg>
-                        </i>
-                      </div>
-                       $t('menu.cockpit')
-                    </a>
-                    
-                  </div>
-                </button>
-              </div>
-              <div
-                class="v-col d-none d-md-flex align-center"
+                    <img
+                      class="v-img__img v-img__img--contain"
+                      src="/src/assets/dreammall-logo.svg"
+                      style="display: none;"
+                    />
+                  </transition-stub>
+                  <transition-stub
+                    appear="false"
+                    css="true"
+                    name="fade-transition"
+                    persisted="false"
+                  >
+                    <!---->
+                  </transition-stub>
+                  <!---->
+                  <!---->
+                  <!---->
+                  
+                  
+                  <!---->
+                </div>
+              </a>
+            </div>
+            <div
+              class="v-col d-flex align-center justify-center"
+              data-v-e787b5f9=""
+            >
+              <button
+                class="tab-control ma-auto border-sm text-font open"
+                data-v-d58c92bb=""
                 data-v-e787b5f9=""
               >
                 <div
-                  class="v-row"
-                  data-v-e787b5f9=""
+                  class="marker"
+                  data-v-d58c92bb=""
+                  style="display: none; width: 0px; left: 0px;"
+                />
+                <div
+                  class="d-flex align-center justify-center h-100 w-100"
+                  data-v-d58c92bb=""
                 >
-                  <div
-                    class="v-col d-flex align-center"
-                    data-v-e787b5f9=""
+                  
+                  <a
+                    class="item active"
+                    data-v-d58c92bb=""
                   >
-                    <button
-                      class="d-flex align-center justify-center light-dark-switch d-none d-lg-flex"
-                      data-v-e787b5f9=""
+                    <div
+                      class="icon d-flex justify-center align-center"
+                      data-v-d58c92bb=""
                     >
-                      <svg
-                        fill="none"
-                        height="15"
-                        viewBox="0 0 28 15"
-                        width="28"
-                        xmlns="http://www.w3.org/2000/svg"
+                      <i
+                        aria-hidden="true"
+                        class="v-icon notranslate v-theme--light v-icon--size-default w-100 world-cafe"
+                        data-v-d58c92bb=""
                       >
-                        <path
-                          d="M7.63636 15C5.51515 15 3.71212 14.2708 2.22727 12.8125C0.742424 11.3542 0 9.58333 0 7.5C0 5.41667 0.742424 3.64583 2.22727 2.1875C3.71212 0.729167 5.51515 0 7.63636 0H20.3636C22.4848 0 24.2879 0.729167 25.7727 2.1875C27.2576 3.64583 28 5.41667 28 7.5C28 9.58333 27.2576 11.3542 25.7727 12.8125C24.2879 14.2708 22.4848 15 20.3636 15H7.63636ZM7.63636 12.5H20.3636C21.7636 12.5 22.9621 12.0104 23.9591 11.0312C24.9561 10.0521 25.4545 8.875 25.4545 7.5C25.4545 6.125 24.9561 4.94792 23.9591 3.96875C22.9621 2.98958 21.7636 2.5 20.3636 2.5H7.63636C6.23636 2.5 5.03788 2.98958 4.04091 3.96875C3.04394 4.94792 2.54545 6.125 2.54545 7.5C2.54545 8.875 3.04394 10.0521 4.04091 11.0312C5.03788 12.0104 6.23636 12.5 7.63636 12.5ZM7.63636 11.25C8.69697 11.25 9.59848 10.8854 10.3409 10.1562C11.0833 9.42708 11.4545 8.54167 11.4545 7.5C11.4545 6.45833 11.0833 5.57292 10.3409 4.84375C9.59848 4.11458 8.69697 3.75 7.63636 3.75C6.57576 3.75 5.67424 4.11458 4.93182 4.84375C4.18939 5.57292 3.81818 6.45833 3.81818 7.5C3.81818 8.54167 4.18939 9.42708 4.93182 10.1562C5.67424 10.8854 6.57576 11.25 7.63636 11.25Z"
-                          fill="currentColor"
-                        />
-                      </svg>
-                      <svg
-                        fill="none"
-                        height="15"
-                        style="display: none;"
-                        viewBox="0 0 28 15"
-                        width="28"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M7.63636 15C5.51515 15 3.71212 14.2708 2.22727 12.8125C0.742424 11.3542 0 9.58333 0 7.5C0 5.41667 0.742424 3.64583 2.22727 2.1875C3.71212 0.729167 5.51515 0 7.63636 0H20.3636C22.4848 0 24.2879 0.729167 25.7727 2.1875C27.2576 3.64583 28 5.41667 28 7.5C28 9.58333 27.2576 11.3542 25.7727 12.8125C24.2879 14.2708 22.4848 15 20.3636 15H7.63636ZM7.63636 12.5H20.3636C21.7636 12.5 22.9621 12.0104 23.9591 11.0312C24.9561 10.0521 25.4545 8.875 25.4545 7.5C25.4545 6.125 24.9561 4.94792 23.9591 3.96875C22.9621 2.98958 21.7636 2.5 20.3636 2.5H7.63636C6.23636 2.5 5.03788 2.98958 4.04091 3.96875C3.04394 4.94792 2.54545 6.125 2.54545 7.5C2.54545 8.875 3.04394 10.0521 4.04091 11.0312C5.03788 12.0104 6.23636 12.5 7.63636 12.5ZM20.3636 11.25C21.4242 11.25 22.3258 10.8854 23.0682 10.1562C23.8106 9.42708 24.1818 8.54167 24.1818 7.5C24.1818 6.45833 23.8106 5.57292 23.0682 4.84375C22.3258 4.11458 21.4242 3.75 20.3636 3.75C19.303 3.75 18.4015 4.11458 17.6591 4.84375C16.9167 5.57292 16.5455 6.45833 16.5455 7.5C16.5455 8.54167 16.9167 9.42708 17.6591 10.1562C18.4015 10.8854 19.303 11.25 20.3636 11.25Z"
-                          fill="currentColor"
-                        />
-                      </svg>
-                      <span
-                        class="ml-2"
-                      >
-                        $t('menu.theme.light') / $t('menu.theme.dark')
-                      </span>
-                    </button>
-                  </div>
-                  <div
-                    class="v-col d-flex align-center justify-end"
-                    data-v-e787b5f9=""
-                  >
-                    <button
-                      data-v-e787b5f9=""
-                    >
-                      <div
-                        class="circle rounded-circle border-sm text-icon pa-2 d-flex justify-center align-center"
-                        data-v-39e8094e=""
-                        data-v-e787b5f9=""
-                      >
-                        
-                        <i
-                          aria-hidden="true"
-                          class="v-icon notranslate v-theme--light v-icon--size-default"
-                          data-v-e787b5f9=""
+                        <svg
+                          fill="none"
+                          height="193"
+                          viewBox="0 0 138 193"
+                          width="138"
+                          xmlns="http://www.w3.org/2000/svg"
                         >
-                          <svg
-                            fill="none"
-                            height="17"
-                            viewBox="0 0 21 17"
-                            width="21"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M7.68844 12.4824H9.66834V9.51172H12.6382V7.53125H9.66834V4.56055H7.68844V7.53125H4.71859V9.51172H7.68844V12.4824ZM2.73869 16.4434C2.19422 16.4434 1.72812 16.2494 1.34038 15.8616C0.952654 15.4738 0.758789 15.0075 0.758789 14.4629V2.58008C0.758789 2.03545 0.952654 1.56921 1.34038 1.18137C1.72812 0.79353 2.19422 0.599609 2.73869 0.599609H14.6181C15.1626 0.599609 15.6287 0.79353 16.0164 1.18137C16.4041 1.56921 16.598 2.03545 16.598 2.58008V7.03613L20.5578 3.0752V13.9678L16.598 10.0068V14.4629C16.598 15.0075 16.4041 15.4738 16.0164 15.8616C15.6287 16.2494 15.1626 16.4434 14.6181 16.4434H2.73869ZM2.73869 14.4629H14.6181V2.58008H2.73869V14.4629Z"
-                              fill="currentColor"
-                            />
-                          </svg>
-                        </i>
-                        
-                      </div>
-                    </button>
-                    
-                    
-                    <button
-                      aria-expanded="false"
-                      aria-haspopup="menu"
-                      aria-owns="v-menu-1"
-                      class="ml-2 user-info rounded-pill d-flex flex-row text-icon border-sm align-center justify-center"
-                      data-v-607bdd70=""
-                      targetref="[object Object]"
-                    >
-                      <div
-                        class="v-avatar v-theme--light v-avatar--density-default v-avatar--variant-flat avatar d-flex align-center text-font border-sm bg-primary"
-                        data-v-607bdd70=""
-                        style="width: 44px; height: 44px;"
-                      >
-                        
-                        
-                        <span
-                          data-v-607bdd70=""
-                        />
-                        
-                        
-                        
-                        <!---->
-                        <span
-                          class="v-avatar__underlay"
-                        />
-                        
-                      </div>
-                      <div
-                        class="d-flex flex-column justify-center text-right pa-1 pl-3 w-100"
-                        data-v-607bdd70=""
-                      >
-                        <i
-                          aria-hidden="true"
-                          class="v-icon notranslate v-theme--light v-icon--size-default ellipsis-icon"
-                          data-test="user-dropdown"
-                          data-v-607bdd70=""
-                        >
-                          <svg
-                            fill="none"
-                            height="4"
-                            viewBox="0 0 18 4"
-                            width="18"
-                            xmlns="http://www.w3.org/2000/svg"
+                          <g
+                            clip-path="url(#clip0_932_149)"
                           >
                             <path
                               clip-rule="evenodd"
-                              d="M2 0C3.10457 0 4 0.895431 4 2C4 3.10457 3.10457 4 2 4C0.895431 4 0 3.10457 0 2C0 0.895431 0.895431 0 2 0ZM9 0C10.1046 0 11 0.895431 11 2C11 3.10457 10.1046 4 9 4C7.89543 4 7 3.10457 7 2C7 0.895431 7.89543 0 9 0ZM18 2C18 0.895431 17.1046 0 16 0C14.8954 0 14 0.895431 14 2C14 3.10457 14.8954 4 16 4C17.1046 4 18 3.10457 18 2Z"
-                              fill="currentColor"
+                              d="M29.6 136.89C7.05 118.08 -2.7 92.78 0.64 66.02C3.97 39.35 29.88 -0.749964 56.89 0.0100358C106.62 20.82 -15.77 78.98 29.6 136.89Z"
+                              fill="url(#paint0_linear_932_149)"
                               fill-rule="evenodd"
                             />
-                          </svg>
-                        </i>
-                      </div>
-                    </button>
-                    
-                    <!---->
-                    
-                  </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M29.6 136.89C24.66 132.77 20.33 128.33 16.62 123.64C3.99 107.66 -1.48 88.69 0.339998 68.8C1.06 88.98 14.09 89.62 20.99 79.13V79.15C41.21 43.56 86.69 15.42 56.89 0.0100098C106.63 20.82 -15.77 78.98 29.6 136.89Z"
+                              fill="#2D0100"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M29.61 136.9C-15.79 78.98 106.67 20.8 56.87 0C60.92 0.11 64.99 1.14 69.02 3.27C77.12 7.55 81.67 16.94 81.29 28.86C80.18 64.11 50.09 75.76 39.88 103.39C36.49 112.58 36.08 121.65 38.65 130.61C39.38 133.13 38.47 135.74 36.36 137.21C34.25 138.68 31.58 138.56 29.6 136.91L29.61 136.9Z"
+                              fill="url(#paint1_linear_932_149)"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M29.61 136.9C-15.79 78.99 106.63 20.82 56.89 0.0100098C70.63 1.37001 77.6 14.24 75.77 26.29C70.7 59.76 29 71.47 28.59 110.64C28.49 119.81 31.09 128.67 36.37 137.21C34.26 138.68 31.59 138.56 29.61 136.91V136.9Z"
+                              fill="url(#paint2_linear_932_149)"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M108.38 12.96C130.93 31.77 140.68 57.06 137.34 83.82C134.01 110.49 108.1 150.59 81.09 149.83C31.36 129.02 153.75 70.86 108.38 12.96Z"
+                              fill="url(#paint3_linear_932_149)"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M108.38 12.96C113.32 17.08 117.65 21.52 121.36 26.21C133.99 42.18 139.46 61.15 137.64 81.04C136.92 60.86 123.89 60.22 116.99 70.71V70.69C96.77 106.28 51.29 134.43 81.09 149.83C31.36 129.02 153.75 70.86 108.38 12.96Z"
+                              fill="#2D0100"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M108.37 12.95C153.77 70.86 31.31 129.04 81.11 149.84C77.06 149.73 72.99 148.7 68.96 146.57C60.86 142.29 56.31 132.9 56.69 120.98C57.8 85.73 87.89 74.08 98.1 46.45C101.49 37.26 101.9 28.19 99.33 19.23C98.6 16.71 99.51 14.1 101.62 12.63C103.73 11.16 106.4 11.28 108.38 12.93L108.37 12.95Z"
+                              fill="url(#paint4_linear_932_149)"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M108.37 12.95C153.76 70.85 31.35 129.03 81.09 149.84C67.35 148.48 60.38 135.61 62.21 123.56C67.28 90.09 108.98 78.38 109.39 39.21C109.49 30.04 106.89 21.18 101.61 12.64C103.72 11.17 106.39 11.29 108.37 12.94V12.95Z"
+                              fill="url(#paint5_linear_932_149)"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M46.08 182.97C46.04 188.09 50.16 192.27 55.29 192.31C59.9 192.34 63.48 188.95 64.5 184.6C66.82 174.7 62.43 164.87 49.88 158.79C57.01 170.18 46.15 173.4 46.09 182.96L46.08 182.97Z"
+                              fill="url(#paint6_linear_932_149)"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M48.07 182.99C48.04 187.01 51.28 190.3 55.3 190.33C56.87 190.34 58.28 189.85 59.44 189C56.57 187.88 54.11 185.72 52.66 182.73C51.21 179.74 51.03 176.26 52.02 173.24C50.26 176.33 48.1 179.16 48.07 182.98V182.99Z"
+                              fill="url(#paint7_linear_932_149)"
+                              fill-rule="evenodd"
+                              opacity="0.5"
+                            />
+                          </g>
+                          <defs>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint0_linear_932_149"
+                              x1="-16.8153"
+                              x2="61.3369"
+                              y1="116.566"
+                              y2="-41.9949"
+                            >
+                              <stop
+                                stop-color="#1C2A39"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#7C8A99"
+                              />
+                            </lineargradient>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint1_linear_932_149"
+                              x1="11.8868"
+                              x2="75.9494"
+                              y1="87.02"
+                              y2="-30.1607"
+                            >
+                              <stop
+                                stop-color="#7C8A99"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#FEFEFE"
+                              />
+                            </lineargradient>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint2_linear_932_149"
+                              x1="19.31"
+                              x2="76.06"
+                              y1="69.12"
+                              y2="69.12"
+                            >
+                              <stop
+                                stop-color="#1C2A39"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#BCCAD9"
+                              />
+                            </lineargradient>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint3_linear_932_149"
+                              x1="160.483"
+                              x2="82.3302"
+                              y1="32.9545"
+                              y2="191.516"
+                            >
+                              <stop
+                                stop-color="#1C2A39"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#7C8A99"
+                              />
+                            </lineargradient>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint4_linear_932_149"
+                              x1="131.78"
+                              x2="67.7184"
+                              y1="62.5008"
+                              y2="179.682"
+                            >
+                              <stop
+                                stop-color="#7C8A99"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#FEFEFE"
+                              />
+                            </lineargradient>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint5_linear_932_149"
+                              x1="118.66"
+                              x2="61.92"
+                              y1="80.73"
+                              y2="80.73"
+                            >
+                              <stop
+                                stop-color="#1C2A39"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#BCCAD9"
+                              />
+                            </lineargradient>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint6_linear_932_149"
+                              x1="66.33"
+                              x2="38.1302"
+                              y1="185.538"
+                              y2="166.541"
+                            >
+                              <stop
+                                stop-color="#1C2A39"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#BCCAD9"
+                              />
+                            </lineargradient>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint7_linear_932_149"
+                              x1="48.07"
+                              x2="59.43"
+                              y1="181.79"
+                              y2="181.79"
+                            >
+                              <stop
+                                stop-color="#1C2A39"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#BCCAD9"
+                              />
+                            </lineargradient>
+                            <clippath
+                              id="clip0_932_149"
+                            >
+                              <rect
+                                fill="white"
+                                height="192.32"
+                                width="137.98"
+                              />
+                            </clippath>
+                          </defs>
+                        </svg>
+                      </i>
+                    </div>
+                     $t('menu.worldCafe')
+                  </a>
+                  <a
+                    class="item"
+                    data-v-d58c92bb=""
+                  >
+                    <div
+                      class="icon d-flex justify-center align-center"
+                      data-v-d58c92bb=""
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="v-icon notranslate v-theme--light v-icon--size-default w-100 cockpit"
+                        data-v-d58c92bb=""
+                      >
+                        <svg
+                          fill="none"
+                          height="176"
+                          viewBox="0 0 199 176"
+                          width="199"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <g
+                            clip-path="url(#clip0_932_164)"
+                          >
+                            <path
+                              clip-rule="evenodd"
+                              d="M114.97 173.44C150.48 163.92 197.5 127.82 198.21 73.86C198.52 50.4 187.26 48.27 182.97 56.91C181.13 60.62 180.98 64.24 180.14 67.95C177.14 81.18 165.8 87 153.69 80.23C146.63 76.28 138.07 68.51 127.45 56.28C112.25 38.92 78 64.72 110.87 91.07C118 98.01 122.48 103.77 124.92 108.48C139.8 134.22 138.6 163.82 114.97 173.44ZM165.84 29.6C175.36 34.5 179.11 46.19 174.21 55.71C169.31 65.23 157.62 68.98 148.1 64.08C138.58 59.18 134.83 47.49 139.73 37.97C144.63 28.45 156.32 24.7 165.84 29.6Z"
+                              fill="#3D4753"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M185.89 118.69C193.31 105.64 197.99 90.61 198.21 73.86C198.52 50.4 187.26 48.27 182.97 56.91C181.13 60.62 180.98 64.24 180.14 67.95C177.14 81.18 165.8 87 153.69 80.23C146.63 76.28 138.07 68.51 127.45 56.28C112.25 38.92 78 64.72 110.87 91.07C118 98.01 122.48 103.77 124.92 108.48C127.09 112.22 128.91 116.05 130.37 119.89C148.68 128.16 169.03 127.17 185.89 118.69ZM165.84 29.6C175.36 34.5 179.11 46.19 174.21 55.71C169.31 65.23 157.62 68.98 148.1 64.08C138.58 59.18 134.83 47.49 139.73 37.97C144.63 28.45 156.32 24.7 165.84 29.6Z"
+                              fill="url(#paint0_linear_932_164)"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M164.66 83.03C161.24 83.23 157.51 82.35 153.7 80.22C146.64 76.27 138.08 68.5 127.46 56.27C112.26 38.91 78.01 64.71 110.88 91.06C118.01 98 122.49 103.76 124.93 108.47C139.81 134.21 138.61 163.81 114.98 173.43C152.26 161.24 170.74 117.56 164.67 83.03H164.66Z"
+                              fill="url(#paint1_linear_932_164)"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M126.63 112.63C135.3 139.02 62.87 143.52 78.27 167.93C83.66 176.47 98 177.98 114.97 173.43C138.6 163.81 139.8 134.21 124.92 108.47C125.32 109.24 125.66 109.98 125.95 110.69C126.22 111.36 126.45 112 126.63 112.62V112.63Z"
+                              fill="#3D4753"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M126.63 112.63C128.19 117.39 127.11 121.43 124.39 125.01C132.94 143.69 131.33 163.08 114.97 173.43C138.6 163.81 139.8 134.21 124.92 108.47C125.32 109.24 125.66 109.98 125.95 110.69C126.22 111.36 126.45 112 126.63 112.62V112.63Z"
+                              fill="#0E215E"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M175.13 49.4501C176.21 41.9201 172.51 34.2001 165.36 30.5201C156.35 25.8801 145.29 29.4301 140.65 38.4401C136.41 46.6901 139.02 56.6501 146.4 61.8401C145.13 57.9801 145.35 53.6301 147.35 49.7401C151.32 42.0301 160.79 38.9901 168.5 42.9601C171.42 44.4701 173.68 46.7601 175.13 49.4501Z"
+                              fill="url(#paint2_linear_932_164)"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M83.25 2.51001C47.74 12.04 0.710003 48.13 3.42075e-06 102.1C-0.309997 125.55 10.95 127.69 15.24 119.05C17.08 115.34 17.23 111.72 18.07 108.01C21.07 94.78 32.41 88.96 44.52 95.73C51.58 99.68 60.14 107.45 70.76 119.68C85.96 137.04 120.21 111.24 87.34 84.89C80.21 77.95 75.73 72.19 73.29 67.48C58.41 41.74 59.61 12.14 83.24 2.52001L83.25 2.51001ZM32.38 146.35C22.86 141.45 19.11 129.76 24.01 120.24C28.91 110.72 40.6 106.97 50.12 111.87C59.64 116.77 63.39 128.46 58.49 137.99C53.59 147.51 41.9 151.26 32.38 146.36V146.35Z"
+                              fill="url(#paint3_linear_932_164)"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M12.33 57.27C4.91 70.31 0.230003 85.34 3.42075e-06 102.1C-0.309997 125.55 10.95 127.69 15.24 119.05C17.08 115.34 17.23 111.72 18.07 108.01C21.07 94.78 32.41 88.96 44.52 95.73C51.58 99.68 60.14 107.45 70.76 119.68C85.96 137.04 120.21 111.24 87.34 84.89C80.21 77.95 75.73 72.19 73.29 67.48C71.12 63.74 69.3 59.91 67.84 56.07C49.53 47.8 29.18 48.79 12.32 57.27H12.33ZM32.38 146.36C22.86 141.46 19.11 129.77 24.01 120.25C28.91 110.73 40.6 106.98 50.12 111.88C59.64 116.78 63.39 128.47 58.49 138C53.59 147.52 41.9 151.27 32.38 146.37V146.36Z"
+                              fill="url(#paint4_linear_932_164)"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M33.56 92.92C36.98 92.72 40.71 93.6 44.52 95.73C51.58 99.68 60.14 107.45 70.76 119.68C85.96 137.04 120.21 111.24 87.34 84.89C80.21 77.95 75.73 72.19 73.29 67.48C58.41 41.74 59.61 12.14 83.24 2.52002C45.97 14.7 27.49 58.38 33.56 92.92Z"
+                              fill="url(#paint5_linear_932_164)"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M71.58 63.32C62.91 36.93 135.34 32.43 119.94 8.02001C114.55 -0.519989 100.21 -2.02999 83.24 2.52001C59.61 12.14 58.41 41.74 73.29 67.48C72.89 66.71 72.55 65.97 72.26 65.26C71.99 64.59 71.76 63.95 71.58 63.33V63.32Z"
+                              fill="url(#paint6_linear_932_164)"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M71.58 63.32C70.02 58.56 71.1 54.52 73.82 50.94C65.27 32.26 66.88 12.87 83.24 2.52002C59.61 12.14 58.41 41.74 73.29 67.48C72.89 66.71 72.55 65.97 72.26 65.26C71.99 64.59 71.76 63.95 71.58 63.33V63.32Z"
+                              fill="url(#paint7_linear_932_164)"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M23.09 126.5C22.01 134.03 25.71 141.75 32.86 145.43C41.87 150.07 52.93 146.52 57.57 137.51C61.81 129.26 59.2 119.3 51.82 114.11C53.09 117.97 52.87 122.32 50.87 126.21C46.9 133.92 37.43 136.96 29.72 132.99C26.8 131.48 24.54 129.19 23.09 126.5Z"
+                              fill="url(#paint8_linear_932_164)"
+                              fill-rule="evenodd"
+                            />
+                          </g>
+                          <defs>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint0_linear_932_164"
+                              x1="97.08"
+                              x2="198.22"
+                              y1="76.52"
+                              y2="76.52"
+                            >
+                              <stop
+                                stop-color="#1C2A39"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#7C8A99"
+                              />
+                            </lineargradient>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint1_linear_932_164"
+                              x1="97.08"
+                              x2="165.79"
+                              y1="112.04"
+                              y2="112.04"
+                            >
+                              <stop
+                                stop-color="#1C2A39"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#7C8A99"
+                              />
+                            </lineargradient>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint2_linear_932_164"
+                              x1="138.61"
+                              x2="175.31"
+                              y1="45.1601"
+                              y2="45.1601"
+                            >
+                              <stop
+                                stop-color="#1C2A39"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#7C8A99"
+                              />
+                            </lineargradient>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint3_linear_932_164"
+                              x1="-21.8556"
+                              x2="51.1173"
+                              y1="117.802"
+                              y2="16.8919"
+                            >
+                              <stop
+                                stop-color="#1C2A39"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#BCCAD9"
+                              />
+                            </lineargradient>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint4_linear_932_164"
+                              x1="3.41999e-06"
+                              x2="101.14"
+                              y1="99.43"
+                              y2="99.43"
+                            >
+                              <stop
+                                stop-color="#7C8A99"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#FEFEFE"
+                              />
+                            </lineargradient>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint5_linear_932_164"
+                              x1="32.42"
+                              x2="1.00001"
+                              y1="63.92"
+                              y2="63.92"
+                            >
+                              <stop
+                                stop-color="#7C8A99"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#FEFEFE"
+                              />
+                            </lineargradient>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint6_linear_932_164"
+                              x1="34.9389"
+                              x2="87.84"
+                              y1="8.56541"
+                              y2="-25.5456"
+                            >
+                              <stop
+                                stop-color="#1C2A39"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#BCCAD9"
+                              />
+                            </lineargradient>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint7_linear_932_164"
+                              x1="63.53"
+                              x2="83.25"
+                              y1="34.99"
+                              y2="34.99"
+                            >
+                              <stop
+                                stop-color="#7C8A99"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#FEFEFE"
+                              />
+                            </lineargradient>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint8_linear_932_164"
+                              x1="22.9"
+                              x2="59.61"
+                              y1="130.79"
+                              y2="130.79"
+                            >
+                              <stop
+                                stop-color="#7C8A99"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#FEFEFE"
+                              />
+                            </lineargradient>
+                            <clippath
+                              id="clip0_932_164"
+                            >
+                              <rect
+                                fill="white"
+                                height="175.95"
+                                width="198.22"
+                              />
+                            </clippath>
+                          </defs>
+                        </svg>
+                      </i>
+                    </div>
+                     $t('menu.cockpit')
+                  </a>
+                  
+                </div>
+              </button>
+            </div>
+            <div
+              class="v-col d-none d-md-flex align-center"
+              data-v-e787b5f9=""
+            >
+              <div
+                class="v-row"
+                data-v-e787b5f9=""
+              >
+                <div
+                  class="v-col d-flex align-center"
+                  data-v-e787b5f9=""
+                >
+                  <button
+                    class="d-flex align-center justify-center light-dark-switch d-none d-lg-flex"
+                    data-v-e787b5f9=""
+                  >
+                    <svg
+                      fill="none"
+                      height="15"
+                      viewBox="0 0 28 15"
+                      width="28"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M7.63636 15C5.51515 15 3.71212 14.2708 2.22727 12.8125C0.742424 11.3542 0 9.58333 0 7.5C0 5.41667 0.742424 3.64583 2.22727 2.1875C3.71212 0.729167 5.51515 0 7.63636 0H20.3636C22.4848 0 24.2879 0.729167 25.7727 2.1875C27.2576 3.64583 28 5.41667 28 7.5C28 9.58333 27.2576 11.3542 25.7727 12.8125C24.2879 14.2708 22.4848 15 20.3636 15H7.63636ZM7.63636 12.5H20.3636C21.7636 12.5 22.9621 12.0104 23.9591 11.0312C24.9561 10.0521 25.4545 8.875 25.4545 7.5C25.4545 6.125 24.9561 4.94792 23.9591 3.96875C22.9621 2.98958 21.7636 2.5 20.3636 2.5H7.63636C6.23636 2.5 5.03788 2.98958 4.04091 3.96875C3.04394 4.94792 2.54545 6.125 2.54545 7.5C2.54545 8.875 3.04394 10.0521 4.04091 11.0312C5.03788 12.0104 6.23636 12.5 7.63636 12.5ZM7.63636 11.25C8.69697 11.25 9.59848 10.8854 10.3409 10.1562C11.0833 9.42708 11.4545 8.54167 11.4545 7.5C11.4545 6.45833 11.0833 5.57292 10.3409 4.84375C9.59848 4.11458 8.69697 3.75 7.63636 3.75C6.57576 3.75 5.67424 4.11458 4.93182 4.84375C4.18939 5.57292 3.81818 6.45833 3.81818 7.5C3.81818 8.54167 4.18939 9.42708 4.93182 10.1562C5.67424 10.8854 6.57576 11.25 7.63636 11.25Z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                    <svg
+                      fill="none"
+                      height="15"
+                      style="display: none;"
+                      viewBox="0 0 28 15"
+                      width="28"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M7.63636 15C5.51515 15 3.71212 14.2708 2.22727 12.8125C0.742424 11.3542 0 9.58333 0 7.5C0 5.41667 0.742424 3.64583 2.22727 2.1875C3.71212 0.729167 5.51515 0 7.63636 0H20.3636C22.4848 0 24.2879 0.729167 25.7727 2.1875C27.2576 3.64583 28 5.41667 28 7.5C28 9.58333 27.2576 11.3542 25.7727 12.8125C24.2879 14.2708 22.4848 15 20.3636 15H7.63636ZM7.63636 12.5H20.3636C21.7636 12.5 22.9621 12.0104 23.9591 11.0312C24.9561 10.0521 25.4545 8.875 25.4545 7.5C25.4545 6.125 24.9561 4.94792 23.9591 3.96875C22.9621 2.98958 21.7636 2.5 20.3636 2.5H7.63636C6.23636 2.5 5.03788 2.98958 4.04091 3.96875C3.04394 4.94792 2.54545 6.125 2.54545 7.5C2.54545 8.875 3.04394 10.0521 4.04091 11.0312C5.03788 12.0104 6.23636 12.5 7.63636 12.5ZM20.3636 11.25C21.4242 11.25 22.3258 10.8854 23.0682 10.1562C23.8106 9.42708 24.1818 8.54167 24.1818 7.5C24.1818 6.45833 23.8106 5.57292 23.0682 4.84375C22.3258 4.11458 21.4242 3.75 20.3636 3.75C19.303 3.75 18.4015 4.11458 17.6591 4.84375C16.9167 5.57292 16.5455 6.45833 16.5455 7.5C16.5455 8.54167 16.9167 9.42708 17.6591 10.1562C18.4015 10.8854 19.303 11.25 20.3636 11.25Z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                    <span
+                      class="ml-2"
+                    >
+                      $t('menu.theme.light') / $t('menu.theme.dark')
+                    </span>
+                  </button>
+                </div>
+                <div
+                  class="v-col d-flex align-center justify-end"
+                  data-v-e787b5f9=""
+                >
+                  <button
+                    data-v-e787b5f9=""
+                  >
+                    <div
+                      class="circle rounded-circle border-sm text-icon pa-2 d-flex justify-center align-center"
+                      data-v-39e8094e=""
+                      data-v-e787b5f9=""
+                    >
+                      
+                      <i
+                        aria-hidden="true"
+                        class="v-icon notranslate v-theme--light v-icon--size-default"
+                        data-v-e787b5f9=""
+                      >
+                        <svg
+                          fill="none"
+                          height="17"
+                          viewBox="0 0 21 17"
+                          width="21"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M7.68844 12.4824H9.66834V9.51172H12.6382V7.53125H9.66834V4.56055H7.68844V7.53125H4.71859V9.51172H7.68844V12.4824ZM2.73869 16.4434C2.19422 16.4434 1.72812 16.2494 1.34038 15.8616C0.952654 15.4738 0.758789 15.0075 0.758789 14.4629V2.58008C0.758789 2.03545 0.952654 1.56921 1.34038 1.18137C1.72812 0.79353 2.19422 0.599609 2.73869 0.599609H14.6181C15.1626 0.599609 15.6287 0.79353 16.0164 1.18137C16.4041 1.56921 16.598 2.03545 16.598 2.58008V7.03613L20.5578 3.0752V13.9678L16.598 10.0068V14.4629C16.598 15.0075 16.4041 15.4738 16.0164 15.8616C15.6287 16.2494 15.1626 16.4434 14.6181 16.4434H2.73869ZM2.73869 14.4629H14.6181V2.58008H2.73869V14.4629Z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                      </i>
+                      
+                    </div>
+                  </button>
+                  
+                  
+                  <button
+                    aria-expanded="false"
+                    aria-haspopup="menu"
+                    aria-owns="v-menu-1"
+                    class="ml-2 user-info rounded-pill d-flex flex-row text-icon border-sm align-center justify-center"
+                    data-v-607bdd70=""
+                    targetref="[object Object]"
+                  >
+                    <div
+                      class="v-avatar v-theme--light v-avatar--density-default v-avatar--variant-flat avatar d-flex align-center text-font border-sm bg-primary"
+                      data-v-607bdd70=""
+                      style="width: 44px; height: 44px;"
+                    >
+                      
+                      
+                      <span
+                        data-v-607bdd70=""
+                      />
+                      
+                      
+                      
+                      <!---->
+                      <span
+                        class="v-avatar__underlay"
+                      />
+                      
+                    </div>
+                    <div
+                      class="d-flex flex-column justify-center text-right pa-1 pl-3 w-100"
+                      data-v-607bdd70=""
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="v-icon notranslate v-theme--light v-icon--size-default ellipsis-icon"
+                        data-test="user-dropdown"
+                        data-v-607bdd70=""
+                      >
+                        <svg
+                          fill="none"
+                          height="4"
+                          viewBox="0 0 18 4"
+                          width="18"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M2 0C3.10457 0 4 0.895431 4 2C4 3.10457 3.10457 4 2 4C0.895431 4 0 3.10457 0 2C0 0.895431 0.895431 0 2 0ZM9 0C10.1046 0 11 0.895431 11 2C11 3.10457 10.1046 4 9 4C7.89543 4 7 3.10457 7 2C7 0.895431 7.89543 0 9 0ZM18 2C18 0.895431 17.1046 0 16 0C14.8954 0 14 0.895431 14 2C14 3.10457 14.8954 4 16 4C17.1046 4 18 3.10457 18 2Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </i>
+                    </div>
+                  </button>
+                  
+                  <!---->
+                  
                 </div>
               </div>
             </div>
-            
-            <!---->
           </div>
           
-          
-          <transition-stub
-            appear="false"
-            css="true"
-            name="expand-transition"
-            persisted="false"
-          >
-            <!---->
-          </transition-stub>
-          
-        </header>
-      </div>
+          <!---->
+        </div>
+        
+        
+        <transition-stub
+          appear="false"
+          css="true"
+          name="expand-transition"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        
+      </header>
       
       <nav
-        class="v-navigation-drawer v-navigation-drawer--right v-navigation-drawer--temporary v-theme--light v-navigation-drawer--mobile menu-drawer px-4"
+        class="v-navigation-drawer v-navigation-drawer--right v-navigation-drawer--temporary v-theme--light v-navigation-drawer--mobile menu-drawer px-4 hide-on-mobile"
         data-v-cf2c9067=""
         style="right: 0px; z-index: 1006; transform: translateX(110%); position: fixed; transition: none !important; height: calc(100% - 70px - 0px); top: 70px; bottom: 0px;"
       >

--- a/frontend/src/pages/index/__snapshots__/Page.test.ts.snap
+++ b/frontend/src/pages/index/__snapshots__/Page.test.ts.snap
@@ -878,7 +878,7 @@ exports[`IndexPage > without apollo error > renders 1`] = `
                     
                     <i
                       aria-hidden="false"
-                      aria-label="$vuetify.input.clear"
+                      aria-label="Löschen"
                       class="mdi-close-circle mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable"
                       role="button"
                       tabindex="0"
@@ -1729,7 +1729,7 @@ exports[`IndexPage > without apollo error > renders 1`] = `
                     
                     <i
                       aria-hidden="false"
-                      aria-label="$vuetify.input.clear"
+                      aria-label="Löschen"
                       class="mdi-close-circle mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable"
                       role="button"
                       tabindex="0"

--- a/frontend/src/pages/room/__snapshots__/Page.test.ts.snap
+++ b/frontend/src/pages/room/__snapshots__/Page.test.ts.snap
@@ -757,7 +757,7 @@ exports[`Room Page > renders 1`] = `
       </div>
       
       <nav
-        class="v-navigation-drawer v-navigation-drawer--right v-navigation-drawer--temporary v-theme--light v-navigation-drawer--mobile menu-drawer"
+        class="v-navigation-drawer v-navigation-drawer--right v-navigation-drawer--temporary v-theme--light v-navigation-drawer--mobile menu-drawer px-4"
         data-v-cf2c9067=""
         style="right: 0px; z-index: 1006; transform: translateX(110%); position: fixed; transition: none !important; height: calc(100% - 70px - 0px); top: 70px; bottom: 0px;"
       >
@@ -768,7 +768,7 @@ exports[`Room Page > renders 1`] = `
         >
           
           <div
-            class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-text-field mx-4 mt-4 search"
+            class="v-input v-input--horizontal v-input--center-affix v-input--density-compact v-theme--light v-locale--is-ltr v-text-field search"
             data-v-cf2c9067=""
           >
             <!---->
@@ -777,7 +777,7 @@ exports[`Room Page > renders 1`] = `
             >
               
               <div
-                class="v-field v-field--appended v-field--center-affix v-field--prepended v-field--variant-solo v-theme--light v-field--rounded v-locale--is-ltr"
+                class="v-field v-field--appended v-field--center-affix v-field--flat v-field--prepended v-field--variant-solo v-theme--light v-field--rounded v-locale--is-ltr"
               >
                 <div
                   class="v-field__overlay"
@@ -930,78 +930,15 @@ exports[`Room Page > renders 1`] = `
           >
             
             <h2
-              class="mx-4"
+              class="header mb-4"
               data-v-cf2c9067=""
             >
               $t('tablesDrawer.header')
             </h2>
             <div
-              class="v-card v-theme--light v-card--density-default v-card--variant-elevated mx-auto"
               data-v-cf2c9067=""
-              data-v-de37061b=""
-              style="width: 400px;"
             >
-              <!---->
-              <div
-                class="v-card__loader"
-              >
-                <div
-                  aria-hidden="true"
-                  aria-valuemax="100"
-                  aria-valuemin="0"
-                  class="v-progress-linear v-theme--light v-locale--is-ltr"
-                  role="progressbar"
-                  style="top: 0px; height: 0px; --v-progress-linear-height: 2px;"
-                >
-                  <!---->
-                  <div
-                    class="v-progress-linear__background"
-                    style="width: 100%;"
-                  />
-                  <transition-stub
-                    appear="false"
-                    css="true"
-                    name="fade-transition"
-                    persisted="false"
-                  >
-                    <div
-                      class="v-progress-linear__indeterminate"
-                    >
-                      
-                      <div
-                        class="v-progress-linear__indeterminate long"
-                      />
-                      <div
-                        class="v-progress-linear__indeterminate short"
-                      />
-                      
-                    </div>
-                  </transition-stub>
-                  <!---->
-                </div>
-              </div>
-              <!---->
-              <!---->
-              
-              <div
-                class="v-list v-theme--light bg-transparent v-list--density-default v-list--two-line"
-                data-v-de37061b=""
-                role="listbox"
-                tabindex="0"
-              >
-                
-                
-                
-                
-              </div>
-              
-              <!---->
-              
-              <!---->
-              <span
-                class="v-card__underlay"
-              />
-              
+              $t('tablesDrawer.noTables')
             </div>
             
           </div>
@@ -1044,199 +981,35 @@ exports[`Room Page > renders 1`] = `
         </div>
       </div>
       
-      <div
-        class="navigation-drawer-box d-md-none position-fixed mb-5 pb-5"
-        data-v-96a196cc=""
+      
+      <nav
+        class="v-navigation-drawer v-navigation-drawer--bottom v-navigation-drawer--temporary v-theme--light v-navigation-drawer--mobile menu-drawer px-4 d-md-none"
+        data-v-cf2c9067=""
+        style="bottom: 0px; z-index: 1004; transform: translateY(110%); position: fixed; transition: none !important; left: 0px; width: calc(100% - 0px - 0px);"
       >
-        
-        <nav
-          class="v-navigation-drawer v-navigation-drawer--bottom v-navigation-drawer--temporary v-theme--light v-navigation-drawer--mobile menu-drawer"
-          data-v-cf2c9067=""
-          style="bottom: 0px; z-index: 1004; transform: translateY(110%); position: fixed; transition: none !important; left: 0px; width: calc(100% - 0px - 0px);"
+        <!---->
+        <!---->
+        <div
+          class="v-navigation-drawer__content"
         >
-          <!---->
-          <!---->
+          
           <div
-            class="v-navigation-drawer__content"
+            class="v-input v-input--horizontal v-input--center-affix v-input--density-compact v-theme--light v-locale--is-ltr v-text-field search"
+            data-v-cf2c9067=""
           >
-            
+            <!---->
             <div
-              class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-text-field mx-4 mt-4 search"
-              data-v-cf2c9067=""
-            >
-              <!---->
-              <div
-                class="v-input__control"
-              >
-                
-                <div
-                  class="v-field v-field--appended v-field--center-affix v-field--prepended v-field--variant-solo v-theme--light v-field--rounded v-locale--is-ltr"
-                >
-                  <div
-                    class="v-field__overlay"
-                  />
-                  <div
-                    class="v-field__loader"
-                  >
-                    <div
-                      aria-hidden="true"
-                      aria-valuemax="100"
-                      aria-valuemin="0"
-                      class="v-progress-linear v-theme--light v-locale--is-ltr"
-                      role="progressbar"
-                      style="top: 0px; height: 0px; --v-progress-linear-height: 2px;"
-                    >
-                      <!---->
-                      <div
-                        class="v-progress-linear__background"
-                        style="width: 100%;"
-                      />
-                      <transition-stub
-                        appear="false"
-                        css="true"
-                        name="fade-transition"
-                        persisted="false"
-                      >
-                        <div
-                          class="v-progress-linear__indeterminate"
-                        >
-                          
-                          <div
-                            class="v-progress-linear__indeterminate long"
-                          />
-                          <div
-                            class="v-progress-linear__indeterminate short"
-                          />
-                          
-                        </div>
-                      </transition-stub>
-                      <!---->
-                    </div>
-                  </div>
-                  <div
-                    class="v-field__prepend-inner"
-                  >
-                    <i
-                      aria-hidden="true"
-                      class="mdi-tune mdi v-icon notranslate v-theme--light v-icon--size-default"
-                    />
-                    <!---->
-                  </div>
-                  <div
-                    class="v-field__field"
-                    data-no-activator=""
-                  >
-                    <label
-                      aria-hidden="true"
-                      class="v-label v-field-label v-field-label--floating"
-                      for="input-6"
-                    >
-                      <!---->
-                      
-                      $t('tablesDrawer.searchPlaceholder')
-                      
-                    </label>
-                    <label
-                      class="v-label v-field-label"
-                      for="input-6"
-                    >
-                      <!---->
-                      
-                      $t('tablesDrawer.searchPlaceholder')
-                      
-                    </label>
-                    
-                    
-                    <!---->
-                    <input
-                      aria-describedby="input-6-messages"
-                      class="v-field__input"
-                      id="input-6"
-                      size="1"
-                      type="text"
-                    />
-                    <!---->
-                    
-                    
-                  </div>
-                  <transition-stub
-                    appear="false"
-                    css="true"
-                    name="expand-x-transition"
-                    persisted="false"
-                  >
-                    <div
-                      class="v-field__clearable"
-                      style="display: none;"
-                    >
-                      
-                      <i
-                        aria-hidden="false"
-                        aria-label="$vuetify.input.clear"
-                        class="mdi-close-circle mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable"
-                        role="button"
-                        tabindex="0"
-                      />
-                      
-                    </div>
-                  </transition-stub>
-                  <div
-                    class="v-field__append-inner"
-                  >
-                    <!---->
-                    <!---->
-                  </div>
-                  <div
-                    class="v-field__outline"
-                  >
-                    <!---->
-                    <!---->
-                  </div>
-                </div>
-                
-              </div>
-              <!---->
-              <div
-                class="v-input__details"
-              >
-                <transition-group-stub
-                  appear="false"
-                  aria-live="polite"
-                  class="v-messages"
-                  css="true"
-                  id="input-6-messages"
-                  name="slide-y-transition"
-                  persisted="false"
-                  role="alert"
-                  tag="div"
-                >
-                  <!---->
-                </transition-group-stub>
-                <!---->
-              </div>
-            </div>
-            <div
-              class="v-list v-theme--light bg-transparent v-list--density-default v-list--one-line"
-              data-v-cf2c9067=""
-              role="listbox"
-              tabindex="0"
+              class="v-input__control"
             >
               
-              <h2
-                class="mx-4"
-                data-v-cf2c9067=""
-              >
-                $t('tablesDrawer.header')
-              </h2>
               <div
-                class="v-card v-theme--light v-card--density-default v-card--variant-elevated mx-auto"
-                data-v-cf2c9067=""
-                data-v-de37061b=""
-                style="width: 400px;"
+                class="v-field v-field--appended v-field--center-affix v-field--flat v-field--prepended v-field--variant-solo v-theme--light v-field--rounded v-locale--is-ltr"
               >
-                <!---->
                 <div
-                  class="v-card__loader"
+                  class="v-field__overlay"
+                />
+                <div
+                  class="v-field__loader"
                 >
                   <div
                     aria-hidden="true"
@@ -1273,45 +1046,141 @@ exports[`Room Page > renders 1`] = `
                     <!---->
                   </div>
                 </div>
-                <!---->
-                <!---->
-                
                 <div
-                  class="v-list v-theme--light bg-transparent v-list--density-default v-list--two-line"
-                  data-v-de37061b=""
-                  role="listbox"
-                  tabindex="0"
+                  class="v-field__prepend-inner"
                 >
+                  <i
+                    aria-hidden="true"
+                    class="mdi-tune mdi v-icon notranslate v-theme--light v-icon--size-default"
+                  />
+                  <!---->
+                </div>
+                <div
+                  class="v-field__field"
+                  data-no-activator=""
+                >
+                  <label
+                    aria-hidden="true"
+                    class="v-label v-field-label v-field-label--floating"
+                    for="input-6"
+                  >
+                    <!---->
+                    
+                    $t('tablesDrawer.searchPlaceholder')
+                    
+                  </label>
+                  <label
+                    class="v-label v-field-label"
+                    for="input-6"
+                  >
+                    <!---->
+                    
+                    $t('tablesDrawer.searchPlaceholder')
+                    
+                  </label>
                   
                   
+                  <!---->
+                  <input
+                    aria-describedby="input-6-messages"
+                    class="v-field__input"
+                    id="input-6"
+                    size="1"
+                    type="text"
+                  />
+                  <!---->
                   
                   
                 </div>
-                
-                <!---->
-                
-                <!---->
-                <span
-                  class="v-card__underlay"
-                />
-                
+                <transition-stub
+                  appear="false"
+                  css="true"
+                  name="expand-x-transition"
+                  persisted="false"
+                >
+                  <div
+                    class="v-field__clearable"
+                    style="display: none;"
+                  >
+                    
+                    <i
+                      aria-hidden="false"
+                      aria-label="$vuetify.input.clear"
+                      class="mdi-close-circle mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable"
+                      role="button"
+                      tabindex="0"
+                    />
+                    
+                  </div>
+                </transition-stub>
+                <div
+                  class="v-field__append-inner"
+                >
+                  <!---->
+                  <!---->
+                </div>
+                <div
+                  class="v-field__outline"
+                >
+                  <!---->
+                  <!---->
+                </div>
               </div>
               
             </div>
+            <!---->
+            <div
+              class="v-input__details"
+            >
+              <transition-group-stub
+                appear="false"
+                aria-live="polite"
+                class="v-messages"
+                css="true"
+                id="input-6-messages"
+                name="slide-y-transition"
+                persisted="false"
+                role="alert"
+                tag="div"
+              >
+                <!---->
+              </transition-group-stub>
+              <!---->
+            </div>
+          </div>
+          <div
+            class="v-list v-theme--light bg-transparent v-list--density-default v-list--one-line"
+            data-v-cf2c9067=""
+            role="listbox"
+            tabindex="0"
+          >
+            
+            <h2
+              class="header mb-4"
+              data-v-cf2c9067=""
+            >
+              $t('tablesDrawer.header')
+            </h2>
+            <div
+              data-v-cf2c9067=""
+            >
+              $t('tablesDrawer.noTables')
+            </div>
             
           </div>
-          <!---->
-        </nav>
-        <transition-stub
-          appear="false"
-          css="true"
-          name="fade-transition"
-          persisted="false"
-        >
-          <!---->
-        </transition-stub>
-        
-      </div>
+          
+        </div>
+        <!---->
+      </nav>
+      <transition-stub
+        appear="false"
+        css="true"
+        name="fade-transition"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      
       <div
         class="bottom-menu d-flex w-100 position-fixed bottom-0 justify-space-around align-center py-2 bg-surface d-md-none"
         data-v-96a196cc=""

--- a/frontend/src/pages/room/__snapshots__/Page.test.ts.snap
+++ b/frontend/src/pages/room/__snapshots__/Page.test.ts.snap
@@ -16,748 +16,743 @@ exports[`Room Page > renders 1`] = `
     >
       
       
-      <div
-        class="top-menu mt-6 mt-sm-0"
+      <header
+        class="v-toolbar v-toolbar--flat v-toolbar--density-default v-theme--light v-locale--is-ltr v-app-bar app-bar"
         data-v-e787b5f9=""
+        style="top: 0px; z-index: 1008; transform: translateY(0%); position: fixed; transition: none !important; left: 0px; width: calc(100% - 0px - 0px);"
       >
-        <header
-          class="v-toolbar v-toolbar--flat v-toolbar--density-default v-theme--light v-locale--is-ltr v-app-bar app-bar"
-          data-v-e787b5f9=""
-          style="top: 0px; z-index: 1008; transform: translateY(0%); position: fixed; transition: none !important; left: 0px; width: calc(100% - 0px - 0px);"
+        <!---->
+        
+        <div
+          class="v-toolbar__content"
+          style="height: 70px;"
         >
+          <!---->
           <!---->
           
           <div
-            class="v-toolbar__content"
-            style="height: 70px;"
+            class="v-row ma-1"
+            data-v-e787b5f9=""
           >
-            <!---->
-            <!---->
-            
             <div
-              class="v-row ma-1"
+              class="v-col d-none d-md-flex align-center"
               data-v-e787b5f9=""
             >
-              <div
-                class="v-col d-none d-md-flex align-center"
+              <a
+                class="logo"
                 data-v-e787b5f9=""
+                href="/"
               >
-                <a
-                  class="logo"
+                <div
+                  class="v-responsive v-img v-img--booting w-100 logo-small"
                   data-v-e787b5f9=""
-                  href="/"
+                  data-v-f6be2607=""
                 >
                   <div
-                    class="v-responsive v-img v-img--booting w-100 logo-small"
-                    data-v-e787b5f9=""
-                    data-v-f6be2607=""
-                  >
-                    <div
-                      class="v-responsive__sizer"
-                    />
-                    
-                    
-                    <transition-stub
-                      appear="true"
-                      css="true"
-                      name="fade-transition"
-                      persisted="false"
-                    >
-                      <img
-                        class="v-img__img v-img__img--contain"
-                        src="/src/assets/dreammall-logo.svg"
-                        style="display: none;"
-                      />
-                    </transition-stub>
-                    <transition-stub
-                      appear="false"
-                      css="true"
-                      name="fade-transition"
-                      persisted="false"
-                    >
-                      <!---->
-                    </transition-stub>
-                    <!---->
-                    <!---->
-                    <!---->
-                    
-                    
-                    <!---->
-                  </div>
-                </a>
-              </div>
-              <div
-                class="v-col d-flex align-center justify-center"
-                data-v-e787b5f9=""
-              >
-                <button
-                  class="tab-control ma-auto border-sm text-font open"
-                  data-v-d58c92bb=""
-                  data-v-e787b5f9=""
-                >
-                  <div
-                    class="marker"
-                    data-v-d58c92bb=""
-                    style="display: none; width: 0px; left: 0px;"
+                    class="v-responsive__sizer"
                   />
-                  <div
-                    class="d-flex align-center justify-center h-100 w-100"
-                    data-v-d58c92bb=""
+                  
+                  
+                  <transition-stub
+                    appear="true"
+                    css="true"
+                    name="fade-transition"
+                    persisted="false"
                   >
-                    
-                    <a
-                      class="item active"
-                      data-v-d58c92bb=""
-                    >
-                      <div
-                        class="icon d-flex justify-center align-center"
-                        data-v-d58c92bb=""
-                      >
-                        <i
-                          aria-hidden="true"
-                          class="v-icon notranslate v-theme--light v-icon--size-default w-100 world-cafe"
-                          data-v-d58c92bb=""
-                        >
-                          <svg
-                            fill="none"
-                            height="193"
-                            viewBox="0 0 138 193"
-                            width="138"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <g
-                              clip-path="url(#clip0_932_149)"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M29.6 136.89C7.05 118.08 -2.7 92.78 0.64 66.02C3.97 39.35 29.88 -0.749964 56.89 0.0100358C106.62 20.82 -15.77 78.98 29.6 136.89Z"
-                                fill="url(#paint0_linear_932_149)"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M29.6 136.89C24.66 132.77 20.33 128.33 16.62 123.64C3.99 107.66 -1.48 88.69 0.339998 68.8C1.06 88.98 14.09 89.62 20.99 79.13V79.15C41.21 43.56 86.69 15.42 56.89 0.0100098C106.63 20.82 -15.77 78.98 29.6 136.89Z"
-                                fill="#2D0100"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M29.61 136.9C-15.79 78.98 106.67 20.8 56.87 0C60.92 0.11 64.99 1.14 69.02 3.27C77.12 7.55 81.67 16.94 81.29 28.86C80.18 64.11 50.09 75.76 39.88 103.39C36.49 112.58 36.08 121.65 38.65 130.61C39.38 133.13 38.47 135.74 36.36 137.21C34.25 138.68 31.58 138.56 29.6 136.91L29.61 136.9Z"
-                                fill="url(#paint1_linear_932_149)"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M29.61 136.9C-15.79 78.99 106.63 20.82 56.89 0.0100098C70.63 1.37001 77.6 14.24 75.77 26.29C70.7 59.76 29 71.47 28.59 110.64C28.49 119.81 31.09 128.67 36.37 137.21C34.26 138.68 31.59 138.56 29.61 136.91V136.9Z"
-                                fill="url(#paint2_linear_932_149)"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M108.38 12.96C130.93 31.77 140.68 57.06 137.34 83.82C134.01 110.49 108.1 150.59 81.09 149.83C31.36 129.02 153.75 70.86 108.38 12.96Z"
-                                fill="url(#paint3_linear_932_149)"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M108.38 12.96C113.32 17.08 117.65 21.52 121.36 26.21C133.99 42.18 139.46 61.15 137.64 81.04C136.92 60.86 123.89 60.22 116.99 70.71V70.69C96.77 106.28 51.29 134.43 81.09 149.83C31.36 129.02 153.75 70.86 108.38 12.96Z"
-                                fill="#2D0100"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M108.37 12.95C153.77 70.86 31.31 129.04 81.11 149.84C77.06 149.73 72.99 148.7 68.96 146.57C60.86 142.29 56.31 132.9 56.69 120.98C57.8 85.73 87.89 74.08 98.1 46.45C101.49 37.26 101.9 28.19 99.33 19.23C98.6 16.71 99.51 14.1 101.62 12.63C103.73 11.16 106.4 11.28 108.38 12.93L108.37 12.95Z"
-                                fill="url(#paint4_linear_932_149)"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M108.37 12.95C153.76 70.85 31.35 129.03 81.09 149.84C67.35 148.48 60.38 135.61 62.21 123.56C67.28 90.09 108.98 78.38 109.39 39.21C109.49 30.04 106.89 21.18 101.61 12.64C103.72 11.17 106.39 11.29 108.37 12.94V12.95Z"
-                                fill="url(#paint5_linear_932_149)"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M46.08 182.97C46.04 188.09 50.16 192.27 55.29 192.31C59.9 192.34 63.48 188.95 64.5 184.6C66.82 174.7 62.43 164.87 49.88 158.79C57.01 170.18 46.15 173.4 46.09 182.96L46.08 182.97Z"
-                                fill="url(#paint6_linear_932_149)"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M48.07 182.99C48.04 187.01 51.28 190.3 55.3 190.33C56.87 190.34 58.28 189.85 59.44 189C56.57 187.88 54.11 185.72 52.66 182.73C51.21 179.74 51.03 176.26 52.02 173.24C50.26 176.33 48.1 179.16 48.07 182.98V182.99Z"
-                                fill="url(#paint7_linear_932_149)"
-                                fill-rule="evenodd"
-                                opacity="0.5"
-                              />
-                            </g>
-                            <defs>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint0_linear_932_149"
-                                x1="-16.8153"
-                                x2="61.3369"
-                                y1="116.566"
-                                y2="-41.9949"
-                              >
-                                <stop
-                                  stop-color="#1C2A39"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#7C8A99"
-                                />
-                              </lineargradient>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint1_linear_932_149"
-                                x1="11.8868"
-                                x2="75.9494"
-                                y1="87.02"
-                                y2="-30.1607"
-                              >
-                                <stop
-                                  stop-color="#7C8A99"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#FEFEFE"
-                                />
-                              </lineargradient>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint2_linear_932_149"
-                                x1="19.31"
-                                x2="76.06"
-                                y1="69.12"
-                                y2="69.12"
-                              >
-                                <stop
-                                  stop-color="#1C2A39"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#BCCAD9"
-                                />
-                              </lineargradient>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint3_linear_932_149"
-                                x1="160.483"
-                                x2="82.3302"
-                                y1="32.9545"
-                                y2="191.516"
-                              >
-                                <stop
-                                  stop-color="#1C2A39"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#7C8A99"
-                                />
-                              </lineargradient>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint4_linear_932_149"
-                                x1="131.78"
-                                x2="67.7184"
-                                y1="62.5008"
-                                y2="179.682"
-                              >
-                                <stop
-                                  stop-color="#7C8A99"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#FEFEFE"
-                                />
-                              </lineargradient>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint5_linear_932_149"
-                                x1="118.66"
-                                x2="61.92"
-                                y1="80.73"
-                                y2="80.73"
-                              >
-                                <stop
-                                  stop-color="#1C2A39"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#BCCAD9"
-                                />
-                              </lineargradient>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint6_linear_932_149"
-                                x1="66.33"
-                                x2="38.1302"
-                                y1="185.538"
-                                y2="166.541"
-                              >
-                                <stop
-                                  stop-color="#1C2A39"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#BCCAD9"
-                                />
-                              </lineargradient>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint7_linear_932_149"
-                                x1="48.07"
-                                x2="59.43"
-                                y1="181.79"
-                                y2="181.79"
-                              >
-                                <stop
-                                  stop-color="#1C2A39"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#BCCAD9"
-                                />
-                              </lineargradient>
-                              <clippath
-                                id="clip0_932_149"
-                              >
-                                <rect
-                                  fill="white"
-                                  height="192.32"
-                                  width="137.98"
-                                />
-                              </clippath>
-                            </defs>
-                          </svg>
-                        </i>
-                      </div>
-                       $t('menu.worldCafe')
-                    </a>
-                    <a
-                      class="item"
-                      data-v-d58c92bb=""
-                    >
-                      <div
-                        class="icon d-flex justify-center align-center"
-                        data-v-d58c92bb=""
-                      >
-                        <i
-                          aria-hidden="true"
-                          class="v-icon notranslate v-theme--light v-icon--size-default w-100 cockpit"
-                          data-v-d58c92bb=""
-                        >
-                          <svg
-                            fill="none"
-                            height="176"
-                            viewBox="0 0 199 176"
-                            width="199"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <g
-                              clip-path="url(#clip0_932_164)"
-                            >
-                              <path
-                                clip-rule="evenodd"
-                                d="M114.97 173.44C150.48 163.92 197.5 127.82 198.21 73.86C198.52 50.4 187.26 48.27 182.97 56.91C181.13 60.62 180.98 64.24 180.14 67.95C177.14 81.18 165.8 87 153.69 80.23C146.63 76.28 138.07 68.51 127.45 56.28C112.25 38.92 78 64.72 110.87 91.07C118 98.01 122.48 103.77 124.92 108.48C139.8 134.22 138.6 163.82 114.97 173.44ZM165.84 29.6C175.36 34.5 179.11 46.19 174.21 55.71C169.31 65.23 157.62 68.98 148.1 64.08C138.58 59.18 134.83 47.49 139.73 37.97C144.63 28.45 156.32 24.7 165.84 29.6Z"
-                                fill="#3D4753"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M185.89 118.69C193.31 105.64 197.99 90.61 198.21 73.86C198.52 50.4 187.26 48.27 182.97 56.91C181.13 60.62 180.98 64.24 180.14 67.95C177.14 81.18 165.8 87 153.69 80.23C146.63 76.28 138.07 68.51 127.45 56.28C112.25 38.92 78 64.72 110.87 91.07C118 98.01 122.48 103.77 124.92 108.48C127.09 112.22 128.91 116.05 130.37 119.89C148.68 128.16 169.03 127.17 185.89 118.69ZM165.84 29.6C175.36 34.5 179.11 46.19 174.21 55.71C169.31 65.23 157.62 68.98 148.1 64.08C138.58 59.18 134.83 47.49 139.73 37.97C144.63 28.45 156.32 24.7 165.84 29.6Z"
-                                fill="url(#paint0_linear_932_164)"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M164.66 83.03C161.24 83.23 157.51 82.35 153.7 80.22C146.64 76.27 138.08 68.5 127.46 56.27C112.26 38.91 78.01 64.71 110.88 91.06C118.01 98 122.49 103.76 124.93 108.47C139.81 134.21 138.61 163.81 114.98 173.43C152.26 161.24 170.74 117.56 164.67 83.03H164.66Z"
-                                fill="url(#paint1_linear_932_164)"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M126.63 112.63C135.3 139.02 62.87 143.52 78.27 167.93C83.66 176.47 98 177.98 114.97 173.43C138.6 163.81 139.8 134.21 124.92 108.47C125.32 109.24 125.66 109.98 125.95 110.69C126.22 111.36 126.45 112 126.63 112.62V112.63Z"
-                                fill="#3D4753"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M126.63 112.63C128.19 117.39 127.11 121.43 124.39 125.01C132.94 143.69 131.33 163.08 114.97 173.43C138.6 163.81 139.8 134.21 124.92 108.47C125.32 109.24 125.66 109.98 125.95 110.69C126.22 111.36 126.45 112 126.63 112.62V112.63Z"
-                                fill="#0E215E"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M175.13 49.4501C176.21 41.9201 172.51 34.2001 165.36 30.5201C156.35 25.8801 145.29 29.4301 140.65 38.4401C136.41 46.6901 139.02 56.6501 146.4 61.8401C145.13 57.9801 145.35 53.6301 147.35 49.7401C151.32 42.0301 160.79 38.9901 168.5 42.9601C171.42 44.4701 173.68 46.7601 175.13 49.4501Z"
-                                fill="url(#paint2_linear_932_164)"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M83.25 2.51001C47.74 12.04 0.710003 48.13 3.42075e-06 102.1C-0.309997 125.55 10.95 127.69 15.24 119.05C17.08 115.34 17.23 111.72 18.07 108.01C21.07 94.78 32.41 88.96 44.52 95.73C51.58 99.68 60.14 107.45 70.76 119.68C85.96 137.04 120.21 111.24 87.34 84.89C80.21 77.95 75.73 72.19 73.29 67.48C58.41 41.74 59.61 12.14 83.24 2.52001L83.25 2.51001ZM32.38 146.35C22.86 141.45 19.11 129.76 24.01 120.24C28.91 110.72 40.6 106.97 50.12 111.87C59.64 116.77 63.39 128.46 58.49 137.99C53.59 147.51 41.9 151.26 32.38 146.36V146.35Z"
-                                fill="url(#paint3_linear_932_164)"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M12.33 57.27C4.91 70.31 0.230003 85.34 3.42075e-06 102.1C-0.309997 125.55 10.95 127.69 15.24 119.05C17.08 115.34 17.23 111.72 18.07 108.01C21.07 94.78 32.41 88.96 44.52 95.73C51.58 99.68 60.14 107.45 70.76 119.68C85.96 137.04 120.21 111.24 87.34 84.89C80.21 77.95 75.73 72.19 73.29 67.48C71.12 63.74 69.3 59.91 67.84 56.07C49.53 47.8 29.18 48.79 12.32 57.27H12.33ZM32.38 146.36C22.86 141.46 19.11 129.77 24.01 120.25C28.91 110.73 40.6 106.98 50.12 111.88C59.64 116.78 63.39 128.47 58.49 138C53.59 147.52 41.9 151.27 32.38 146.37V146.36Z"
-                                fill="url(#paint4_linear_932_164)"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M33.56 92.92C36.98 92.72 40.71 93.6 44.52 95.73C51.58 99.68 60.14 107.45 70.76 119.68C85.96 137.04 120.21 111.24 87.34 84.89C80.21 77.95 75.73 72.19 73.29 67.48C58.41 41.74 59.61 12.14 83.24 2.52002C45.97 14.7 27.49 58.38 33.56 92.92Z"
-                                fill="url(#paint5_linear_932_164)"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M71.58 63.32C62.91 36.93 135.34 32.43 119.94 8.02001C114.55 -0.519989 100.21 -2.02999 83.24 2.52001C59.61 12.14 58.41 41.74 73.29 67.48C72.89 66.71 72.55 65.97 72.26 65.26C71.99 64.59 71.76 63.95 71.58 63.33V63.32Z"
-                                fill="url(#paint6_linear_932_164)"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M71.58 63.32C70.02 58.56 71.1 54.52 73.82 50.94C65.27 32.26 66.88 12.87 83.24 2.52002C59.61 12.14 58.41 41.74 73.29 67.48C72.89 66.71 72.55 65.97 72.26 65.26C71.99 64.59 71.76 63.95 71.58 63.33V63.32Z"
-                                fill="url(#paint7_linear_932_164)"
-                                fill-rule="evenodd"
-                              />
-                              <path
-                                clip-rule="evenodd"
-                                d="M23.09 126.5C22.01 134.03 25.71 141.75 32.86 145.43C41.87 150.07 52.93 146.52 57.57 137.51C61.81 129.26 59.2 119.3 51.82 114.11C53.09 117.97 52.87 122.32 50.87 126.21C46.9 133.92 37.43 136.96 29.72 132.99C26.8 131.48 24.54 129.19 23.09 126.5Z"
-                                fill="url(#paint8_linear_932_164)"
-                                fill-rule="evenodd"
-                              />
-                            </g>
-                            <defs>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint0_linear_932_164"
-                                x1="97.08"
-                                x2="198.22"
-                                y1="76.52"
-                                y2="76.52"
-                              >
-                                <stop
-                                  stop-color="#1C2A39"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#7C8A99"
-                                />
-                              </lineargradient>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint1_linear_932_164"
-                                x1="97.08"
-                                x2="165.79"
-                                y1="112.04"
-                                y2="112.04"
-                              >
-                                <stop
-                                  stop-color="#1C2A39"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#7C8A99"
-                                />
-                              </lineargradient>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint2_linear_932_164"
-                                x1="138.61"
-                                x2="175.31"
-                                y1="45.1601"
-                                y2="45.1601"
-                              >
-                                <stop
-                                  stop-color="#1C2A39"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#7C8A99"
-                                />
-                              </lineargradient>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint3_linear_932_164"
-                                x1="-21.8556"
-                                x2="51.1173"
-                                y1="117.802"
-                                y2="16.8919"
-                              >
-                                <stop
-                                  stop-color="#1C2A39"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#BCCAD9"
-                                />
-                              </lineargradient>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint4_linear_932_164"
-                                x1="3.41999e-06"
-                                x2="101.14"
-                                y1="99.43"
-                                y2="99.43"
-                              >
-                                <stop
-                                  stop-color="#7C8A99"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#FEFEFE"
-                                />
-                              </lineargradient>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint5_linear_932_164"
-                                x1="32.42"
-                                x2="1.00001"
-                                y1="63.92"
-                                y2="63.92"
-                              >
-                                <stop
-                                  stop-color="#7C8A99"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#FEFEFE"
-                                />
-                              </lineargradient>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint6_linear_932_164"
-                                x1="34.9389"
-                                x2="87.84"
-                                y1="8.56541"
-                                y2="-25.5456"
-                              >
-                                <stop
-                                  stop-color="#1C2A39"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#BCCAD9"
-                                />
-                              </lineargradient>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint7_linear_932_164"
-                                x1="63.53"
-                                x2="83.25"
-                                y1="34.99"
-                                y2="34.99"
-                              >
-                                <stop
-                                  stop-color="#7C8A99"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#FEFEFE"
-                                />
-                              </lineargradient>
-                              <lineargradient
-                                gradientUnits="userSpaceOnUse"
-                                id="paint8_linear_932_164"
-                                x1="22.9"
-                                x2="59.61"
-                                y1="130.79"
-                                y2="130.79"
-                              >
-                                <stop
-                                  stop-color="#7C8A99"
-                                />
-                                <stop
-                                  offset="1"
-                                  stop-color="#FEFEFE"
-                                />
-                              </lineargradient>
-                              <clippath
-                                id="clip0_932_164"
-                              >
-                                <rect
-                                  fill="white"
-                                  height="175.95"
-                                  width="198.22"
-                                />
-                              </clippath>
-                            </defs>
-                          </svg>
-                        </i>
-                      </div>
-                       $t('menu.cockpit')
-                    </a>
-                    
-                  </div>
-                </button>
-              </div>
-              <div
-                class="v-col d-none d-md-flex align-center"
+                    <img
+                      class="v-img__img v-img__img--contain"
+                      src="/src/assets/dreammall-logo.svg"
+                      style="display: none;"
+                    />
+                  </transition-stub>
+                  <transition-stub
+                    appear="false"
+                    css="true"
+                    name="fade-transition"
+                    persisted="false"
+                  >
+                    <!---->
+                  </transition-stub>
+                  <!---->
+                  <!---->
+                  <!---->
+                  
+                  
+                  <!---->
+                </div>
+              </a>
+            </div>
+            <div
+              class="v-col d-flex align-center justify-center"
+              data-v-e787b5f9=""
+            >
+              <button
+                class="tab-control ma-auto border-sm text-font open"
+                data-v-d58c92bb=""
                 data-v-e787b5f9=""
               >
                 <div
-                  class="v-row"
-                  data-v-e787b5f9=""
+                  class="marker"
+                  data-v-d58c92bb=""
+                  style="display: none; width: 0px; left: 0px;"
+                />
+                <div
+                  class="d-flex align-center justify-center h-100 w-100"
+                  data-v-d58c92bb=""
                 >
-                  <div
-                    class="v-col d-flex align-center"
-                    data-v-e787b5f9=""
+                  
+                  <a
+                    class="item active"
+                    data-v-d58c92bb=""
                   >
-                    <button
-                      class="d-flex align-center justify-center light-dark-switch d-none d-lg-flex"
-                      data-v-e787b5f9=""
+                    <div
+                      class="icon d-flex justify-center align-center"
+                      data-v-d58c92bb=""
                     >
-                      <svg
-                        fill="none"
-                        height="15"
-                        viewBox="0 0 28 15"
-                        width="28"
-                        xmlns="http://www.w3.org/2000/svg"
+                      <i
+                        aria-hidden="true"
+                        class="v-icon notranslate v-theme--light v-icon--size-default w-100 world-cafe"
+                        data-v-d58c92bb=""
                       >
-                        <path
-                          d="M7.63636 15C5.51515 15 3.71212 14.2708 2.22727 12.8125C0.742424 11.3542 0 9.58333 0 7.5C0 5.41667 0.742424 3.64583 2.22727 2.1875C3.71212 0.729167 5.51515 0 7.63636 0H20.3636C22.4848 0 24.2879 0.729167 25.7727 2.1875C27.2576 3.64583 28 5.41667 28 7.5C28 9.58333 27.2576 11.3542 25.7727 12.8125C24.2879 14.2708 22.4848 15 20.3636 15H7.63636ZM7.63636 12.5H20.3636C21.7636 12.5 22.9621 12.0104 23.9591 11.0312C24.9561 10.0521 25.4545 8.875 25.4545 7.5C25.4545 6.125 24.9561 4.94792 23.9591 3.96875C22.9621 2.98958 21.7636 2.5 20.3636 2.5H7.63636C6.23636 2.5 5.03788 2.98958 4.04091 3.96875C3.04394 4.94792 2.54545 6.125 2.54545 7.5C2.54545 8.875 3.04394 10.0521 4.04091 11.0312C5.03788 12.0104 6.23636 12.5 7.63636 12.5ZM7.63636 11.25C8.69697 11.25 9.59848 10.8854 10.3409 10.1562C11.0833 9.42708 11.4545 8.54167 11.4545 7.5C11.4545 6.45833 11.0833 5.57292 10.3409 4.84375C9.59848 4.11458 8.69697 3.75 7.63636 3.75C6.57576 3.75 5.67424 4.11458 4.93182 4.84375C4.18939 5.57292 3.81818 6.45833 3.81818 7.5C3.81818 8.54167 4.18939 9.42708 4.93182 10.1562C5.67424 10.8854 6.57576 11.25 7.63636 11.25Z"
-                          fill="currentColor"
-                        />
-                      </svg>
-                      <svg
-                        fill="none"
-                        height="15"
-                        style="display: none;"
-                        viewBox="0 0 28 15"
-                        width="28"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M7.63636 15C5.51515 15 3.71212 14.2708 2.22727 12.8125C0.742424 11.3542 0 9.58333 0 7.5C0 5.41667 0.742424 3.64583 2.22727 2.1875C3.71212 0.729167 5.51515 0 7.63636 0H20.3636C22.4848 0 24.2879 0.729167 25.7727 2.1875C27.2576 3.64583 28 5.41667 28 7.5C28 9.58333 27.2576 11.3542 25.7727 12.8125C24.2879 14.2708 22.4848 15 20.3636 15H7.63636ZM7.63636 12.5H20.3636C21.7636 12.5 22.9621 12.0104 23.9591 11.0312C24.9561 10.0521 25.4545 8.875 25.4545 7.5C25.4545 6.125 24.9561 4.94792 23.9591 3.96875C22.9621 2.98958 21.7636 2.5 20.3636 2.5H7.63636C6.23636 2.5 5.03788 2.98958 4.04091 3.96875C3.04394 4.94792 2.54545 6.125 2.54545 7.5C2.54545 8.875 3.04394 10.0521 4.04091 11.0312C5.03788 12.0104 6.23636 12.5 7.63636 12.5ZM20.3636 11.25C21.4242 11.25 22.3258 10.8854 23.0682 10.1562C23.8106 9.42708 24.1818 8.54167 24.1818 7.5C24.1818 6.45833 23.8106 5.57292 23.0682 4.84375C22.3258 4.11458 21.4242 3.75 20.3636 3.75C19.303 3.75 18.4015 4.11458 17.6591 4.84375C16.9167 5.57292 16.5455 6.45833 16.5455 7.5C16.5455 8.54167 16.9167 9.42708 17.6591 10.1562C18.4015 10.8854 19.303 11.25 20.3636 11.25Z"
-                          fill="currentColor"
-                        />
-                      </svg>
-                      <span
-                        class="ml-2"
-                      >
-                        $t('menu.theme.light') / $t('menu.theme.dark')
-                      </span>
-                    </button>
-                  </div>
-                  <div
-                    class="v-col d-flex align-center justify-end"
-                    data-v-e787b5f9=""
-                  >
-                    <button
-                      data-v-e787b5f9=""
-                    >
-                      <div
-                        class="circle rounded-circle border-sm text-icon pa-2 d-flex justify-center align-center"
-                        data-v-39e8094e=""
-                        data-v-e787b5f9=""
-                      >
-                        
-                        <i
-                          aria-hidden="true"
-                          class="v-icon notranslate v-theme--light v-icon--size-default"
-                          data-v-e787b5f9=""
+                        <svg
+                          fill="none"
+                          height="193"
+                          viewBox="0 0 138 193"
+                          width="138"
+                          xmlns="http://www.w3.org/2000/svg"
                         >
-                          <svg
-                            fill="none"
-                            height="17"
-                            viewBox="0 0 21 17"
-                            width="21"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M7.68844 12.4824H9.66834V9.51172H12.6382V7.53125H9.66834V4.56055H7.68844V7.53125H4.71859V9.51172H7.68844V12.4824ZM2.73869 16.4434C2.19422 16.4434 1.72812 16.2494 1.34038 15.8616C0.952654 15.4738 0.758789 15.0075 0.758789 14.4629V2.58008C0.758789 2.03545 0.952654 1.56921 1.34038 1.18137C1.72812 0.79353 2.19422 0.599609 2.73869 0.599609H14.6181C15.1626 0.599609 15.6287 0.79353 16.0164 1.18137C16.4041 1.56921 16.598 2.03545 16.598 2.58008V7.03613L20.5578 3.0752V13.9678L16.598 10.0068V14.4629C16.598 15.0075 16.4041 15.4738 16.0164 15.8616C15.6287 16.2494 15.1626 16.4434 14.6181 16.4434H2.73869ZM2.73869 14.4629H14.6181V2.58008H2.73869V14.4629Z"
-                              fill="currentColor"
-                            />
-                          </svg>
-                        </i>
-                        
-                      </div>
-                    </button>
-                    
-                    
-                    <button
-                      aria-expanded="false"
-                      aria-haspopup="menu"
-                      aria-owns="v-menu-1"
-                      class="ml-2 user-info rounded-pill d-flex flex-row text-icon border-sm align-center justify-center"
-                      data-v-607bdd70=""
-                      targetref="[object Object]"
-                    >
-                      <div
-                        class="v-avatar v-theme--light v-avatar--density-default v-avatar--variant-flat avatar d-flex align-center text-font border-sm bg-primary"
-                        data-v-607bdd70=""
-                        style="width: 44px; height: 44px;"
-                      >
-                        
-                        
-                        <span
-                          data-v-607bdd70=""
-                        />
-                        
-                        
-                        
-                        <!---->
-                        <span
-                          class="v-avatar__underlay"
-                        />
-                        
-                      </div>
-                      <div
-                        class="d-flex flex-column justify-center text-right pa-1 pl-3 w-100"
-                        data-v-607bdd70=""
-                      >
-                        <i
-                          aria-hidden="true"
-                          class="v-icon notranslate v-theme--light v-icon--size-default ellipsis-icon"
-                          data-test="user-dropdown"
-                          data-v-607bdd70=""
-                        >
-                          <svg
-                            fill="none"
-                            height="4"
-                            viewBox="0 0 18 4"
-                            width="18"
-                            xmlns="http://www.w3.org/2000/svg"
+                          <g
+                            clip-path="url(#clip0_932_149)"
                           >
                             <path
                               clip-rule="evenodd"
-                              d="M2 0C3.10457 0 4 0.895431 4 2C4 3.10457 3.10457 4 2 4C0.895431 4 0 3.10457 0 2C0 0.895431 0.895431 0 2 0ZM9 0C10.1046 0 11 0.895431 11 2C11 3.10457 10.1046 4 9 4C7.89543 4 7 3.10457 7 2C7 0.895431 7.89543 0 9 0ZM18 2C18 0.895431 17.1046 0 16 0C14.8954 0 14 0.895431 14 2C14 3.10457 14.8954 4 16 4C17.1046 4 18 3.10457 18 2Z"
-                              fill="currentColor"
+                              d="M29.6 136.89C7.05 118.08 -2.7 92.78 0.64 66.02C3.97 39.35 29.88 -0.749964 56.89 0.0100358C106.62 20.82 -15.77 78.98 29.6 136.89Z"
+                              fill="url(#paint0_linear_932_149)"
                               fill-rule="evenodd"
                             />
-                          </svg>
-                        </i>
-                      </div>
-                    </button>
-                    
-                    <!---->
-                    
-                  </div>
+                            <path
+                              clip-rule="evenodd"
+                              d="M29.6 136.89C24.66 132.77 20.33 128.33 16.62 123.64C3.99 107.66 -1.48 88.69 0.339998 68.8C1.06 88.98 14.09 89.62 20.99 79.13V79.15C41.21 43.56 86.69 15.42 56.89 0.0100098C106.63 20.82 -15.77 78.98 29.6 136.89Z"
+                              fill="#2D0100"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M29.61 136.9C-15.79 78.98 106.67 20.8 56.87 0C60.92 0.11 64.99 1.14 69.02 3.27C77.12 7.55 81.67 16.94 81.29 28.86C80.18 64.11 50.09 75.76 39.88 103.39C36.49 112.58 36.08 121.65 38.65 130.61C39.38 133.13 38.47 135.74 36.36 137.21C34.25 138.68 31.58 138.56 29.6 136.91L29.61 136.9Z"
+                              fill="url(#paint1_linear_932_149)"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M29.61 136.9C-15.79 78.99 106.63 20.82 56.89 0.0100098C70.63 1.37001 77.6 14.24 75.77 26.29C70.7 59.76 29 71.47 28.59 110.64C28.49 119.81 31.09 128.67 36.37 137.21C34.26 138.68 31.59 138.56 29.61 136.91V136.9Z"
+                              fill="url(#paint2_linear_932_149)"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M108.38 12.96C130.93 31.77 140.68 57.06 137.34 83.82C134.01 110.49 108.1 150.59 81.09 149.83C31.36 129.02 153.75 70.86 108.38 12.96Z"
+                              fill="url(#paint3_linear_932_149)"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M108.38 12.96C113.32 17.08 117.65 21.52 121.36 26.21C133.99 42.18 139.46 61.15 137.64 81.04C136.92 60.86 123.89 60.22 116.99 70.71V70.69C96.77 106.28 51.29 134.43 81.09 149.83C31.36 129.02 153.75 70.86 108.38 12.96Z"
+                              fill="#2D0100"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M108.37 12.95C153.77 70.86 31.31 129.04 81.11 149.84C77.06 149.73 72.99 148.7 68.96 146.57C60.86 142.29 56.31 132.9 56.69 120.98C57.8 85.73 87.89 74.08 98.1 46.45C101.49 37.26 101.9 28.19 99.33 19.23C98.6 16.71 99.51 14.1 101.62 12.63C103.73 11.16 106.4 11.28 108.38 12.93L108.37 12.95Z"
+                              fill="url(#paint4_linear_932_149)"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M108.37 12.95C153.76 70.85 31.35 129.03 81.09 149.84C67.35 148.48 60.38 135.61 62.21 123.56C67.28 90.09 108.98 78.38 109.39 39.21C109.49 30.04 106.89 21.18 101.61 12.64C103.72 11.17 106.39 11.29 108.37 12.94V12.95Z"
+                              fill="url(#paint5_linear_932_149)"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M46.08 182.97C46.04 188.09 50.16 192.27 55.29 192.31C59.9 192.34 63.48 188.95 64.5 184.6C66.82 174.7 62.43 164.87 49.88 158.79C57.01 170.18 46.15 173.4 46.09 182.96L46.08 182.97Z"
+                              fill="url(#paint6_linear_932_149)"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M48.07 182.99C48.04 187.01 51.28 190.3 55.3 190.33C56.87 190.34 58.28 189.85 59.44 189C56.57 187.88 54.11 185.72 52.66 182.73C51.21 179.74 51.03 176.26 52.02 173.24C50.26 176.33 48.1 179.16 48.07 182.98V182.99Z"
+                              fill="url(#paint7_linear_932_149)"
+                              fill-rule="evenodd"
+                              opacity="0.5"
+                            />
+                          </g>
+                          <defs>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint0_linear_932_149"
+                              x1="-16.8153"
+                              x2="61.3369"
+                              y1="116.566"
+                              y2="-41.9949"
+                            >
+                              <stop
+                                stop-color="#1C2A39"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#7C8A99"
+                              />
+                            </lineargradient>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint1_linear_932_149"
+                              x1="11.8868"
+                              x2="75.9494"
+                              y1="87.02"
+                              y2="-30.1607"
+                            >
+                              <stop
+                                stop-color="#7C8A99"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#FEFEFE"
+                              />
+                            </lineargradient>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint2_linear_932_149"
+                              x1="19.31"
+                              x2="76.06"
+                              y1="69.12"
+                              y2="69.12"
+                            >
+                              <stop
+                                stop-color="#1C2A39"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#BCCAD9"
+                              />
+                            </lineargradient>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint3_linear_932_149"
+                              x1="160.483"
+                              x2="82.3302"
+                              y1="32.9545"
+                              y2="191.516"
+                            >
+                              <stop
+                                stop-color="#1C2A39"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#7C8A99"
+                              />
+                            </lineargradient>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint4_linear_932_149"
+                              x1="131.78"
+                              x2="67.7184"
+                              y1="62.5008"
+                              y2="179.682"
+                            >
+                              <stop
+                                stop-color="#7C8A99"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#FEFEFE"
+                              />
+                            </lineargradient>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint5_linear_932_149"
+                              x1="118.66"
+                              x2="61.92"
+                              y1="80.73"
+                              y2="80.73"
+                            >
+                              <stop
+                                stop-color="#1C2A39"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#BCCAD9"
+                              />
+                            </lineargradient>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint6_linear_932_149"
+                              x1="66.33"
+                              x2="38.1302"
+                              y1="185.538"
+                              y2="166.541"
+                            >
+                              <stop
+                                stop-color="#1C2A39"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#BCCAD9"
+                              />
+                            </lineargradient>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint7_linear_932_149"
+                              x1="48.07"
+                              x2="59.43"
+                              y1="181.79"
+                              y2="181.79"
+                            >
+                              <stop
+                                stop-color="#1C2A39"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#BCCAD9"
+                              />
+                            </lineargradient>
+                            <clippath
+                              id="clip0_932_149"
+                            >
+                              <rect
+                                fill="white"
+                                height="192.32"
+                                width="137.98"
+                              />
+                            </clippath>
+                          </defs>
+                        </svg>
+                      </i>
+                    </div>
+                     $t('menu.worldCafe')
+                  </a>
+                  <a
+                    class="item"
+                    data-v-d58c92bb=""
+                  >
+                    <div
+                      class="icon d-flex justify-center align-center"
+                      data-v-d58c92bb=""
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="v-icon notranslate v-theme--light v-icon--size-default w-100 cockpit"
+                        data-v-d58c92bb=""
+                      >
+                        <svg
+                          fill="none"
+                          height="176"
+                          viewBox="0 0 199 176"
+                          width="199"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <g
+                            clip-path="url(#clip0_932_164)"
+                          >
+                            <path
+                              clip-rule="evenodd"
+                              d="M114.97 173.44C150.48 163.92 197.5 127.82 198.21 73.86C198.52 50.4 187.26 48.27 182.97 56.91C181.13 60.62 180.98 64.24 180.14 67.95C177.14 81.18 165.8 87 153.69 80.23C146.63 76.28 138.07 68.51 127.45 56.28C112.25 38.92 78 64.72 110.87 91.07C118 98.01 122.48 103.77 124.92 108.48C139.8 134.22 138.6 163.82 114.97 173.44ZM165.84 29.6C175.36 34.5 179.11 46.19 174.21 55.71C169.31 65.23 157.62 68.98 148.1 64.08C138.58 59.18 134.83 47.49 139.73 37.97C144.63 28.45 156.32 24.7 165.84 29.6Z"
+                              fill="#3D4753"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M185.89 118.69C193.31 105.64 197.99 90.61 198.21 73.86C198.52 50.4 187.26 48.27 182.97 56.91C181.13 60.62 180.98 64.24 180.14 67.95C177.14 81.18 165.8 87 153.69 80.23C146.63 76.28 138.07 68.51 127.45 56.28C112.25 38.92 78 64.72 110.87 91.07C118 98.01 122.48 103.77 124.92 108.48C127.09 112.22 128.91 116.05 130.37 119.89C148.68 128.16 169.03 127.17 185.89 118.69ZM165.84 29.6C175.36 34.5 179.11 46.19 174.21 55.71C169.31 65.23 157.62 68.98 148.1 64.08C138.58 59.18 134.83 47.49 139.73 37.97C144.63 28.45 156.32 24.7 165.84 29.6Z"
+                              fill="url(#paint0_linear_932_164)"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M164.66 83.03C161.24 83.23 157.51 82.35 153.7 80.22C146.64 76.27 138.08 68.5 127.46 56.27C112.26 38.91 78.01 64.71 110.88 91.06C118.01 98 122.49 103.76 124.93 108.47C139.81 134.21 138.61 163.81 114.98 173.43C152.26 161.24 170.74 117.56 164.67 83.03H164.66Z"
+                              fill="url(#paint1_linear_932_164)"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M126.63 112.63C135.3 139.02 62.87 143.52 78.27 167.93C83.66 176.47 98 177.98 114.97 173.43C138.6 163.81 139.8 134.21 124.92 108.47C125.32 109.24 125.66 109.98 125.95 110.69C126.22 111.36 126.45 112 126.63 112.62V112.63Z"
+                              fill="#3D4753"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M126.63 112.63C128.19 117.39 127.11 121.43 124.39 125.01C132.94 143.69 131.33 163.08 114.97 173.43C138.6 163.81 139.8 134.21 124.92 108.47C125.32 109.24 125.66 109.98 125.95 110.69C126.22 111.36 126.45 112 126.63 112.62V112.63Z"
+                              fill="#0E215E"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M175.13 49.4501C176.21 41.9201 172.51 34.2001 165.36 30.5201C156.35 25.8801 145.29 29.4301 140.65 38.4401C136.41 46.6901 139.02 56.6501 146.4 61.8401C145.13 57.9801 145.35 53.6301 147.35 49.7401C151.32 42.0301 160.79 38.9901 168.5 42.9601C171.42 44.4701 173.68 46.7601 175.13 49.4501Z"
+                              fill="url(#paint2_linear_932_164)"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M83.25 2.51001C47.74 12.04 0.710003 48.13 3.42075e-06 102.1C-0.309997 125.55 10.95 127.69 15.24 119.05C17.08 115.34 17.23 111.72 18.07 108.01C21.07 94.78 32.41 88.96 44.52 95.73C51.58 99.68 60.14 107.45 70.76 119.68C85.96 137.04 120.21 111.24 87.34 84.89C80.21 77.95 75.73 72.19 73.29 67.48C58.41 41.74 59.61 12.14 83.24 2.52001L83.25 2.51001ZM32.38 146.35C22.86 141.45 19.11 129.76 24.01 120.24C28.91 110.72 40.6 106.97 50.12 111.87C59.64 116.77 63.39 128.46 58.49 137.99C53.59 147.51 41.9 151.26 32.38 146.36V146.35Z"
+                              fill="url(#paint3_linear_932_164)"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M12.33 57.27C4.91 70.31 0.230003 85.34 3.42075e-06 102.1C-0.309997 125.55 10.95 127.69 15.24 119.05C17.08 115.34 17.23 111.72 18.07 108.01C21.07 94.78 32.41 88.96 44.52 95.73C51.58 99.68 60.14 107.45 70.76 119.68C85.96 137.04 120.21 111.24 87.34 84.89C80.21 77.95 75.73 72.19 73.29 67.48C71.12 63.74 69.3 59.91 67.84 56.07C49.53 47.8 29.18 48.79 12.32 57.27H12.33ZM32.38 146.36C22.86 141.46 19.11 129.77 24.01 120.25C28.91 110.73 40.6 106.98 50.12 111.88C59.64 116.78 63.39 128.47 58.49 138C53.59 147.52 41.9 151.27 32.38 146.37V146.36Z"
+                              fill="url(#paint4_linear_932_164)"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M33.56 92.92C36.98 92.72 40.71 93.6 44.52 95.73C51.58 99.68 60.14 107.45 70.76 119.68C85.96 137.04 120.21 111.24 87.34 84.89C80.21 77.95 75.73 72.19 73.29 67.48C58.41 41.74 59.61 12.14 83.24 2.52002C45.97 14.7 27.49 58.38 33.56 92.92Z"
+                              fill="url(#paint5_linear_932_164)"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M71.58 63.32C62.91 36.93 135.34 32.43 119.94 8.02001C114.55 -0.519989 100.21 -2.02999 83.24 2.52001C59.61 12.14 58.41 41.74 73.29 67.48C72.89 66.71 72.55 65.97 72.26 65.26C71.99 64.59 71.76 63.95 71.58 63.33V63.32Z"
+                              fill="url(#paint6_linear_932_164)"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M71.58 63.32C70.02 58.56 71.1 54.52 73.82 50.94C65.27 32.26 66.88 12.87 83.24 2.52002C59.61 12.14 58.41 41.74 73.29 67.48C72.89 66.71 72.55 65.97 72.26 65.26C71.99 64.59 71.76 63.95 71.58 63.33V63.32Z"
+                              fill="url(#paint7_linear_932_164)"
+                              fill-rule="evenodd"
+                            />
+                            <path
+                              clip-rule="evenodd"
+                              d="M23.09 126.5C22.01 134.03 25.71 141.75 32.86 145.43C41.87 150.07 52.93 146.52 57.57 137.51C61.81 129.26 59.2 119.3 51.82 114.11C53.09 117.97 52.87 122.32 50.87 126.21C46.9 133.92 37.43 136.96 29.72 132.99C26.8 131.48 24.54 129.19 23.09 126.5Z"
+                              fill="url(#paint8_linear_932_164)"
+                              fill-rule="evenodd"
+                            />
+                          </g>
+                          <defs>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint0_linear_932_164"
+                              x1="97.08"
+                              x2="198.22"
+                              y1="76.52"
+                              y2="76.52"
+                            >
+                              <stop
+                                stop-color="#1C2A39"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#7C8A99"
+                              />
+                            </lineargradient>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint1_linear_932_164"
+                              x1="97.08"
+                              x2="165.79"
+                              y1="112.04"
+                              y2="112.04"
+                            >
+                              <stop
+                                stop-color="#1C2A39"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#7C8A99"
+                              />
+                            </lineargradient>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint2_linear_932_164"
+                              x1="138.61"
+                              x2="175.31"
+                              y1="45.1601"
+                              y2="45.1601"
+                            >
+                              <stop
+                                stop-color="#1C2A39"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#7C8A99"
+                              />
+                            </lineargradient>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint3_linear_932_164"
+                              x1="-21.8556"
+                              x2="51.1173"
+                              y1="117.802"
+                              y2="16.8919"
+                            >
+                              <stop
+                                stop-color="#1C2A39"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#BCCAD9"
+                              />
+                            </lineargradient>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint4_linear_932_164"
+                              x1="3.41999e-06"
+                              x2="101.14"
+                              y1="99.43"
+                              y2="99.43"
+                            >
+                              <stop
+                                stop-color="#7C8A99"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#FEFEFE"
+                              />
+                            </lineargradient>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint5_linear_932_164"
+                              x1="32.42"
+                              x2="1.00001"
+                              y1="63.92"
+                              y2="63.92"
+                            >
+                              <stop
+                                stop-color="#7C8A99"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#FEFEFE"
+                              />
+                            </lineargradient>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint6_linear_932_164"
+                              x1="34.9389"
+                              x2="87.84"
+                              y1="8.56541"
+                              y2="-25.5456"
+                            >
+                              <stop
+                                stop-color="#1C2A39"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#BCCAD9"
+                              />
+                            </lineargradient>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint7_linear_932_164"
+                              x1="63.53"
+                              x2="83.25"
+                              y1="34.99"
+                              y2="34.99"
+                            >
+                              <stop
+                                stop-color="#7C8A99"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#FEFEFE"
+                              />
+                            </lineargradient>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="paint8_linear_932_164"
+                              x1="22.9"
+                              x2="59.61"
+                              y1="130.79"
+                              y2="130.79"
+                            >
+                              <stop
+                                stop-color="#7C8A99"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#FEFEFE"
+                              />
+                            </lineargradient>
+                            <clippath
+                              id="clip0_932_164"
+                            >
+                              <rect
+                                fill="white"
+                                height="175.95"
+                                width="198.22"
+                              />
+                            </clippath>
+                          </defs>
+                        </svg>
+                      </i>
+                    </div>
+                     $t('menu.cockpit')
+                  </a>
+                  
+                </div>
+              </button>
+            </div>
+            <div
+              class="v-col d-none d-md-flex align-center"
+              data-v-e787b5f9=""
+            >
+              <div
+                class="v-row"
+                data-v-e787b5f9=""
+              >
+                <div
+                  class="v-col d-flex align-center"
+                  data-v-e787b5f9=""
+                >
+                  <button
+                    class="d-flex align-center justify-center light-dark-switch d-none d-lg-flex"
+                    data-v-e787b5f9=""
+                  >
+                    <svg
+                      fill="none"
+                      height="15"
+                      viewBox="0 0 28 15"
+                      width="28"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M7.63636 15C5.51515 15 3.71212 14.2708 2.22727 12.8125C0.742424 11.3542 0 9.58333 0 7.5C0 5.41667 0.742424 3.64583 2.22727 2.1875C3.71212 0.729167 5.51515 0 7.63636 0H20.3636C22.4848 0 24.2879 0.729167 25.7727 2.1875C27.2576 3.64583 28 5.41667 28 7.5C28 9.58333 27.2576 11.3542 25.7727 12.8125C24.2879 14.2708 22.4848 15 20.3636 15H7.63636ZM7.63636 12.5H20.3636C21.7636 12.5 22.9621 12.0104 23.9591 11.0312C24.9561 10.0521 25.4545 8.875 25.4545 7.5C25.4545 6.125 24.9561 4.94792 23.9591 3.96875C22.9621 2.98958 21.7636 2.5 20.3636 2.5H7.63636C6.23636 2.5 5.03788 2.98958 4.04091 3.96875C3.04394 4.94792 2.54545 6.125 2.54545 7.5C2.54545 8.875 3.04394 10.0521 4.04091 11.0312C5.03788 12.0104 6.23636 12.5 7.63636 12.5ZM7.63636 11.25C8.69697 11.25 9.59848 10.8854 10.3409 10.1562C11.0833 9.42708 11.4545 8.54167 11.4545 7.5C11.4545 6.45833 11.0833 5.57292 10.3409 4.84375C9.59848 4.11458 8.69697 3.75 7.63636 3.75C6.57576 3.75 5.67424 4.11458 4.93182 4.84375C4.18939 5.57292 3.81818 6.45833 3.81818 7.5C3.81818 8.54167 4.18939 9.42708 4.93182 10.1562C5.67424 10.8854 6.57576 11.25 7.63636 11.25Z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                    <svg
+                      fill="none"
+                      height="15"
+                      style="display: none;"
+                      viewBox="0 0 28 15"
+                      width="28"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M7.63636 15C5.51515 15 3.71212 14.2708 2.22727 12.8125C0.742424 11.3542 0 9.58333 0 7.5C0 5.41667 0.742424 3.64583 2.22727 2.1875C3.71212 0.729167 5.51515 0 7.63636 0H20.3636C22.4848 0 24.2879 0.729167 25.7727 2.1875C27.2576 3.64583 28 5.41667 28 7.5C28 9.58333 27.2576 11.3542 25.7727 12.8125C24.2879 14.2708 22.4848 15 20.3636 15H7.63636ZM7.63636 12.5H20.3636C21.7636 12.5 22.9621 12.0104 23.9591 11.0312C24.9561 10.0521 25.4545 8.875 25.4545 7.5C25.4545 6.125 24.9561 4.94792 23.9591 3.96875C22.9621 2.98958 21.7636 2.5 20.3636 2.5H7.63636C6.23636 2.5 5.03788 2.98958 4.04091 3.96875C3.04394 4.94792 2.54545 6.125 2.54545 7.5C2.54545 8.875 3.04394 10.0521 4.04091 11.0312C5.03788 12.0104 6.23636 12.5 7.63636 12.5ZM20.3636 11.25C21.4242 11.25 22.3258 10.8854 23.0682 10.1562C23.8106 9.42708 24.1818 8.54167 24.1818 7.5C24.1818 6.45833 23.8106 5.57292 23.0682 4.84375C22.3258 4.11458 21.4242 3.75 20.3636 3.75C19.303 3.75 18.4015 4.11458 17.6591 4.84375C16.9167 5.57292 16.5455 6.45833 16.5455 7.5C16.5455 8.54167 16.9167 9.42708 17.6591 10.1562C18.4015 10.8854 19.303 11.25 20.3636 11.25Z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                    <span
+                      class="ml-2"
+                    >
+                      $t('menu.theme.light') / $t('menu.theme.dark')
+                    </span>
+                  </button>
+                </div>
+                <div
+                  class="v-col d-flex align-center justify-end"
+                  data-v-e787b5f9=""
+                >
+                  <button
+                    data-v-e787b5f9=""
+                  >
+                    <div
+                      class="circle rounded-circle border-sm text-icon pa-2 d-flex justify-center align-center"
+                      data-v-39e8094e=""
+                      data-v-e787b5f9=""
+                    >
+                      
+                      <i
+                        aria-hidden="true"
+                        class="v-icon notranslate v-theme--light v-icon--size-default"
+                        data-v-e787b5f9=""
+                      >
+                        <svg
+                          fill="none"
+                          height="17"
+                          viewBox="0 0 21 17"
+                          width="21"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M7.68844 12.4824H9.66834V9.51172H12.6382V7.53125H9.66834V4.56055H7.68844V7.53125H4.71859V9.51172H7.68844V12.4824ZM2.73869 16.4434C2.19422 16.4434 1.72812 16.2494 1.34038 15.8616C0.952654 15.4738 0.758789 15.0075 0.758789 14.4629V2.58008C0.758789 2.03545 0.952654 1.56921 1.34038 1.18137C1.72812 0.79353 2.19422 0.599609 2.73869 0.599609H14.6181C15.1626 0.599609 15.6287 0.79353 16.0164 1.18137C16.4041 1.56921 16.598 2.03545 16.598 2.58008V7.03613L20.5578 3.0752V13.9678L16.598 10.0068V14.4629C16.598 15.0075 16.4041 15.4738 16.0164 15.8616C15.6287 16.2494 15.1626 16.4434 14.6181 16.4434H2.73869ZM2.73869 14.4629H14.6181V2.58008H2.73869V14.4629Z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                      </i>
+                      
+                    </div>
+                  </button>
+                  
+                  
+                  <button
+                    aria-expanded="false"
+                    aria-haspopup="menu"
+                    aria-owns="v-menu-1"
+                    class="ml-2 user-info rounded-pill d-flex flex-row text-icon border-sm align-center justify-center"
+                    data-v-607bdd70=""
+                    targetref="[object Object]"
+                  >
+                    <div
+                      class="v-avatar v-theme--light v-avatar--density-default v-avatar--variant-flat avatar d-flex align-center text-font border-sm bg-primary"
+                      data-v-607bdd70=""
+                      style="width: 44px; height: 44px;"
+                    >
+                      
+                      
+                      <span
+                        data-v-607bdd70=""
+                      />
+                      
+                      
+                      
+                      <!---->
+                      <span
+                        class="v-avatar__underlay"
+                      />
+                      
+                    </div>
+                    <div
+                      class="d-flex flex-column justify-center text-right pa-1 pl-3 w-100"
+                      data-v-607bdd70=""
+                    >
+                      <i
+                        aria-hidden="true"
+                        class="v-icon notranslate v-theme--light v-icon--size-default ellipsis-icon"
+                        data-test="user-dropdown"
+                        data-v-607bdd70=""
+                      >
+                        <svg
+                          fill="none"
+                          height="4"
+                          viewBox="0 0 18 4"
+                          width="18"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M2 0C3.10457 0 4 0.895431 4 2C4 3.10457 3.10457 4 2 4C0.895431 4 0 3.10457 0 2C0 0.895431 0.895431 0 2 0ZM9 0C10.1046 0 11 0.895431 11 2C11 3.10457 10.1046 4 9 4C7.89543 4 7 3.10457 7 2C7 0.895431 7.89543 0 9 0ZM18 2C18 0.895431 17.1046 0 16 0C14.8954 0 14 0.895431 14 2C14 3.10457 14.8954 4 16 4C17.1046 4 18 3.10457 18 2Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </i>
+                    </div>
+                  </button>
+                  
+                  <!---->
+                  
                 </div>
               </div>
             </div>
-            
-            <!---->
           </div>
           
-          
-          <transition-stub
-            appear="false"
-            css="true"
-            name="expand-transition"
-            persisted="false"
-          >
-            <!---->
-          </transition-stub>
-          
-        </header>
-      </div>
+          <!---->
+        </div>
+        
+        
+        <transition-stub
+          appear="false"
+          css="true"
+          name="expand-transition"
+          persisted="false"
+        >
+          <!---->
+        </transition-stub>
+        
+      </header>
       
       <nav
-        class="v-navigation-drawer v-navigation-drawer--right v-navigation-drawer--temporary v-theme--light v-navigation-drawer--mobile menu-drawer px-4"
+        class="v-navigation-drawer v-navigation-drawer--right v-navigation-drawer--temporary v-theme--light v-navigation-drawer--mobile menu-drawer px-4 hide-on-mobile"
         data-v-cf2c9067=""
         style="right: 0px; z-index: 1006; transform: translateX(110%); position: fixed; transition: none !important; height: calc(100% - 70px - 0px); top: 70px; bottom: 0px;"
       >

--- a/frontend/src/pages/room/__snapshots__/Page.test.ts.snap
+++ b/frontend/src/pages/room/__snapshots__/Page.test.ts.snap
@@ -879,7 +879,7 @@ exports[`Room Page > renders 1`] = `
                     
                     <i
                       aria-hidden="false"
-                      aria-label="$vuetify.input.clear"
+                      aria-label="Löschen"
                       class="mdi-close-circle mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable"
                       role="button"
                       tabindex="0"
@@ -1105,7 +1105,7 @@ exports[`Room Page > renders 1`] = `
                     
                     <i
                       aria-hidden="false"
-                      aria-label="$vuetify.input.clear"
+                      aria-label="Löschen"
                       class="mdi-close-circle mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable"
                       role="button"
                       tabindex="0"


### PR DESCRIPTION
## 🍰 Pullrequest
Styles the open tables drawer according to Figma. Also adds messages in case of no open tables or no search results.

<img width="443" alt="Screenshot 2024-07-19 at 16 13 28" src="https://github.com/user-attachments/assets/bef17a3f-fd6a-43c9-981b-906be45b0344">
<img width="317" alt="Screenshot 2024-07-19 at 16 14 01" src="https://github.com/user-attachments/assets/0034957e-7998-4ff1-be30-48a2386feb0f">
<img width="266" alt="Screenshot 2024-07-19 at 16 14 52" src="https://github.com/user-attachments/assets/347e78fe-3096-438c-813f-816215463309">
<img width="261" alt="Screenshot 2024-07-19 at 16 19 43" src="https://github.com/user-attachments/assets/282f111e-c440-4235-afab-086710d7d9dc">

Also fixes these warnings: 
![Uploading Screenshot 2024-07-19 at 17.07.44.png…]()


### Issues
- fixes #1171 

### Todo
- [x] Set border color of search field depending on theme
- [x] Check colors - there should be a contrast on mobile?
- [x] Participants like in Figma (https://www.figma.com/design/nkCyyDFx7fGeBnguwpardz/Dreammall-pr%C3%A4si?node-id=3359-32946&m=dev)
- [ ] Ability to drag down on mobile would be nice. Should work, but doesn't (https://github.com/vuetifyjs/vuetify/issues/10713) - Let's do it later (#1456)
- [x] Tests