### PR TITLE
fix(backend): endless redirects

### DIFF
--- a/backend/src/auth/authChecker.spec.ts
+++ b/backend/src/auth/authChecker.spec.ts
@@ -70,11 +70,12 @@ describe('authChecker', () => {
       } as unknown as typeof prisma
 
       it('resolves to "INTERNAL_SERVER_ERROR" instead of "UNAUTHENTICATED"', async () => {
-        const [request, opts] = [
-          { query: 'mutation { joinMyRoom }' },
-          { contextValue: { token: 'token', dataSources: { prisma: failingPrisma } } },
-        ]
-        const expected = {
+        await expect(
+          testServer.executeOperation(
+            { query: 'mutation { joinMyRoom }' },
+            { contextValue: { token: 'token', dataSources: { prisma: failingPrisma } } },
+          ),
+        ).resolves.toEqual({
           http: expect.anything(), // eslint-disable-line @typescript-eslint/no-unsafe-assignment
           body: {
             kind: 'single',
@@ -90,8 +91,7 @@ describe('authChecker', () => {
               ],
             },
           },
-        }
-        await expect(testServer.executeOperation(request, opts)).resolves.toEqual(expected)
+        })
       })
     })
 

--- a/backend/src/auth/authChecker.spec.ts
+++ b/backend/src/auth/authChecker.spec.ts
@@ -1,9 +1,9 @@
 import { ApolloServer } from '@apollo/server'
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import axios from 'axios'
 
 import { prisma } from '#src/prisma'
 import { createTestServer } from '#src/server/server'
+
+import type { Context } from '#src/server/context'
 
 jest.mock('axios', () => {
   return {
@@ -25,7 +25,7 @@ jest.mock('axios', () => {
   }
 })
 
-let testServer: ApolloServer
+let testServer: ApolloServer<Context>
 
 beforeAll(async () => {
   testServer = await createTestServer()
@@ -36,9 +36,12 @@ describe('authChecker', () => {
   describe('no token in context', () => {
     it('returns access denied error', async () => {
       await expect(
-        testServer.executeOperation({
-          query: 'mutation { joinMyRoom }',
-        }),
+        testServer.executeOperation(
+          {
+            query: 'mutation { joinMyRoom }',
+          },
+          { contextValue: { dataSources: { prisma } } },
+        ),
       ).resolves.toMatchObject({
         body: {
           kind: 'single',
@@ -61,6 +64,37 @@ describe('authChecker', () => {
       expect(await prisma.user.findMany()).toHaveLength(0)
     })
 
+    describe('if prisma client throws an error, e.g. because of pending migrations', () => {
+      const failingPrisma = {
+        user: { findUnique: jest.fn(prisma.user.findUnique).mockRejectedValue('Ouch!') },
+      } as unknown as typeof prisma
+
+      it('resolves to "INTERNAL_SERVER_ERROR" instead of "UNAUTHENTICATED"', async () => {
+        const [request, opts] = [
+          { query: 'mutation { joinMyRoom }' },
+          { contextValue: { token: 'token', dataSources: { prisma: failingPrisma } } },
+        ]
+        const expected = {
+          http: expect.anything(), // eslint-disable-line @typescript-eslint/no-unsafe-assignment
+          body: {
+            kind: 'single',
+            singleResult: {
+              data: null,
+              errors: [
+                {
+                  extensions: { code: 'INTERNAL_SERVER_ERROR' },
+                  locations: expect.anything(), // eslint-disable-line @typescript-eslint/no-unsafe-assignment
+                  message: 'Unexpected error value: "Ouch!"',
+                  path: ['joinMyRoom'],
+                },
+              ],
+            },
+          },
+        }
+        await expect(testServer.executeOperation(request, opts)).resolves.toEqual(expected)
+      })
+    })
+
     describe('first call', () => {
       let userId: number
 
@@ -72,6 +106,7 @@ describe('authChecker', () => {
           {
             contextValue: {
               token: 'token',
+              dataSources: { prisma },
             },
           },
         )
@@ -121,6 +156,7 @@ describe('authChecker', () => {
           {
             contextValue: {
               token: 'token',
+              dataSources: { prisma },
             },
           },
         )

--- a/backend/src/auth/authChecker.ts
+++ b/backend/src/auth/authChecker.ts
@@ -5,8 +5,9 @@ import { verify, JwtPayload } from 'jsonwebtoken'
 import { AuthChecker } from 'type-graphql'
 
 import { EVENT_CREATE_USER } from '#src/event/Events'
-import { prisma } from '#src/prisma'
 import { Context } from '#src/server/context'
+
+import type { prisma as Prisma } from '#src/prisma'
 
 interface CustomJwtPayload extends JwtPayload {
   nickname: string
@@ -23,40 +24,44 @@ export const getCert = (): Buffer => {
   return cert
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const authChecker: AuthChecker<Context> = async ({ root, args, context, info }, roles) => {
-  const { token } = context
+export const authChecker: AuthChecker<Context> = async ({ context }) => {
+  const { token, dataSources } = context
+  const { prisma } = dataSources
 
   if (!token) return false
 
+  let decoded
   try {
-    const decoded = verify(token, getCert()) as CustomJwtPayload
-    if (decoded) {
-      const { nickname, name } = decoded
-      const user = await contextUser(nickname, name)
-      context.user = user
-      return true
-    }
-  } catch {
+    decoded = verify(token, getCert()) as CustomJwtPayload
+  } catch (err) {
     return false
+  }
+
+  if (decoded) {
+    const { nickname, name } = decoded
+    const user = await contextUser(prisma)(nickname, name)
+    context.user = user
+    return true
   }
 
   return false
 }
 
-const contextUser = async (username: string, name: string): Promise<User> => {
-  let user: User | null = await prisma.user.findUnique({
-    where: {
-      username,
-    },
-  })
-  if (user) return user
-  user = await prisma.user.create({
-    data: {
-      username,
-      name,
-    },
-  })
-  await EVENT_CREATE_USER(user.id)
-  return user
-}
+const contextUser =
+  (prisma: typeof Prisma) =>
+  async (username: string, name: string): Promise<User> => {
+    let user: User | null = await prisma.user.findUnique({
+      where: {
+        username,
+      },
+    })
+    if (user) return user
+    user = await prisma.user.create({
+      data: {
+        username,
+        name,
+      },
+    })
+    void EVENT_CREATE_USER(user.id)
+    return user
+  }

--- a/backend/src/auth/authChecker.ts
+++ b/backend/src/auth/authChecker.ts
@@ -62,6 +62,6 @@ const contextUser =
         name,
       },
     })
-    void EVENT_CREATE_USER(user.id)
+    await EVENT_CREATE_USER(user.id)
     return user
   }

--- a/backend/src/graphql/resolvers/ContactFormResolver.spec.ts
+++ b/backend/src/graphql/resolvers/ContactFormResolver.spec.ts
@@ -5,7 +5,9 @@ import { EventType } from '#src/event/EventType'
 import { prisma } from '#src/prisma'
 import { createTestServer } from '#src/server/server'
 
-let testServer: ApolloServer
+import type { Context } from '#src/server/context'
+
+let testServer: ApolloServer<Context>
 
 jest.mock('#api/Brevo', () => {
   return {

--- a/backend/src/graphql/resolvers/NewsletterSubscriptionResolver.spec.ts
+++ b/backend/src/graphql/resolvers/NewsletterSubscriptionResolver.spec.ts
@@ -6,12 +6,14 @@ import { EventType } from '#src/event/EventType'
 import { prisma } from '#src/prisma'
 import { createTestServer } from '#src/server/server'
 
+import type { Context } from '#src/server/context'
+
 CONFIG.BREVO_KEY = 'MY KEY'
 CONFIG.BREVO_ADMIN_NAME = 'Bibi Bloxberg'
 CONFIG.BREVO_ADMIN_EMAIL = 'bibi@bloxberg.de'
 CONFIG.BREVO_NEWSLETTER_TEMPLATE_OPTIN = 3
 
-let testServer: ApolloServer
+let testServer: ApolloServer<Context>
 
 jest.mock('#api/Brevo', () => ({
   subscribeToNewsletter: jest.fn().mockResolvedValue(true),

--- a/backend/src/graphql/resolvers/RoomResolver.spec.ts
+++ b/backend/src/graphql/resolvers/RoomResolver.spec.ts
@@ -7,13 +7,15 @@ import { CONFIG } from '#config/config'
 import { prisma } from '#src/prisma'
 import { createTestServer } from '#src/server/server'
 
+import type { Context } from '#src/server/context'
+
 jest.mock('#api/BBB')
 
 const createMeetingMock = createMeeting as jest.MockedFunction<typeof createMeeting>
 const joinMeetingLinkMock = joinMeetingLink as jest.MockedFunction<typeof joinMeetingLink>
 const getMeetingsMock = getMeetings as jest.MockedFunction<typeof getMeetings>
 
-let testServer: ApolloServer
+let testServer: ApolloServer<Context>
 
 CONFIG.FRONTEND_INVITE_LINK_URL = '/'
 
@@ -26,10 +28,13 @@ describe('RoomResolver', () => {
     describe('createMyRoom', () => {
       it('throws access denied', async () => {
         await expect(
-          testServer.executeOperation({
-            query: 'mutation($name: String!) { createMyRoom(name: $name) { id } }',
-            variables: { name: 'My Room' },
-          }),
+          testServer.executeOperation(
+            {
+              query: 'mutation($name: String!) { createMyRoom(name: $name) { id } }',
+              variables: { name: 'My Room' },
+            },
+            { contextValue: { dataSources: { prisma } } },
+          ),
         ).resolves.toMatchObject({
           body: {
             kind: 'single',
@@ -50,9 +55,12 @@ describe('RoomResolver', () => {
     describe('joinMyRoom', () => {
       it('throws access denied', async () => {
         await expect(
-          testServer.executeOperation({
-            query: 'mutation { joinMyRoom }',
-          }),
+          testServer.executeOperation(
+            {
+              query: 'mutation { joinMyRoom }',
+            },
+            { contextValue: { dataSources: { prisma } } },
+          ),
         ).resolves.toMatchObject({
           body: {
             kind: 'single',
@@ -73,9 +81,12 @@ describe('RoomResolver', () => {
     describe('openRooms', () => {
       it('throws access denied', async () => {
         await expect(
-          testServer.executeOperation({
-            query: 'query { openRooms { meetingName } }',
-          }),
+          testServer.executeOperation(
+            {
+              query: 'query { openRooms { meetingName } }',
+            },
+            { contextValue: { dataSources: { prisma } } },
+          ),
         ).resolves.toMatchObject({
           body: {
             kind: 'single',
@@ -102,13 +113,16 @@ describe('RoomResolver', () => {
       describe('No room in DB', () => {
         it('throws an Error', async () => {
           await expect(
-            testServer.executeOperation({
-              query,
-              variables: {
-                userName: 'Pinky Pie',
-                roomId: 25,
+            testServer.executeOperation(
+              {
+                query,
+                variables: {
+                  userName: 'Pinky Pie',
+                  roomId: 25,
+                },
               },
-            }),
+              { contextValue: { dataSources: { prisma } } },
+            ),
           ).resolves.toMatchObject({
             body: {
               kind: 'single',
@@ -140,13 +154,16 @@ describe('RoomResolver', () => {
 
         it('returns link to room', async () => {
           await expect(
-            testServer.executeOperation({
-              query,
-              variables: {
-                userName: 'Pinky Pie',
-                roomId,
+            testServer.executeOperation(
+              {
+                query,
+                variables: {
+                  userName: 'Pinky Pie',
+                  roomId,
+                },
               },
-            }),
+              { contextValue: { dataSources: { prisma } } },
+            ),
           ).resolves.toMatchObject({
             body: {
               kind: 'single',
@@ -160,13 +177,16 @@ describe('RoomResolver', () => {
         })
 
         it('calls join meeting link', async () => {
-          await testServer.executeOperation({
-            query,
-            variables: {
-              userName: 'Pinky Pie',
-              roomId,
+          await testServer.executeOperation(
+            {
+              query,
+              variables: {
+                userName: 'Pinky Pie',
+                roomId,
+              },
             },
-          })
+            { contextValue: { dataSources: { prisma } } },
+          )
           expect(joinMeetingLinkMock).toHaveBeenCalledWith({
             fullName: 'Pinky Pie',
             meetingID: 'Pony Ville',
@@ -191,6 +211,7 @@ describe('RoomResolver', () => {
                 contextValue: {
                   token: 'token',
                   user: undefined,
+                  dataSources: { prisma },
                 },
               },
             ),
@@ -218,6 +239,7 @@ describe('RoomResolver', () => {
                 contextValue: {
                   token: 'token',
                   user: undefined,
+                  dataSources: { prisma },
                 },
               },
             ),
@@ -267,6 +289,7 @@ describe('RoomResolver', () => {
                 contextValue: {
                   token: 'token',
                   user: undefined,
+                  dataSources: { prisma },
                 },
               },
             ),
@@ -327,6 +350,7 @@ describe('RoomResolver', () => {
                 contextValue: {
                   token: 'token',
                   user: undefined,
+                  dataSources: { prisma },
                 },
               },
             ),
@@ -412,6 +436,7 @@ describe('RoomResolver', () => {
                 contextValue: {
                   token: 'token',
                   user: undefined,
+                  dataSources: { prisma },
                 },
               },
             ),
@@ -464,6 +489,7 @@ describe('RoomResolver', () => {
               {
                 contextValue: {
                   token: 'token',
+                  dataSources: { prisma },
                 },
               },
             ),
@@ -500,6 +526,7 @@ describe('RoomResolver', () => {
               {
                 contextValue: {
                   token: 'token',
+                  dataSources: { prisma },
                 },
               },
             ),
@@ -558,6 +585,7 @@ describe('RoomResolver', () => {
               {
                 contextValue: {
                   token: 'token',
+                  dataSources: { prisma },
                 },
               },
             ),
@@ -649,6 +677,7 @@ describe('RoomResolver', () => {
               {
                 contextValue: {
                   token: 'token',
+                  dataSources: { prisma },
                 },
               },
             ),
@@ -753,6 +782,7 @@ describe('RoomResolver', () => {
               {
                 contextValue: {
                   token: 'token',
+                  dataSources: { prisma },
                 },
               },
             ),

--- a/backend/src/graphql/resolvers/UserResolver.spec.ts
+++ b/backend/src/graphql/resolvers/UserResolver.spec.ts
@@ -1,8 +1,11 @@
 import { ApolloServer } from '@apollo/server'
 
+import { prisma } from '#src/prisma'
 import { createTestServer } from '#src/server/server'
 
-let testServer: ApolloServer
+import type { Context } from '#src/server/context'
+
+let testServer: ApolloServer<Context>
 
 beforeAll(async () => {
   testServer = await createTestServer()
@@ -12,9 +15,12 @@ describe('UserResolver', () => {
   describe('users query', () => {
     describe('unauthenticated', () => {
       it('returns an unauthenticated error', async () => {
-        const response = await testServer.executeOperation({
-          query: `{users {id name username}}`,
-        })
+        const response = await testServer.executeOperation(
+          {
+            query: `{users {id name username}}`,
+          },
+          { contextValue: { dataSources: { prisma } } },
+        )
         expect(response).toMatchObject({
           body: {
             kind: 'single',
@@ -42,6 +48,7 @@ describe('UserResolver', () => {
             contextValue: {
               token: 'token',
               user: undefined,
+              dataSources: { prisma },
             },
           },
         )

--- a/backend/src/server/context.ts
+++ b/backend/src/server/context.ts
@@ -1,8 +1,11 @@
 import { User } from '@prisma/client'
 
+import type { prisma } from '#src/prisma'
+
 export type Context = {
   token?: string
   user?: User | undefined
+  dataSources: { prisma: typeof prisma }
 }
 
 export type GetContextToken = (authorization: string | undefined) => string | undefined


### PR DESCRIPTION
Motivation
----------
This is a side quest of #1451.

If there is an error with the prisma client, we send `UNAUTHENTICATED` instead of `INTERNAL_ERROR`. This will lead to an endless loop because the frontend redirects to `/signin` over and over again.

I also made a refactoring: I want to be able to mock the prisma client, so that it rejects with an error. It is a best practice to use the `dataSources` pattern from Apollo <= v2:
https://www.apollographql.com/docs/apollo-server/v2/data/data-sources/

In Apollo v4 you simply put it into `context`. I like the name `dataSources` though and nested the `prisma` client in there.

How to test
-----------
1. `docker compose down database -v`
2. `docker compose up database backend frontend authentik`
3. Login in at http://localhost:3000/
4. No endless redirects

ToDos
-----
- [ ] As a follow up we should make sure to always use the `prisma` client from the `context`. But I'll leave this for another day.

