### PR TITLE
refactor(backend): read JWKS_URI after dotenv

### DIFF
--- a/backend/src/auth/authChecker.ts
+++ b/backend/src/auth/authChecker.ts
@@ -2,6 +2,7 @@ import { User } from '@prisma/client'
 import { createRemoteJWKSet } from 'jose'
 import { AuthChecker } from 'type-graphql'
 
+import { CONFIG } from '#config/config'
 import { EVENT_CREATE_USER } from '#src/event/Events'
 import { Context } from '#src/server/context'
 
@@ -14,12 +15,7 @@ export interface CustomJwtPayload {
   name: string
 }
 
-// eslint-disable-next-line n/no-process-env
-const { JWKS_URI } = process.env
-if (!JWKS_URI) {
-  throw new Error('missing environment variable: JWKS_URI')
-}
-const JWKS = createRemoteJWKSet(new URL(JWKS_URI))
+const JWKS = createRemoteJWKSet(new URL(CONFIG.JWKS_URI))
 
 export const authChecker: AuthChecker<Context> = async ({ context }) => {
   const { token, dataSources } = context

--- a/backend/src/config/config.ts
+++ b/backend/src/config/config.ts
@@ -41,10 +41,16 @@ const FRONTEND = {
     process.env.FRONTEND_INVITE_LINK_URL ?? 'http://localhost:3000/join-room/',
 }
 
+const { JWKS_URI } = process.env
+if (!JWKS_URI) {
+  throw new Error('missing environment variable: JWKS_URI')
+}
+
 export const CONFIG = {
   ...BREVO,
   ...BBB,
   ...FRONTEND,
+  JWKS_URI,
 }
 
 // Config Checks


### PR DESCRIPTION
Motivation
----------
This might also be a fix of our vServer deployment which relies on `.env` (bad idea in production, but another story).

I cannot reproduce the error on `master` though. Nevertheless, this should get merged for code quality. Then we can see if we get the `master` deployed.

I was checking the script that starts the backend in production [here](./deployment/scripts/start.backend.sh):
```
NODE_ENV=production TZ=UTC TS_NODE_BASEURL=./build pm2 start --name backend "node -r tsconfig-paths/register build/src/index.js" -l $LOG_FILE --log-date-format 'YYYY-MM-DD HH:mm:ss.SSS'
```

It's not even `npm run start` or sth. alike :(

How to test
-----------
1. `cd backend`
2. `npm run build`
3. `node -r tsconfig-paths/register build/src/index.js`
4. I was expecting to see the error on `master` here but it's actually running fine on both branches.

