### PR TITLE
refactor(docker): add image tags to docker-compose

### DIFF
--- a/authentik/docker-compose.yml
+++ b/authentik/docker-compose.yml
@@ -40,6 +40,7 @@ services:
       - redis:/data
 
   authentik:
+    image: ghcr.io/dreammall-earth/dreammall.earth/authentik:latest
     build:
       context: .
       target: production
@@ -59,6 +60,7 @@ services:
       - redis
 
   authentik-worker:
+    image: ghcr.io/dreammall-earth/dreammall.earth/authentik:latest
     build:
       context: .
       target: production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - db_vol:/var/lib/mysql
 
   presenter:
+    image: ghcr.io/dreammall-earth/dreammall.earth/presenter:latest
     build:
       context: ./presenter
       target: production
@@ -23,6 +24,7 @@ services:
       - NODE_ENV=production
 
   frontend:
+    image: ghcr.io/dreammall-earth/dreammall.earth/frontend:latest
     build:
       context: ./frontend
       target: production
@@ -32,6 +34,7 @@ services:
       - NODE_ENV=production
 
   admin:
+    image: ghcr.io/dreammall-earth/dreammall.earth/admin:latest
     build:
       context: ./admin
       target: production
@@ -41,6 +44,7 @@ services:
       - NODE_ENV=production
 
   backend:
+    image: ghcr.io/dreammall-earth/dreammall.earth/backend:latest
     build:
       context: ./backend
       target: production


### PR DESCRIPTION
Motivation
----------
Now that we're shipping our own docker images. It makes sense to add
image tags to build them with the right tag as well as be able to:
```
docker compose pull
```

How to test
-----------
1. `docker compose build`
2. `docker images` shows sth. like this:
```
REPOSITORY                                          TAG           IMAGE ID       CREATED              SIZE
ghcr.io/dreammall-earth/dreammall.earth/authentik   latest        2fb9b4dcf84c   About a minute ago   1.06GB
ghcr.io/dreammall-earth/dreammall.earth/admin       latest        9af3932c4d98   43 minutes ago       141MB
ghcr.io/dreammall-earth/dreammall.earth/presenter   latest        971f8a1dfe3f   43 minutes ago       141MB
ghcr.io/dreammall-earth/dreammall.earth/backend     latest        d0fd7f4644bb   43 minutes ago       141MB
```

