### PR TITLE
fix(frontend): production build

### DIFF
--- a/frontend/server/index.ts
+++ b/frontend/server/index.ts
@@ -52,7 +52,6 @@ async function startServer() {
         gzip: true,
       }),
     )
-    /*
     // cache things for 10min
     app.use(
       sirv(`${root}/build/client`, {
@@ -61,7 +60,6 @@ async function startServer() {
         gzip: true,
       }),
     )
-    */
   } else {
     // We instantiate Vite's development server and integrate its middleware to our server.
     // ⚠️ We instantiate it only in development. (It isn't needed in production and it


### PR DESCRIPTION
Motivation
----------
Side quest of #1451.

The frontend production build for docker was broken in fd41310641a4014b7f0935de69824cab862fd920.

```
> dreammall-frontend@1.0.0 server:prod
> cross-env NODE_ENV=production node ./build/index.cjs

🚀 Server running at http://localhost:3000
Error: [@brillout/vite-plugin-server-entry@0.4.5][Wrong Usage] Cannot find server entry. (Re-)build your app and try again. If you still get this error, then you may need to manually import the server entry, see https://github.com/brillout/vite-plugin-server-entry#manual-import
    at importServerEntry (/app/node_modules/@brillout/vite-plugin-server-entry/dist/importServerEntry/index.js:51:29)
    at async loadImportBuild (/app/node_modules/vike/dist/cjs/node/runtime/globalContext/loadImportBuild.js:15:9)
    at async initGlobalContext (/app/node_modules/vike/dist/cjs/node/runtime/globalContext.js:111:30)
    at async renderPageAndPrepare (/app/node_modules/vike/dist/cjs/node/runtime/renderPage.js:70:9)
    at async renderPage_wrapper (/app/node_modules/vike/dist/cjs/node/runtime/renderPage.js:30:24)
    at async renderPage (/app/node_modules/vike/dist/cjs/node/runtime/renderPage.js:50:35)
    at async /app/build/index.cjs:2:1329
Error: [@brillout/vite-plugin-server-entry@0.4.5][Wrong Usage] Cannot find server entry. (Re-)build your app and try again. If you still get this error, then you may need to manually import the server entry, see https://github.com/brillout/vite-plugin-server-entry#manual-import
    at importServerEntry (/app/node_modules/@brillout/vite-plugin-server-entry/dist/importServerEntry/index.js:51:29)
    at async loadImportBuild (/app/node_modules/vike/dist/cjs/node/runtime/globalContext/loadImportBuild.js:15:9)
    at async initGlobalContext (/app/node_modules/vike/dist/cjs/node/runtime/globalContext.js:111:30)
    at async renderPageAndPrepare (/app/node_modules/vike/dist/cjs/node/runtime/renderPage.js:70:9)
    at async renderPage_wrapper (/app/node_modules/vike/dist/cjs/node/runtime/renderPage.js:30:24)
    at async renderPage (/app/node_modules/vike/dist/cjs/node/runtime/renderPage.js:50:35)
    at async /app/build/index.cjs:2:1329
```

How to test
-----------
1. `docker compose -f docker-compose.yml build frontend --no-cache`
2. `docker run --rm -p "3000:3000" dreammallearth-frontend`
3. Visit <http://localhost:3000/>
4. On `origin/master` you will see the error, on this feature branch it's fixed

