### PR TITLE
fix(docker): include prisma folder in migrations

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -71,6 +71,7 @@ FROM base as production
 
 # Copy "binary"-files from build image
 COPY --from=build ${DOCKER_WORKDIR}/build ./build
+COPY --from=build ${DOCKER_WORKDIR}/prisma ./prisma
 # We also copy the node_modules express and serve-static for the run script
 COPY --from=build ${DOCKER_WORKDIR}/node_modules ./node_modules
 # Copy package.json & tsconfig.json


### PR DESCRIPTION
Motivation
----------
Otherwise, we cannot run the migrations from the docker image.

How to test
-----------
1. `docker run --rm -it ghcr.io/roschaefer/dreammall-backend:sha-4508a40a24a864b8699ddcddac5d2add1b2c6f4f npm run db:migrate`
2. See the following error:
```

> dreammall-backend@1.2.1 db:migrate
> TZ=UTC npx prisma migrate dev

Error: Could not find Prisma Schema that is required for this command.
You can either provide it with `--schema` argument, set it as `prisma.schema` in your package.json or put it into the default location.
Checked following paths:

schema.prisma: file not found
prisma/schema.prisma: file not found
prisma/schema: directory not found

See also https://pris.ly/d/prisma-schema-location
```