### PR TITLE
refactor(workflow): pin all github actions by commit hash

### DIFF
--- a/.github/workflows/admin.deploy.chromatic.yml
+++ b/.github/workflows/admin.deploy.chromatic.yml
@@ -10,10 +10,10 @@ jobs:
     env:
       CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN_ADMIN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 # v4.1.7
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@26961cf329f22f6837d5f54c3efd76b480300ace # v4.0.3
         with:
           node-version-file: './.tool-versions'
       - name: Admin | Build

--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -9,8 +9,8 @@ jobs:
     outputs:
       admin: ${{ steps.filter.outputs.admin }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3.0.2
+      - uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 # v4.1.7
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: filter
         with:
           filters: |
@@ -23,8 +23,8 @@ jobs:
     needs: files-changed
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 # v4.1.7
+      - uses: actions/setup-node@26961cf329f22f6837d5f54c3efd76b480300ace # v4.0.3
         with:
           node-version-file: './.tool-versions'
       - name: Admin | Build
@@ -37,7 +37,7 @@ jobs:
     needs: files-changed
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 # v4.1.7
       - name: Admin | Build Docker Production
         run: docker compose -f docker-compose.yml build admin
 
@@ -47,7 +47,7 @@ jobs:
     needs: files-changed
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 # v4.1.7
       - name: Admin | Build Docker Development
         run: docker compose build admin admin-storybook
 
@@ -57,8 +57,8 @@ jobs:
     needs: files-changed
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 # v4.1.7
+      - uses: actions/setup-node@26961cf329f22f6837d5f54c3efd76b480300ace # v4.0.3
         with:
           node-version-file: './.tool-versions'
       - name: Admin | Build Storybook
@@ -71,8 +71,8 @@ jobs:
     needs: files-changed
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 # v4.1.7
+      - uses: actions/setup-node@26961cf329f22f6837d5f54c3efd76b480300ace # v4.0.3
         with:
           node-version-file: './.tool-versions'
       - name: Admin | Lint
@@ -85,8 +85,8 @@ jobs:
     needs: files-changed
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 # v4.1.7
+      - uses: actions/setup-node@26961cf329f22f6837d5f54c3efd76b480300ace # v4.0.3
         with:
           node-version-file: './.tool-versions'
       - name: Admin | Unit

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -9,8 +9,8 @@ jobs:
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3.0.2
+      - uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 # v4.1.7
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: filter
         with:
           filters: |
@@ -24,8 +24,8 @@ jobs:
     needs: files-changed
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 # v4.1.7
+      - uses: actions/setup-node@26961cf329f22f6837d5f54c3efd76b480300ace # v4.0.3
         with:
           node-version-file: './.tool-versions'
       - name: Backend | Build
@@ -38,7 +38,7 @@ jobs:
     needs: files-changed
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 # v4.1.7
       - name: Backend | Build Docker Production
         run: docker compose -f docker-compose.yml build backend
 
@@ -48,7 +48,7 @@ jobs:
     needs: files-changed
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 # v4.1.7
       - name: Backend | Build Docker Development
         run: docker compose build backend
 
@@ -58,8 +58,8 @@ jobs:
     needs: files-changed
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 # v4.1.7
+      - uses: actions/setup-node@26961cf329f22f6837d5f54c3efd76b480300ace # v4.0.3
         with:
           node-version-file: './.tool-versions'
       - name: Backend | Lint
@@ -74,8 +74,8 @@ jobs:
     env:
       DATABASE_URL: mysql://root:@localhost:3306/dreammall.earth
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 # v4.1.7
+      - uses: actions/setup-node@26961cf329f22f6837d5f54c3efd76b480300ace # v4.0.3
         with:
           node-version-file: './.tool-versions'
       - name: Backend | docker-compose database

--- a/.github/workflows/deploy.docs.yml
+++ b/.github/workflows/deploy.docs.yml
@@ -12,12 +12,12 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 # v4.1.7
+      - uses: actions/setup-node@26961cf329f22f6837d5f54c3efd76b480300ace # v4.0.3
         with:
           node-version-file: './.tool-versions'
       - name: vuepress-deploy
-        uses: IT4Change/vuepress-build-and-deploy@master
+        uses: IT4Change/vuepress-build-and-deploy@b7244880d4eecbdd2fc984e71b888f7eb5b2ba48 # v1.9.0
         env:
           ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           #TARGET_REPO: username/repo

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 # v4.1.7
       - name: Log in to the Container registry
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
         with:
@@ -57,7 +57,7 @@ jobs:
       # https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds
       #
       # - name: Generate artifact attestation
-      #   uses: actions/attest-build-provenance@v1
+      #   uses: actions/attest-build-provenance@210c1913531870065f03ce1f9440dd87bc0938cd # v1.4.0
       #   with:
       #     subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
       #     subject-digest: ${{ steps.push.outputs.digest }}

--- a/.github/workflows/e2e.run.tests.yml
+++ b/.github/workflows/e2e.run.tests.yml
@@ -7,9 +7,9 @@ jobs:
     name: Run all E2E tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 # v4.1.7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@26961cf329f22f6837d5f54c3efd76b480300ace # v4.0.3
         with:
           node-version-file: './.tool-versions'
 
@@ -40,7 +40,7 @@ jobs:
 
       - name: E2E | Run all tests
         id: e2e-run
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@689551a1df6a10c75be61ae30b642cb84fb8164c # v6.7.2
         with:
           working-directory: tests
 
@@ -53,12 +53,12 @@ jobs:
 
       - name: Get PR number
         if: ${{ failure() && steps.e2e-run.conclusion == 'failure' }}
-        uses: jwalton/gh-find-current-pr@master
+        uses: jwalton/gh-find-current-pr@89ee5799558265a1e0e31fab792ebb4ee91c016b # v1.3.3
         id: pr-number
 
       - name: E2E | if tests failed, upload report
         if: ${{ failure() && steps.e2e-run.conclusion == 'failure' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@89ef406dd8d7e03cfd12d9e0a4a378f454709029 # v4.3.5
         with:
           name: dreammall-e2e-test-report-pr-${{ steps.pr-number.outputs.pr }}
           path: /home/runner/work/dreammall.earth/dreammall.earth/tests/cypress/reports/dreammall-e2e_html_report

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,8 +9,8 @@ jobs:
     outputs:
       e2e: ${{ steps.filter.outputs.e2e }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3.0.2
+      - uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 # v4.1.7
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: filter
         with:
           filters: |
@@ -24,9 +24,9 @@ jobs:
     needs: files-changed
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 # v4.1.7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@26961cf329f22f6837d5f54c3efd76b480300ace # v4.0.3
         with:
           node-version-file: './.tool-versions'
 

--- a/.github/workflows/frontend.deploy.chromatic.yml
+++ b/.github/workflows/frontend.deploy.chromatic.yml
@@ -10,10 +10,10 @@ jobs:
     env:
       CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN_FRONTEND }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 # v4.1.7
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@26961cf329f22f6837d5f54c3efd76b480300ace # v4.0.3
         with:
           node-version-file: './.tool-versions'
       - name: Frontend | Build

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -9,8 +9,8 @@ jobs:
     outputs:
       frontend: ${{ steps.filter.outputs.frontend }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3.0.2
+      - uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 # v4.1.7
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: filter
         with:
           filters: |
@@ -24,8 +24,8 @@ jobs:
     needs: files-changed
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 # v4.1.7
+      - uses: actions/setup-node@26961cf329f22f6837d5f54c3efd76b480300ace # v4.0.3
         with:
           node-version-file: './.tool-versions'
       - name: Frontend | Build
@@ -38,7 +38,7 @@ jobs:
     needs: files-changed
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 # v4.1.7
       - name: Frontend | Build Docker Production
         run: docker compose -f docker-compose.yml build frontend
 
@@ -48,7 +48,7 @@ jobs:
     needs: files-changed
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 # v4.1.7
       - name: Frontend | Build Docker Development
         run: docker compose build frontend frontend-storybook
 
@@ -58,8 +58,8 @@ jobs:
     needs: files-changed
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 # v4.1.7
+      - uses: actions/setup-node@26961cf329f22f6837d5f54c3efd76b480300ace # v4.0.3
         with:
           node-version-file: './.tool-versions'
       - name: Frontend | Build Storybook
@@ -72,8 +72,8 @@ jobs:
     needs: files-changed
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 # v4.1.7
+      - uses: actions/setup-node@26961cf329f22f6837d5f54c3efd76b480300ace # v4.0.3
         with:
           node-version-file: './.tool-versions'
       - name: Frontend | Lint
@@ -86,8 +86,8 @@ jobs:
     needs: files-changed
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 # v4.1.7
+      - uses: actions/setup-node@26961cf329f22f6837d5f54c3efd76b480300ace # v4.0.3
         with:
           node-version-file: './.tool-versions'
       - name: Frontend | Unit

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@80c0371c57c5142ed6c844270bba1864bac8a4c6 # v5.5.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/presenter.deploy.chromatic.yml
+++ b/.github/workflows/presenter.deploy.chromatic.yml
@@ -10,10 +10,10 @@ jobs:
     env:
       CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN_PRESENTER }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 # v4.1.7
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@26961cf329f22f6837d5f54c3efd76b480300ace # v4.0.3
         with:
           node-version-file: './.tool-versions'
       - name: Presenter | Build

--- a/.github/workflows/presenter.yml
+++ b/.github/workflows/presenter.yml
@@ -9,8 +9,8 @@ jobs:
     outputs:
       presenter: ${{ steps.filter.outputs.presenter }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3.0.2
+      - uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 # v4.1.7
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: filter
         with:
           filters: |
@@ -24,8 +24,8 @@ jobs:
     needs: files-changed
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 # v4.1.7
+      - uses: actions/setup-node@26961cf329f22f6837d5f54c3efd76b480300ace # v4.0.3
         with:
           node-version-file: './.tool-versions'
       - name: Presenter | Build
@@ -38,7 +38,7 @@ jobs:
     needs: files-changed
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 # v4.1.7
       - name: Presenter | Build Docker Production
         run: docker compose -f docker-compose.yml build presenter
 
@@ -48,7 +48,7 @@ jobs:
     needs: files-changed
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 # v4.1.7
       - name: Presenter | Build Docker Development
         run: docker compose build presenter presenter-storybook
 
@@ -58,8 +58,8 @@ jobs:
     needs: files-changed
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 # v4.1.7
+      - uses: actions/setup-node@26961cf329f22f6837d5f54c3efd76b480300ace # v4.0.3
         with:
           node-version-file: './.tool-versions'
       - name: Presenter | Build Storybook
@@ -72,8 +72,8 @@ jobs:
     needs: files-changed
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 # v4.1.7
+      - uses: actions/setup-node@26961cf329f22f6837d5f54c3efd76b480300ace # v4.0.3
         with:
           node-version-file: './.tool-versions'
       - name: Presenter | Lint
@@ -86,8 +86,8 @@ jobs:
     needs: files-changed
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 # v4.1.7
+      - uses: actions/setup-node@26961cf329f22f6837d5f54c3efd76b480300ace # v4.0.3
         with:
           node-version-file: './.tool-versions'
       - name: Presenter | Unit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       ##########################################################################
       # CHECKOUT CODE ##########################################################
       ##########################################################################
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 # v4.1.7
         with:
           fetch-depth: 0 # Fetch full History for changelog
       ##########################################################################
@@ -38,7 +38,7 @@ jobs:
       ##########################################################################
       # TODO: this will error on duplicate
       #- name: package-version-to-git-tag
-      #  uses: pkgdeps/git-tag-action@v3
+      #  uses: pkgdeps/git-tag-action@81b45ff87eb7f7bd49e76e2bed448990d4dd72b3 # v3.0.0
       #  with:
       #    github_token: ${{ secrets.GITHUB_TOKEN }}
       #    github_repo: ${{ github.repository }}
@@ -49,7 +49,7 @@ jobs:
       # Push build tag to GitHub ###############################################
       ##########################################################################
       - name: package-version-to-git-tag + build number
-        uses: pkgdeps/git-tag-action@v3
+        uses: pkgdeps/git-tag-action@81b45ff87eb7f7bd49e76e2bed448990d4dd72b3 # v3.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_repo: ${{ github.repository }}
@@ -65,7 +65,7 @@ jobs:
       - name: package-version-to-git-release
         continue-on-error: true # Will fail if tag exists
         id: create_release
-        uses: actions/create-release@v1
+        uses: actions/create-release@4c11c9fe1dcd9636620a16455165783b20fc7ea0 # v1.1.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:

--- a/.github/workflows/root.yml
+++ b/.github/workflows/root.yml
@@ -9,8 +9,8 @@ jobs:
     outputs:
       docs: ${{ steps.filter.outputs.docs }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3.0.2
+      - uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 # v4.1.7
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: filter
         with:
           filters: |
@@ -26,7 +26,7 @@ jobs:
     needs: files-changed
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 # v4.1.7
       - run: npm install && npm run remark
 
   docs:
@@ -35,5 +35,5 @@ jobs:
     needs: files-changed
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 # v4.1.7
       - run: npm install && npm run docs:build


### PR DESCRIPTION
Motivation
----------
[This comment](https://github.com/dreammall-earth/dreammall.earth/pull/1669#pullrequestreview-2217555113) on Github Action versions in Github workflows emphasizes the importance of taking measures to reduce the risk of being affected by supply chain attacks. One Measure is pinning the Github Actions in our workflows by commit hash rather than by tag.


How to test
----------
Just see the workflows work.