### PR TITLE
feat(docker): bake env vars into docker image

### DIFF
--- a/.github/workflows/e2e.run.tests.yml
+++ b/.github/workflows/e2e.run.tests.yml
@@ -24,10 +24,12 @@ jobs:
           npm run start &
           cd ../frontend
           cp .env.dist .env
+          rm .env.production
           npm install
           npm run prod &
           cd  ../presenter
           cp .env.dist .env
+          rm .env.production
           export PORT=3001
           npm install
           npm run prod &

--- a/admin/.env.production
+++ b/admin/.env.production
@@ -1,0 +1,5 @@
+# META
+PUBLIC_ENV__META__BASE_URL="https://admin.master.dreammall.earth"
+PUBLIC_ENV__META__DEFAULT_AUTHOR="IT Team 4 Change"
+PUBLIC_ENV__META__DEFAULT_DESCRIPTION="IT4C Frontend Boilerplate"
+PUBLIC_ENV__META__DEFAULT_TITLE="IT4C"

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,19 @@
+# AUTH
+PUBLIC_ENV__AUTH__AUTHORITY="https://auth.master.dreammall.earth/application/o/dreammallearth/"
+PUBLIC_ENV__AUTH__AUTHORITY_SIGNUP_URI="https://auth.master.dreammall.earth/if/flow/dreammallearth-enrollment/"
+PUBLIC_ENV__AUTH__AUTHORITY_SIGNOUT_URI="https://auth.master.dreammall.earth/if/flow/dreammallearth-invalidation-flow/"
+PUBLIC_ENV__AUTH__CLIENT_ID="G3g0sjCjph1NAyGeeu5Te5ltx1I7WZ0DGB8i6vOI"
+PUBLIC_ENV__AUTH__REDIRECT_URI="https://app.master.dreammall.earth/auth"
+PUBLIC_ENV__AUTH__SILENT_REDIRECT_URI="https://app.master.dreammall.earth/silent-refresh"
+PUBLIC_ENV__AUTH__RESPONSE_TYPE="code"
+PUBLIC_ENV__AUTH__SCOPE="openid profile posts"
+PUBLIC_ENV__AUTH__ADMIN_GROUP="authentik Admins"
+PUBLIC_ENV__AUTH__ADMIN_REDIRECT_URI="https://admin.master.dreammall.earth/signin"
+
+# Endpoints
+PUBLIC_ENV__ENDPOINTS__GRAPHQL_URI=https://master.dreammall.earth/api/
+PUBLIC_ENV__ENDPOINTS__WEBSOCKET_URI=wss://master.dreammall.earth/api/subscriptions
+
+# META
+PUBLIC_ENV__META__BASE_URL="https://app.master.dreammall.earth"
+PUBLIC_ENV__META__DEFAULT_AUTHOR="DreamMall Verlag GbR"

--- a/presenter/.env.production
+++ b/presenter/.env.production
@@ -1,0 +1,10 @@
+# AUTH
+PUBLIC_ENV__SIGNUP_URI="https://auth.master.dreammall.earth/if/flow/dreammallearth-enrollment/"
+PUBLIC_ENV__SIGNIN_URI="https://app.master.dreammall.earth/signin"
+
+# Endpoints
+PUBLIC_ENV__ENDPOINTS__GRAPHQL_URI=https://master.dreammall.earth/api/
+
+# META
+PUBLIC_ENV__META__BASE_URL="https://master.dreammall.earth"
+PUBLIC_ENV__META__DEFAULT_AUTHOR="DreamMall Verlag GbR"


### PR DESCRIPTION
Motivation
----------
This is a workaround for #1504.

There is no (clean) way to accommplish runtime environment variables for our frontends. I bake them into the docker image for now. Not great, but gets things going.

How to test
-----------
1. `docker pull ghcr.io/dreammall-earth/dreammall.earth/presenter:master`
2. Signup/Signin buttons point to the hard-coded domain
