### PR TITLE
fix(workflow): publish packages under repository

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,7 @@ jobs:
         folder: [admin, backend, frontend, presenter]
     runs-on: ubuntu-latest
     env:
-      IMAGE_NAME: ${{ github.repository_owner }}/${{ matrix.folder }}
+      IMAGE_NAME: ${{ github.repository }}/${{ matrix.folder }}
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
... not under the repository owner.

Motivation
----------
I was confused how the ghcr image repository gets constructed and it seems I looked into the wrong folder within my fork.

How to test
-----------
1. The packages are here: https://github.com/orgs/dreammall-earth/packages
2. But I would say the belong to the repository: https://github.com/dreammall-earth/dreammall.earth