### PR TITLE
fix(authentik): make input field text visible

### DIFF
--- a/authentik/web/dist/custom.css
+++ b/authentik/web/dist/custom.css
@@ -31,7 +31,11 @@
   outline: none;
   border: 1px solid transparent;
   border-radius: 80px;
-  background: linear-gradient(white, white) padding-box, linear-gradient(90deg, rgba(240, 150, 48, 1) 0%, rgba(44, 165, 177, 1) 100%) border-box;
+  /*
+   * TODO: handle dark mode
+   * See: https://github.com/dreammall-earth/dreammall.earth/pull/1576
+   * background: linear-gradient(white, white) padding-box, linear-gradient(90deg, rgba(240, 150, 48, 1) 0%, rgba(44, 165, 177, 1) 100%) border-box;
+   */
 }
 
 /* sign in button */


### PR DESCRIPTION
Motivation
----------
On my machine, the text color is the same as the background color, effectively making the text invisible. What was that for?

Browser:
```
$ firefox --version
Mozilla Firefox 128.0.2
```

How to test
-----------
1. `cd authentik && docker compose up`
2. Visit http://localhost:9000
3. You can see what you type in the login form

- related #846