### PR TITLE
fix(frontend): pass required props to message and news indicator in tests

### DIFF
--- a/frontend/src/components/menu/MessageIndicator.test.ts
+++ b/frontend/src/components/menu/MessageIndicator.test.ts
@@ -1,12 +1,11 @@
 import { mount } from '@vue/test-utils'
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { h } from 'vue'
 
 import MessageIndicator from './MessageIndicator.vue'
 
 describe('MessageIndicator', () => {
   const Wrapper = () => {
-    return mount(h(MessageIndicator, { numberOfMessages: 1 }))
+    return mount(MessageIndicator, { props: { numberOfMessages: 1 } })
   }
 
   let wrapper: ReturnType<typeof Wrapper>

--- a/frontend/src/components/menu/MessageIndicator.test.ts
+++ b/frontend/src/components/menu/MessageIndicator.test.ts
@@ -1,29 +1,36 @@
 import { mount } from '@vue/test-utils'
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, afterEach } from 'vitest'
 
 import MessageIndicator from './MessageIndicator.vue'
 
 describe('MessageIndicator', () => {
-  const Wrapper = () => {
-    return mount(MessageIndicator, { props: { numberOfMessages: 1 } })
+  const Wrapper = (options = { props: { numberOfMessages: 1 } }) => {
+    return mount(MessageIndicator, options)
   }
 
   let wrapper: ReturnType<typeof Wrapper>
-
-  beforeEach(() => {
-    wrapper = Wrapper()
-  })
 
   afterEach(() => {
     wrapper.unmount()
   })
 
-  it('renders', () => {
+  it('renders with 1 message', () => {
+    wrapper = Wrapper()
+    expect(wrapper.element).toMatchSnapshot()
+  })
+
+  it('renders with 2 messages', () => {
+    wrapper = Wrapper({ props: { numberOfMessages: 2 } })
+    expect(wrapper.element).toMatchSnapshot()
+  })
+
+  it('renders with 0 messages', () => {
+    wrapper = Wrapper({ props: { numberOfMessages: 2 } })
     expect(wrapper.element).toMatchSnapshot()
   })
 
   it('displays the number of messages', async () => {
-    await wrapper.setProps({ numberOfMessages: 1 })
+    wrapper = Wrapper()
     expect(wrapper.text()).toContain('1')
     await wrapper.setProps({ numberOfMessages: 5 })
     expect(wrapper.text()).toContain('5')

--- a/frontend/src/components/menu/MessageIndicator.test.ts
+++ b/frontend/src/components/menu/MessageIndicator.test.ts
@@ -1,11 +1,12 @@
 import { mount } from '@vue/test-utils'
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { h } from 'vue'
 
 import MessageIndicator from './MessageIndicator.vue'
 
-describe('LogoImage', () => {
+describe('MessageIndicator', () => {
   const Wrapper = () => {
-    return mount(MessageIndicator, { numberOfMessages: 1 })
+    return mount(h(MessageIndicator, { numberOfMessages: 1 }))
   }
 
   let wrapper: ReturnType<typeof Wrapper>

--- a/frontend/src/components/menu/MessageIndicator.test.ts
+++ b/frontend/src/components/menu/MessageIndicator.test.ts
@@ -25,7 +25,7 @@ describe('MessageIndicator', () => {
   })
 
   it('renders with 0 messages', () => {
-    wrapper = Wrapper({ props: { numberOfMessages: 2 } })
+    wrapper = Wrapper({ props: { numberOfMessages: 0 } })
     expect(wrapper.element).toMatchSnapshot()
   })
 

--- a/frontend/src/components/menu/MessageIndicator.test.ts
+++ b/frontend/src/components/menu/MessageIndicator.test.ts
@@ -5,7 +5,7 @@ import MessageIndicator from './MessageIndicator.vue'
 
 describe('LogoImage', () => {
   const Wrapper = () => {
-    return mount(MessageIndicator)
+    return mount(MessageIndicator, { numberOfMessages: 1 })
   }
 
   let wrapper: ReturnType<typeof Wrapper>

--- a/frontend/src/components/menu/NewsIndicator.test.ts
+++ b/frontend/src/components/menu/NewsIndicator.test.ts
@@ -5,7 +5,7 @@ import NewsIndicator from './NewsIndicator.vue'
 
 describe('LogoImage', () => {
   const Wrapper = () => {
-    return mount(NewsIndicator)
+    return mount(NewsIndicator, { hasNews: true })
   }
 
   let wrapper: ReturnType<typeof Wrapper>

--- a/frontend/src/components/menu/NewsIndicator.test.ts
+++ b/frontend/src/components/menu/NewsIndicator.test.ts
@@ -1,11 +1,12 @@
 import { mount } from '@vue/test-utils'
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { h } from 'vue'
 
 import NewsIndicator from './NewsIndicator.vue'
 
-describe('LogoImage', () => {
+describe('NewsIndicator', () => {
   const Wrapper = () => {
-    return mount(NewsIndicator, { hasNews: true })
+    return mount(h(NewsIndicator, { hasNews: true }))
   }
 
   let wrapper: ReturnType<typeof Wrapper>

--- a/frontend/src/components/menu/NewsIndicator.test.ts
+++ b/frontend/src/components/menu/NewsIndicator.test.ts
@@ -1,24 +1,26 @@
 import { mount } from '@vue/test-utils'
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, afterEach } from 'vitest'
 
 import NewsIndicator from './NewsIndicator.vue'
 
 describe('NewsIndicator', () => {
-  const Wrapper = () => {
-    return mount(NewsIndicator, { props: { hasNews: true } })
+  const Wrapper = (options = { props: { hasNews: true } }) => {
+    return mount(NewsIndicator, options)
   }
 
   let wrapper: ReturnType<typeof Wrapper>
-
-  beforeEach(() => {
-    wrapper = Wrapper()
-  })
 
   afterEach(() => {
     wrapper.unmount()
   })
 
-  it('renders', () => {
+  it('renders with news', () => {
+    wrapper = Wrapper()
+    expect(wrapper.element).toMatchSnapshot()
+  })
+
+  it('renders without news', () => {
+    wrapper = Wrapper({ props: { hasNews: false } })
     expect(wrapper.element).toMatchSnapshot()
   })
 })

--- a/frontend/src/components/menu/NewsIndicator.test.ts
+++ b/frontend/src/components/menu/NewsIndicator.test.ts
@@ -1,12 +1,11 @@
 import { mount } from '@vue/test-utils'
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { h } from 'vue'
 
 import NewsIndicator from './NewsIndicator.vue'
 
 describe('NewsIndicator', () => {
   const Wrapper = () => {
-    return mount(h(NewsIndicator, { hasNews: true }))
+    return mount(NewsIndicator, { props: { hasNews: true } })
   }
 
   let wrapper: ReturnType<typeof Wrapper>

--- a/frontend/src/components/menu/__snapshots__/MessageIndicator.test.ts.snap
+++ b/frontend/src/components/menu/__snapshots__/MessageIndicator.test.ts.snap
@@ -33,10 +33,10 @@ exports[`MessageIndicator > renders with 0 messages 1`] = `
   </div>
   <div
     class="count d-flex justify-center align-center"
-    data-show-count="true"
+    data-show-count="false"
     data-v-6b63f7d9=""
   >
-    2
+    0
   </div>
 </div>
 `;

--- a/frontend/src/components/menu/__snapshots__/MessageIndicator.test.ts.snap
+++ b/frontend/src/components/menu/__snapshots__/MessageIndicator.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`LogoImage > renders 1`] = `
+exports[`MessageIndicator > renders 1`] = `
 <div
   class="message-indicator"
   data-v-6b63f7d9=""

--- a/frontend/src/components/menu/__snapshots__/MessageIndicator.test.ts.snap
+++ b/frontend/src/components/menu/__snapshots__/MessageIndicator.test.ts.snap
@@ -33,8 +33,10 @@ exports[`MessageIndicator > renders 1`] = `
   </div>
   <div
     class="count d-flex justify-center align-center"
-    data-show-count="false"
+    data-show-count="true"
     data-v-6b63f7d9=""
-  />
+  >
+    1
+  </div>
 </div>
 `;

--- a/frontend/src/components/menu/__snapshots__/MessageIndicator.test.ts.snap
+++ b/frontend/src/components/menu/__snapshots__/MessageIndicator.test.ts.snap
@@ -1,6 +1,47 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`MessageIndicator > renders 1`] = `
+exports[`MessageIndicator > renders with 0 messages 1`] = `
+<div
+  class="message-indicator"
+  data-v-6b63f7d9=""
+>
+  <div
+    class="circle rounded-circle border-sm text-icon pa-2 d-flex justify-center align-center"
+    data-v-39e8094e=""
+    data-v-6b63f7d9=""
+  >
+    
+    <i
+      aria-hidden="true"
+      class="v-icon notranslate v-theme--light v-icon--size-default"
+      data-v-6b63f7d9=""
+    >
+      <svg
+        fill="none"
+        height="20"
+        viewBox="0 0 20 20"
+        width="20"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M17.6199 4.28609H16.6675V11.9051C16.6675 12.4289 16.239 12.8575 15.7151 12.8575H4.28657V13.8099C4.28657 14.8575 5.14372 15.7147 6.19134 15.7147H15.7151L19.5247 19.5242V6.19085C19.5247 5.14323 18.6675 4.28609 17.6199 4.28609ZM14.7628 9.04799V2.38132C14.7628 1.33371 13.9056 0.476562 12.858 0.476562H2.38181C1.33419 0.476562 0.477051 1.33371 0.477051 2.38132V14.7623L4.28657 10.9528H12.858C13.9056 10.9528 14.7628 10.0956 14.7628 9.04799Z"
+          fill="currentColor"
+        />
+      </svg>
+    </i>
+    
+  </div>
+  <div
+    class="count d-flex justify-center align-center"
+    data-show-count="true"
+    data-v-6b63f7d9=""
+  >
+    2
+  </div>
+</div>
+`;
+
+exports[`MessageIndicator > renders with 1 message 1`] = `
 <div
   class="message-indicator"
   data-v-6b63f7d9=""
@@ -37,6 +78,47 @@ exports[`MessageIndicator > renders 1`] = `
     data-v-6b63f7d9=""
   >
     1
+  </div>
+</div>
+`;
+
+exports[`MessageIndicator > renders with 2 messages 1`] = `
+<div
+  class="message-indicator"
+  data-v-6b63f7d9=""
+>
+  <div
+    class="circle rounded-circle border-sm text-icon pa-2 d-flex justify-center align-center"
+    data-v-39e8094e=""
+    data-v-6b63f7d9=""
+  >
+    
+    <i
+      aria-hidden="true"
+      class="v-icon notranslate v-theme--light v-icon--size-default"
+      data-v-6b63f7d9=""
+    >
+      <svg
+        fill="none"
+        height="20"
+        viewBox="0 0 20 20"
+        width="20"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M17.6199 4.28609H16.6675V11.9051C16.6675 12.4289 16.239 12.8575 15.7151 12.8575H4.28657V13.8099C4.28657 14.8575 5.14372 15.7147 6.19134 15.7147H15.7151L19.5247 19.5242V6.19085C19.5247 5.14323 18.6675 4.28609 17.6199 4.28609ZM14.7628 9.04799V2.38132C14.7628 1.33371 13.9056 0.476562 12.858 0.476562H2.38181C1.33419 0.476562 0.477051 1.33371 0.477051 2.38132V14.7623L4.28657 10.9528H12.858C13.9056 10.9528 14.7628 10.0956 14.7628 9.04799Z"
+          fill="currentColor"
+        />
+      </svg>
+    </i>
+    
+  </div>
+  <div
+    class="count d-flex justify-center align-center"
+    data-show-count="true"
+    data-v-6b63f7d9=""
+  >
+    2
   </div>
 </div>
 `;

--- a/frontend/src/components/menu/__snapshots__/NewsIndicator.test.ts.snap
+++ b/frontend/src/components/menu/__snapshots__/NewsIndicator.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`NewsIndicator > renders 1`] = `
+exports[`NewsIndicator > renders with news 1`] = `
 <div
   class="news-indicator"
   data-v-5cc937bd=""
@@ -34,6 +34,45 @@ exports[`NewsIndicator > renders 1`] = `
   <div
     class="marker d-flex justify-center align-center rounded-circle"
     data-show-marker="true"
+    data-v-5cc937bd=""
+  />
+</div>
+`;
+
+exports[`NewsIndicator > renders without news 1`] = `
+<div
+  class="news-indicator"
+  data-v-5cc937bd=""
+>
+  <div
+    class="circle rounded-circle border-sm text-icon pa-2 d-flex justify-center align-center"
+    data-v-39e8094e=""
+    data-v-5cc937bd=""
+  >
+    
+    <i
+      aria-hidden="true"
+      class="v-icon notranslate v-theme--light v-icon--size-default"
+      data-v-5cc937bd=""
+    >
+      <svg
+        fill="none"
+        height="20"
+        viewBox="0 0 16 20"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M0.381348 16.7172V14.8088H2.28971V8.12956C2.28971 6.80961 2.68729 5.63676 3.48244 4.61101C4.2776 3.58526 5.31129 2.91336 6.58354 2.5953V1.92737C6.58354 1.52979 6.72269 1.19185 7.00099 0.913549C7.2793 0.635245 7.61724 0.496094 8.01481 0.496094C8.41239 0.496094 8.75033 0.635245 9.02863 0.913549C9.30694 1.19185 9.44609 1.52979 9.44609 1.92737V2.5953C10.7183 2.91336 11.752 3.58526 12.5472 4.61101C13.3423 5.63676 13.7399 6.80961 13.7399 8.12956V14.8088H15.6483V16.7172H0.381348ZM8.01481 19.5798C7.49001 19.5798 7.04075 19.3929 6.66703 19.0192C6.29331 18.6455 6.10645 18.1962 6.10645 17.6714H9.92318C9.92318 18.1962 9.73632 18.6455 9.3626 19.0192C8.98888 19.3929 8.53961 19.5798 8.01481 19.5798ZM4.19808 14.8088H11.8315V8.12956C11.8315 7.07996 11.4578 6.18143 10.7104 5.43399C9.96294 4.68655 9.06441 4.31283 8.01481 4.31283C6.96521 4.31283 6.06669 4.68655 5.31925 5.43399C4.5718 6.18143 4.19808 7.07996 4.19808 8.12956V14.8088Z"
+          fill="currentColor"
+        />
+      </svg>
+    </i>
+    
+  </div>
+  <div
+    class="marker d-flex justify-center align-center rounded-circle"
+    data-show-marker="false"
     data-v-5cc937bd=""
   />
 </div>

--- a/frontend/src/components/menu/__snapshots__/NewsIndicator.test.ts.snap
+++ b/frontend/src/components/menu/__snapshots__/NewsIndicator.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`LogoImage > renders 1`] = `
+exports[`NewsIndicator > renders 1`] = `
 <div
   class="news-indicator"
   data-v-5cc937bd=""

--- a/frontend/src/components/menu/__snapshots__/NewsIndicator.test.ts.snap
+++ b/frontend/src/components/menu/__snapshots__/NewsIndicator.test.ts.snap
@@ -33,7 +33,7 @@ exports[`NewsIndicator > renders 1`] = `
   </div>
   <div
     class="marker d-flex justify-center align-center rounded-circle"
-    data-show-marker="false"
+    data-show-marker="true"
     data-v-5cc937bd=""
   />
 </div>


### PR DESCRIPTION
## 🍰 Pullrequest
Makes those little warnings go away:

<img width="567" alt="Screenshot 2024-07-12 at 13 22 12" src="https://github.com/user-attachments/assets/890487d2-27d6-4bdf-9331-d6b92c480cda">
<img width="738" alt="Screenshot 2024-07-12 at 13 22 19" src="https://github.com/user-attachments/assets/56dd0152-31b3-4546-a775-2f34aca1a47c">

Also corrects the components' names.