### PR TITLE
fix(frontend): pin sass to 1.74.1 to avoid deprecation warnings for vuetify

### DIFF
--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -67,7 +67,7 @@
         "prettier": "^3.3.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "sass": "^1.77.8",
+        "sass": "1.74.1",
         "sass-loader": "^16.0.0",
         "storybook": "^8.1.10",
         "stylelint": "^16.7.0",
@@ -19686,9 +19686,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sass": {
-      "version": "1.77.8",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.8.tgz",
-      "integrity": "sha512-4UHg6prsrycW20fqLGPShtEvo/WyHRVRHwOP4DzkUrObWoWI05QBSfzU71TVB7PFaL104TwNaHpjlWXAZbQiNQ==",
+      "version": "1.74.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.74.1.tgz",
+      "integrity": "sha512-w0Z9p/rWZWelb88ISOLyvqTWGmtmu2QJICqDBGyNnfG4OUnPX9BBjjYIXUpXCMOOg5MQWNpqzt876la1fsTvUA==",
       "devOptional": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",

--- a/admin/package.json
+++ b/admin/package.json
@@ -110,7 +110,7 @@
     "prettier": "^3.3.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "sass": "^1.77.8",
+    "sass": "1.74.1",
     "sass-loader": "^16.0.0",
     "storybook": "^8.1.10",
     "stylelint": "^16.7.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -83,7 +83,7 @@
         "prettier": "^3.3.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "sass": "^1.77.8",
+        "sass": "1.74.1",
         "sass-loader": "^15.0.0",
         "storybook": "^8.1.10",
         "stylelint": "^16.7.0",
@@ -20132,9 +20132,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sass": {
-      "version": "1.77.8",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.8.tgz",
-      "integrity": "sha512-4UHg6prsrycW20fqLGPShtEvo/WyHRVRHwOP4DzkUrObWoWI05QBSfzU71TVB7PFaL104TwNaHpjlWXAZbQiNQ==",
+      "version": "1.74.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.74.1.tgz",
+      "integrity": "sha512-w0Z9p/rWZWelb88ISOLyvqTWGmtmu2QJICqDBGyNnfG4OUnPX9BBjjYIXUpXCMOOg5MQWNpqzt876la1fsTvUA==",
       "devOptional": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -127,7 +127,7 @@
     "prettier": "^3.3.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "sass": "^1.77.8",
+    "sass": "1.74.1",
     "sass-loader": "^15.0.0",
     "storybook": "^8.1.10",
     "stylelint": "^16.7.0",

--- a/presenter/package-lock.json
+++ b/presenter/package-lock.json
@@ -76,7 +76,7 @@
         "prettier": "^3.3.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "sass": "^1.77.8",
+        "sass": "1.74.1",
         "sass-loader": "^15.0.0",
         "storybook": "^8.1.9",
         "stylelint": "^16.7.0",
@@ -17657,9 +17657,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sass": {
-      "version": "1.77.8",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.8.tgz",
-      "integrity": "sha512-4UHg6prsrycW20fqLGPShtEvo/WyHRVRHwOP4DzkUrObWoWI05QBSfzU71TVB7PFaL104TwNaHpjlWXAZbQiNQ==",
+      "version": "1.74.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.74.1.tgz",
+      "integrity": "sha512-w0Z9p/rWZWelb88ISOLyvqTWGmtmu2QJICqDBGyNnfG4OUnPX9BBjjYIXUpXCMOOg5MQWNpqzt876la1fsTvUA==",
       "devOptional": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",

--- a/presenter/package.json
+++ b/presenter/package.json
@@ -119,7 +119,7 @@
     "prettier": "^3.3.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "sass": "^1.77.8",
+    "sass": "1.74.1",
     "sass-loader": "^15.0.0",
     "storybook": "^8.1.9",
     "stylelint": "^16.7.0",


### PR DESCRIPTION
## 🍰 Pullrequest
We are getting tons of deprecation warnings in the frontend because Vuetify  needs to change code to avoid Sass deprecation warnings. Here is the issue of Vuetify:

https://github.com/vuetifyjs/vuetify/issues/20139

While we are waiting for this, let's pin Sass to a lower version that doesn't make trouble.