### PR TITLE
refactor(frontend): unauthenticated redirect to signin page

### DIFF
--- a/frontend/.env.dist
+++ b/frontend/.env.dist
@@ -7,7 +7,6 @@ PUBLIC_ENV__AUTH__REDIRECT_URI="http://localhost:3000/auth"
 PUBLIC_ENV__AUTH__SILENT_REDIRECT_URI="http://localhost:3000/silent-refresh"
 PUBLIC_ENV__AUTH__RESPONSE_TYPE="code"
 PUBLIC_ENV__AUTH__SCOPE="openid profile posts"
-PUBLIC_ENV__AUTH__UNAUTHORIZED_REDIRECT_URI="http://localhost:3001/"
 PUBLIC_ENV__AUTH__ADMIN_GROUP="authentik Admins"
 PUBLIC_ENV__AUTH__ADMIN_REDIRECT_URI="http://localhost:3002/signin"
 

--- a/frontend/renderer/plugins/apollo.ts
+++ b/frontend/renderer/plugins/apollo.ts
@@ -7,8 +7,9 @@ import { GraphQLWsLink } from '@apollo/client/link/subscriptions'
 import { getMainDefinition } from '@apollo/client/utilities'
 import { createClient } from 'graphql-ws'
 import { WebSocket } from 'ws'
+import { navigate } from 'vike/client/router'
 
-import { ENDPOINTS, AUTH } from '#src/env'
+import { ENDPOINTS } from '#src/env'
 
 const createAuthLink = (getToken: () => string) => {
   return setContext((_, { headers }) => {
@@ -50,7 +51,7 @@ const errorLink = onError(({ graphQLErrors }) => {
   if (graphQLErrors) {
     graphQLErrors.forEach(({ extensions }) => {
       if (extensions.code === 'UNAUTHENTICATED') {
-        window.location.href = AUTH.UNAUTHORIZED_REDIRECT_URI
+        navigate('/signin')
       }
     })
   }

--- a/frontend/renderer/plugins/apollo.ts
+++ b/frontend/renderer/plugins/apollo.ts
@@ -6,8 +6,8 @@ import { createHttpLink } from '@apollo/client/link/http'
 import { GraphQLWsLink } from '@apollo/client/link/subscriptions'
 import { getMainDefinition } from '@apollo/client/utilities'
 import { createClient } from 'graphql-ws'
-import { WebSocket } from 'ws'
 import { navigate } from 'vike/client/router'
+import { WebSocket } from 'ws'
 
 import { ENDPOINTS } from '#src/env'
 
@@ -51,7 +51,7 @@ const errorLink = onError(({ graphQLErrors }) => {
   if (graphQLErrors) {
     graphQLErrors.forEach(({ extensions }) => {
       if (extensions.code === 'UNAUTHENTICATED') {
-        navigate('/signin')
+        void navigate('/signin')
       }
     })
   }

--- a/frontend/src/env.ts
+++ b/frontend/src/env.ts
@@ -13,8 +13,6 @@ const AUTH = {
     'http://localhost:3001/silent-refresh') as string,
   RESPONSE_TYPE: (import.meta.env.PUBLIC_ENV__AUTH__RESPONSE_TYPE ?? 'code') as string,
   SCOPE: (import.meta.env.PUBLIC_ENV__AUTH__SCOPE ?? 'openid profile posts') as string,
-  UNAUTHORIZED_REDIRECT_URI: (import.meta.env.PUBLIC_ENV__AUTH__UNAUTHORIZED_REDIRECT_URI ??
-    'http://localhost:3001/') as string,
   ADMIN_GROUP: (import.meta.env.PUBLIC_ENV__AUTH__ADMIN_GROUP ?? 'authentik Admins') as string,
   ADMIN_REDIRECT_URI: (import.meta.env.PUBLIC_ENV__AUTH__ADMIN_REDIRECT_URI ??
     'http://localhost:3002/signin') as string,

--- a/frontend/src/pages/+guard.ts
+++ b/frontend/src/pages/+guard.ts
@@ -1,7 +1,6 @@
 import { redirect } from 'vike/abort'
 
 import pinia from '#plugins/pinia'
-import { AUTH } from '#src/env'
 import { useAuthStore } from '#stores/authStore'
 
 import type { GuardSync } from 'vike/types'
@@ -11,7 +10,7 @@ const guard: GuardSync = (pageContext): ReturnType<GuardSync> => {
   // there might be a better solution to combine both into pageContext
   const authStore = useAuthStore(pinia)
   if (!pageContext.hasToken && !authStore.isLoggedIn) {
-    throw redirect(AUTH.UNAUTHORIZED_REDIRECT_URI)
+    throw redirect('/signin')
   }
 }
 

--- a/frontend/src/pages/Guard.spec.ts
+++ b/frontend/src/pages/Guard.spec.ts
@@ -2,12 +2,9 @@ import { redirect } from 'vike/abort'
 import { PageContextServer } from 'vike/types'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-import { AUTH } from '#src/env'
 import { useAuthStore } from '#stores/authStore.js'
 
 import { guard } from './+guard'
-
-AUTH.UNAUTHORIZED_REDIRECT_URI = 'https://some.uri'
 
 vi.mock('vike/abort')
 vi.mocked(redirect).mockResolvedValue(new Error(''))
@@ -22,7 +19,7 @@ describe('global route guard', () => {
       try {
         expect(guard({ hasToken: false } as PageContextServer)).toThrow()
       } catch (error) {
-        expect(redirect).toBeCalledWith('https://some.uri')
+        expect(redirect).toBeCalledWith('/signin')
       }
     })
   })


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

How to test guard:
 * Logout
 * navigate to localhost:3000
 * you should end up on the authentik signin page

How to test global error handler
 * in `backend/src/auth/authChecker.ts` line 38 `return false`
 * Login via the presenter
 * you should end up in an endless loop between authentik and the app, as the open room query always throws an unauthenticated error

### Issues
- fixes #1449

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
