### PR TITLE
refactor(workflow): set current release version for actions in docker flow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,14 +25,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        uses: docker/login-action@v3.3.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        uses: docker/metadata-action@v5.5.1
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -45,7 +45,7 @@ jobs:
             type=sha
       - name: Build and push Docker image
         id: push
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        uses: docker/build-push-action@v6.5.0
         with:
           context: ${{ matrix.folder }}
           target: production


### PR DESCRIPTION
Motivation
----------

[These Docker Action Update Bumps](https://github.com/dreammall-earth/dreammall.earth/pulls?q=is%3Aopen+is%3Apr+bump+docker) revealed that the Github action versions in the [Docker workflow](https://github.com/dreammall-earth/dreammall.earth/blob/master/.github/workflows/docker.yml) were set to commits (from March 2023 [docker/metadata-action](https://github.com/docker/metadata-action/commit/9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7), [docker/login-action](https://github.com/docker/login-action/commit/65b78e6e13532edd9afa3aa52ac7964289d1a9c1), [docker/build-push-action](https://github.com/docker/build-push-action/commit/f2a1d5e99d037542a71f64918e516c093c6f3fc4)) instead to a release version or the `master`. And so Dependabot bumps their updates to the current commit at the time Dependabot time.

If there is no specific reason for this, the actions can be set to the current release version:
- https://github.com/docker/metadata-action/releases/tag/v5.5.1
- https://github.com/docker/login-action/releases/tag/v3.3.0
- https://github.com/docker/build-push-action/releases/tag/v6.5.0

This will let Dependabot bump updates to the current release version.

Alternatively they could beset to `master`, as we do for [several Github actions](https://github.com/search?q=repo%3Adreammall-earth%2Fdreammall.earth%20%40master&type=code).


### Issues
- relates #1601
- relates #1602
- relates #1603