### PR TITLE
refactor(docker): better caching during build

### DIFF
--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:21-alpine3.17 as base
+FROM node:21-alpine3.17 AS base
 
 # ENVs (available in production aswell, can be overwritten by commandline or env file)
 ## DOCKER_WORKDIR would be a classical ARG, but that is not multi layer persistent - shame
@@ -42,67 +42,34 @@ WORKDIR ${DOCKER_WORKDIR}
 ##################################################################################
 # DEVELOPMENT (Connected to the local environment, to reload on demand) ##########
 ##################################################################################
-FROM base as development
-
-# We don't need to copy or build anything since we gonna bind to the
-# local filesystem which will need a rebuild anyway
-
-# Run command
-# (for development we need to execute npm install since the
-#  node_modules are on another volume and need updating)
+FROM base AS development
 CMD /bin/sh -c "npm install && npm run dev"
 
 ##################################################################################
 # STORYBOOK ######################################################################
 ##################################################################################
-FROM base as storybook
-
-# We don't need to copy or build anything since we gonna bind to the
-# local filesystem which will need a rebuild anyway
-
-# Run command
-# (for development we need to execute npm install since the
-#  node_modules are on another volume and need updating)
+FROM base AS storybook
 CMD /bin/sh -c "npm install && npm run storybook"
 
 ##################################################################################
 # BUILD (Does contain all files and is therefore bloated) ########################
 ##################################################################################
-FROM base as build
+FROM base AS build
 
-# Copy everything
-COPY . .
-# npm install
+COPY package.json package-lock.json ./
 RUN npm install --include=dev --frozen-lockfile --non-interactive
-# npm build
+COPY . .
 RUN npm run build
-
-##################################################################################
-# TEST ###########################################################################
-##################################################################################
-#FROM build as test
-
-# Install Additional Software
-# RUN apk add --no-cache bash jq
-
-# Run command
-#CMD /bin/sh -c "yarn run dev"
 
 ##################################################################################
 # PRODUCTION (Does contain only "binary"- and static-files to reduce image size) #
 ##################################################################################
-FROM base as production
+FROM base AS production
 
-# Copy "binary"-files from build image
-COPY --from=build ${DOCKER_WORKDIR}/build ./build
-# Copy server
-COPY --from=build ${DOCKER_WORKDIR}/server ./server
-# Copy package.json & tsconfig.json
-COPY --from=build ${DOCKER_WORKDIR}/package.json ./package.json
-COPY --from=build ${DOCKER_WORKDIR}/package-lock.json ./package-lock.json
-COPY --from=build ${DOCKER_WORKDIR}/tsconfig.json ./tsconfig.json
-# Install production packages
+COPY --from=build ${DOCKER_WORKDIR}/package.json ${DOCKER_WORKDIR}/package-lock.json ./
 RUN npm install --omit=dev --frozen-lockfile --non-interactive
+COPY --from=build ${DOCKER_WORKDIR}/build ./build
+COPY --from=build ${DOCKER_WORKDIR}/server ./server
+COPY --from=build ${DOCKER_WORKDIR}/tsconfig.json ./tsconfig.json
 
-# Run command
 CMD /bin/sh -c "npm run server:prod"

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:21-alpine3.17 as base
+FROM node:21-alpine3.17 AS base
 
 # ENVs (available in production aswell, can be overwritten by commandline or env file)
 ## DOCKER_WORKDIR would be a classical ARG, but that is not multi layer persistent - shame
@@ -42,44 +42,27 @@ WORKDIR ${DOCKER_WORKDIR}
 ##################################################################################
 # DEVELOPMENT (Connected to the local environment, to reload on demand) ##########
 ##################################################################################
-FROM base as development
-
-# We don't need to copy or build anything since we gonna bind to the
-# local filesystem which will need a rebuild anyway
-
-# Run command
-# (for development we need to execute npm install since the
-#  node_modules are on another volume and need updating)
-CMD /bin/sh -c "npm install && npm run dev"
+FROM base AS development
+CMD ["/bin/sh", "-c", "npm install && npm run dev"]
 
 ##################################################################################
 # BUILD (Does contain all files and is therefore bloated) ########################
 ##################################################################################
-FROM base as build
-
-# Copy everything
-COPY . .
-# npm install including dev dependencies to be able to compile
+FROM base AS build
+COPY package.json package-lock.json ./
+COPY prisma ./prisma
 RUN npm install --include=dev --frozen-lockfile --non-interactive
-# npm build
+COPY . .
 RUN npm run build
 
 ##################################################################################
 # PRODUCTION (Does contain only "binary"- and static-files to reduce image size) #
 ##################################################################################
-FROM base as production
-
-# Copy "binary"-files from build image
-COPY --from=build ${DOCKER_WORKDIR}/build ./build
+FROM base AS production
+COPY --from=build ${DOCKER_WORKDIR}/package.json ${DOCKER_WORKDIR}/package-lock.json ./
 COPY --from=build ${DOCKER_WORKDIR}/prisma ./prisma
-# We also copy the node_modules express and serve-static for the run script
-COPY --from=build ${DOCKER_WORKDIR}/node_modules ./node_modules
-# Copy package.json & tsconfig.json
-COPY --from=build ${DOCKER_WORKDIR}/package.json ./package.json
-COPY --from=build ${DOCKER_WORKDIR}/package-lock.json ./package-lock.json
-COPY --from=build ${DOCKER_WORKDIR}/tsconfig.json ./tsconfig.json
-# Install production packages
 RUN npm install --omit=dev --frozen-lockfile --non-interactive
+COPY --from=build ${DOCKER_WORKDIR}/build ./build
+COPY --from=build ${DOCKER_WORKDIR}/tsconfig.json ./tsconfig.json
 
-# Run command
-CMD /bin/sh -c "npm run start"
+CMD ["/bin/sh", "-c",  "npm run start"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:21-alpine3.17 as base
+FROM node:21-alpine3.17 AS base
 
 # ENVs (available in production aswell, can be overwritten by commandline or env file)
 ## DOCKER_WORKDIR would be a classical ARG, but that is not multi layer persistent - shame
@@ -42,70 +42,35 @@ WORKDIR ${DOCKER_WORKDIR}
 ##################################################################################
 # DEVELOPMENT (Connected to the local environment, to reload on demand) ##########
 ##################################################################################
-FROM base as development
-
-# We don't need to copy or build anything since we gonna bind to the
-# local filesystem which will need a rebuild anyway
-
-# Run command
-# (for development we need to execute npm install since the
-#  node_modules are on another volume and need updating)
+FROM base AS development
 CMD /bin/sh -c "npm install && npm run dev"
 
 ##################################################################################
 # STORYBOOK ######################################################################
 ##################################################################################
-FROM base as storybook
-
-# We don't need to copy or build anything since we gonna bind to the
-# local filesystem which will need a rebuild anyway
-
-# Run command
-# (for development we need to execute npm install since the
-#  node_modules are on another volume and need updating)
+FROM base AS storybook
 CMD /bin/sh -c "npm install && npm run storybook"
 
 ##################################################################################
 # BUILD (Does contain all files and is therefore bloated) ########################
 ##################################################################################
-FROM base as build
+FROM base AS build
 
-# Copy everything
-COPY . .
-# npm install
+COPY package.json package-lock.json ./
 RUN npm install --include=dev --frozen-lockfile --non-interactive
-# npm build
-RUN npm run build
-
-##################################################################################
-# TEST ###########################################################################
-##################################################################################
-FROM base as test
-
-# Copy everything
 COPY . .
-# npm install
-RUN npm install --include=dev --frozen-lockfile --non-interactive
 RUN npm run build
-
-# Run command
-CMD /bin/sh -c "npm run server:prod"
 
 ##################################################################################
 # PRODUCTION (Does contain only "binary"- and static-files to reduce image size) #
 ##################################################################################
-FROM base as production
+FROM base AS production
 
-# Copy "binary"-files from build image
-COPY --from=build ${DOCKER_WORKDIR}/build ./build
-# Copy server
-COPY --from=build ${DOCKER_WORKDIR}/server ./server
-# Copy package.json & tsconfig.json
-COPY --from=build ${DOCKER_WORKDIR}/package.json ./package.json
-COPY --from=build ${DOCKER_WORKDIR}/package-lock.json ./package-lock.json
-COPY --from=build ${DOCKER_WORKDIR}/tsconfig.json ./tsconfig.json
-# Install production packages
+COPY --from=build ${DOCKER_WORKDIR}/package.json ${DOCKER_WORKDIR}/package-lock.json ./
 RUN npm install --omit=dev --frozen-lockfile --non-interactive
+COPY --from=build ${DOCKER_WORKDIR}/build ./build
+COPY --from=build ${DOCKER_WORKDIR}/server ./server
+COPY --from=build ${DOCKER_WORKDIR}/tsconfig.json ./tsconfig.json
 
 # Run command
 CMD /bin/sh -c "npm run server:prod"

--- a/presenter/Dockerfile
+++ b/presenter/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:21-alpine3.17 as base
+FROM node:21-alpine3.17 AS base
 
 # ENVs (available in production aswell, can be overwritten by commandline or env file)
 ## DOCKER_WORKDIR would be a classical ARG, but that is not multi layer persistent - shame
@@ -42,7 +42,7 @@ WORKDIR ${DOCKER_WORKDIR}
 ##################################################################################
 # DEVELOPMENT (Connected to the local environment, to reload on demand) ##########
 ##################################################################################
-FROM base as development
+FROM base AS development
 
 # We don't need to copy or build anything since we gonna bind to the
 # local filesystem which will need a rebuild anyway
@@ -55,7 +55,7 @@ CMD /bin/sh -c "npm install && npm run dev"
 ##################################################################################
 # STORYBOOK ######################################################################
 ##################################################################################
-FROM base as storybook
+FROM base AS storybook
 
 # We don't need to copy or build anything since we gonna bind to the
 # local filesystem which will need a rebuild anyway
@@ -68,44 +68,24 @@ CMD /bin/sh -c "npm install && npm run storybook"
 ##################################################################################
 # BUILD (Does contain all files and is therefore bloated) ########################
 ##################################################################################
-FROM base as build
+FROM base AS build
 
-# Copy everything
-COPY . .
-# npm install
+COPY package.json package-lock.json ./
 RUN npm install --include=dev --frozen-lockfile --non-interactive
-# npm build
-RUN npm run build
-
-##################################################################################
-# TEST ###########################################################################
-##################################################################################
-FROM base as test
-
-# Copy everything
 COPY . .
-# npm install
-RUN npm install --include=dev --frozen-lockfile --non-interactive
 RUN npm run build
-
-# Run command
-CMD /bin/sh -c "npm run server:prod"
 
 ##################################################################################
 # PRODUCTION (Does contain only "binary"- and static-files to reduce image size) #
 ##################################################################################
-FROM base as production
+FROM base AS production
 
-# Copy "binary"-files from build image
-COPY --from=build ${DOCKER_WORKDIR}/build ./build
-# Copy server
-COPY --from=build ${DOCKER_WORKDIR}/server ./server
-# Copy package.json & tsconfig.json
-COPY --from=build ${DOCKER_WORKDIR}/package.json ./package.json
-COPY --from=build ${DOCKER_WORKDIR}/package-lock.json ./package-lock.json
-COPY --from=build ${DOCKER_WORKDIR}/tsconfig.json ./tsconfig.json
-# Install production packages
+COPY --from=build ${DOCKER_WORKDIR}/package.json ${DOCKER_WORKDIR}/package-lock.json ./
 RUN npm install --omit=dev --frozen-lockfile --non-interactive
+
+COPY --from=build ${DOCKER_WORKDIR}/build ./build
+COPY --from=build ${DOCKER_WORKDIR}/server ./server
+COPY --from=build ${DOCKER_WORKDIR}/tsconfig.json ./tsconfig.json
 
 # Run command
 CMD /bin/sh -c "npm run server:prod"


### PR DESCRIPTION
Motivation
----------
If you have to rebuild docker images quite often, you will be very happen for every time you can skip `npm install`. If we only `COPY` the `package.json` first and this file has not changed, docker will skip the following `npm install`.

Besides the changes remove some warnings and unnecessary comments repeating the code next to it.

How to test
-----------
1. `docker compose -f docker-compose.yml build ..` multiple times
2. Change files and run 1. again
3. It should skip the first call of `npm install`