### PR TITLE
fix(frontend): same site attribute on auth cookie

### DIFF
--- a/frontend/src/stores/authStore.spec.ts
+++ b/frontend/src/stores/authStore.spec.ts
@@ -84,6 +84,7 @@ describe('Auth Store', () => {
         expect(setCookieSpy).toBeCalledWith('auth', 'state', {
           expires: 3,
           Secure: true,
+          SameSite: 'None',
         })
       })
     })

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -10,6 +10,7 @@ export const cookieStorage = {
     Cookies.set('auth', state, {
       expires: 3,
       Secure: true,
+      SameSite: 'None',
     })
   },
   // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Motivation

In firefox. there is a warning that the same site attribute is missing on the auth cookie. This may lead to the authentication problems on production for firefox users.

This PR sets same site attribute to none to fix this warning.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
