### PR TITLE
feat(frontend): add mutations for about me, update user store and user query

### DIFF
--- a/frontend/src/components/menu/UserInfo.test.ts
+++ b/frontend/src/components/menu/UserInfo.test.ts
@@ -61,6 +61,9 @@ describe('UserInfo', () => {
         name: '',
         username: '',
         id: 22,
+        availability: null,
+        details: [],
+        social: [],
       })
       wrapper = Wrapper()
     })
@@ -79,6 +82,9 @@ describe('UserInfo', () => {
         name: 'Peter Lustig',
         username: 'peter',
         id: 22,
+        availability: null,
+        details: [],
+        social: [],
       })
       wrapper = Wrapper()
     })
@@ -98,6 +104,9 @@ describe('UserInfo', () => {
         username: 'peter',
         id: 22,
         avatar: 'http://url-to.me',
+        availability: null,
+        details: [],
+        social: [],
       })
       wrapper = Wrapper()
     })

--- a/frontend/src/graphql/mutations/addSocialMediaMutation.ts
+++ b/frontend/src/graphql/mutations/addSocialMediaMutation.ts
@@ -1,0 +1,22 @@
+import { gql } from 'graphql-tag'
+
+export type AddSocialMediaInput = {
+  type: string
+  link: string
+}
+
+export const addSocialMediaMutation = gql`
+  mutation addSocialMedia($data: AddSocialMediaInput!) {
+    addSocialMedia(data: $data) {
+      id
+      text
+      category
+    }
+  }
+`
+
+export type AddSocialMediaMutationResult = {
+  addSocialMedia: AddSocialMediaInput & {
+    id: number
+  }
+}

--- a/frontend/src/graphql/mutations/addUserDetailMutation.ts
+++ b/frontend/src/graphql/mutations/addUserDetailMutation.ts
@@ -1,0 +1,22 @@
+import { gql } from 'graphql-tag'
+
+export type AddUserDetailInput = {
+  text: string
+  category: 'place' | 'work' | 'language' | 'education' | 'feeling'
+}
+
+export const addUserDetailMutation = gql`
+  mutation addUserDetail($data: AddUserDetailInput!) {
+    addUserDetail(data: $data) {
+      id
+      text
+      category
+    }
+  }
+`
+
+export type AddUserDetailMutationResult = {
+  addUserDetail: AddUserDetailInput & {
+    id: number
+  }
+}

--- a/frontend/src/graphql/mutations/removeSocialMediaMutation.ts
+++ b/frontend/src/graphql/mutations/removeSocialMediaMutation.ts
@@ -1,0 +1,7 @@
+import { gql } from 'graphql-tag'
+
+export const removeSocialMediaMutation = gql`
+  mutation removeSocialMedia($id: Int!) {
+    removeSocialMedia(id: $id)
+  }
+`

--- a/frontend/src/graphql/mutations/removeUserDetailMutation.ts
+++ b/frontend/src/graphql/mutations/removeUserDetailMutation.ts
@@ -1,0 +1,7 @@
+import { gql } from 'graphql-tag'
+
+export const removeUserDetailMutation = gql`
+  mutation removeUserDetail($id: Int!) {
+    removeUserDetail(id: $id)
+  }
+`

--- a/frontend/src/graphql/mutations/updateUserMutation.ts
+++ b/frontend/src/graphql/mutations/updateUserMutation.ts
@@ -1,6 +1,6 @@
 import { gql } from 'graphql-tag'
 
-import type { CurrentUser } from '#stores/userStore.js'
+import type { CurrentUser } from '#stores/userStore'
 
 export type UpdateUserInput = {
   name: string

--- a/frontend/src/graphql/mutations/updateUserMutation.ts
+++ b/frontend/src/graphql/mutations/updateUserMutation.ts
@@ -1,8 +1,16 @@
 import { gql } from 'graphql-tag'
 
-export const currentUserQuery = gql`
-  query {
-    currentUser {
+import type { CurrentUser } from '#stores/userStore.js'
+
+export type UpdateUserInput = {
+  name: string
+  introduction?: string | null
+  availability?: null | 'available' | 'partly_available' | 'busy'
+}
+
+export const updateUserMutation = gql`
+  mutation updateUser($data: UpdateUserInput!) {
+    updateUser(data: $data) {
       id
       name
       username
@@ -32,3 +40,6 @@ export const currentUserQuery = gql`
     }
   }
 `
+export type UpdateUserMutationResult = {
+  updateUser: CurrentUser
+}

--- a/frontend/src/stores/userStore.spec.ts
+++ b/frontend/src/stores/userStore.spec.ts
@@ -1,7 +1,7 @@
 import { provideApolloClient } from '@vue/apollo-composable'
 import { createMockClient } from 'mock-apollo-client'
 import { setActivePinia, createPinia } from 'pinia'
-import { vi, describe, it, expect, beforeAll, beforeEach } from 'vitest'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
 
 import { addSocialMediaMutation } from '#mutations/addSocialMediaMutation'
 import { addUserDetailMutation } from '#mutations/addUserDetailMutation'
@@ -51,13 +51,15 @@ mockClient.setRequestHandler(removeSocialMediaMutation, removeSocialMediaMock.mo
 
 provideApolloClient(mockClient)
 
-describe('User Store', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
+const setup = () => {
+  setActivePinia(createPinia())
+  const userStore = useUserStore()
+  return userStore
+}
 
+describe('User Store', () => {
   describe('defaults', () => {
-    const userStore = useUserStore()
+    const userStore = setup()
     it('has defaults set correctly', () => {
       expect(userStore.currentUser).toEqual({
         id: 666,
@@ -90,8 +92,9 @@ describe('User Store', () => {
   })
 
   describe('api', () => {
-    const userStore = useUserStore()
+    const userStore = setup()
     it('queries the API', () => {
+      const currentUserQueryMock = vi.fn()
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const user = userStore.currentUser
       expect(currentUserQueryMock).toHaveBeenCalledTimes(1)
@@ -99,8 +102,8 @@ describe('User Store', () => {
   })
 
   describe('set current user action', () => {
-    const userStore = useUserStore()
-    beforeAll(() => {
+    const userStore = setup()
+    beforeEach(() => {
       userStore.setCurrentUser({
         id: 666,
         name: 'Current User',
@@ -203,8 +206,7 @@ describe('User Store', () => {
   })
 
   describe('update user', () => {
-    const userStore = useUserStore()
-    beforeAll(async () => {
+    const updateUser = async (userStore: ReturnType<typeof setup>) => {
       updateUserMutationMock.mockResolvedValue({
         data: {
           updateUser: {
@@ -224,9 +226,11 @@ describe('User Store', () => {
         introduction: 'My introduction',
         availability: 'available',
       })
-    })
+    }
 
-    it('updates the current user', () => {
+    it('updates the current user', async () => {
+      const userStore = setup()
+      await updateUser(userStore)
       expect(userStore.getCurrentUser).toEqual({
         id: 666,
         name: 'Updated Name',
@@ -241,8 +245,8 @@ describe('User Store', () => {
   })
 
   describe('add user detail', () => {
-    const userStore = useUserStore()
-    beforeAll(async () => {
+    const userStore = setup()
+    beforeEach(async () => {
       addUserDetailMock.mockResolvedValue({
         data: {
           addUserDetail: {
@@ -267,8 +271,8 @@ describe('User Store', () => {
   })
 
   describe('remove user detail', () => {
-    const userStore = useUserStore()
-    beforeAll(async () => {
+    const userStore = setup()
+    beforeEach(async () => {
       await userStore.removeUserDetail(1)
     })
 
@@ -278,8 +282,8 @@ describe('User Store', () => {
   })
 
   describe('add social media account', () => {
-    const userStore = useUserStore()
-    beforeAll(async () => {
+    const userStore = setup()
+    beforeEach(async () => {
       addSocialMediaMock.mockResolvedValue({
         data: {
           addSocialMedia: {
@@ -305,8 +309,8 @@ describe('User Store', () => {
   })
 
   describe('remove social media account', () => {
-    const userStore = useUserStore()
-    beforeAll(async () => {
+    const userStore = setup()
+    beforeEach(async () => {
       await userStore.removeSocialMedia(1)
     })
 

--- a/frontend/src/stores/userStore.spec.ts
+++ b/frontend/src/stores/userStore.spec.ts
@@ -1,7 +1,7 @@
 import { provideApolloClient } from '@vue/apollo-composable'
 import { createMockClient } from 'mock-apollo-client'
 import { setActivePinia, createPinia } from 'pinia'
-import { vi, describe, it, expect, beforeAll } from 'vitest'
+import { vi, describe, it, expect, beforeAll, beforeEach } from 'vitest'
 
 import { addSocialMediaMutation } from '#mutations/addSocialMediaMutation'
 import { addUserDetailMutation } from '#mutations/addUserDetailMutation'
@@ -32,8 +32,8 @@ mockClient.setRequestHandler(
         table: null,
         availability: null,
         introduction: '',
-        details: [],
-        social: [],
+        details: [{ id: 1, category: 'education', text: 'I am a student' }],
+        social: [{ id: 1, type: 'instagram', link: 'https://instagram.com' }],
       },
     },
   }),
@@ -52,10 +52,12 @@ mockClient.setRequestHandler(removeSocialMediaMutation, removeSocialMediaMock.mo
 provideApolloClient(mockClient)
 
 describe('User Store', () => {
-  setActivePinia(createPinia())
-  const userStore = useUserStore()
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
 
   describe('defaults', () => {
+    const userStore = useUserStore()
     it('has defaults set correctly', () => {
       expect(userStore.currentUser).toEqual({
         id: 666,
@@ -64,8 +66,8 @@ describe('User Store', () => {
         username: 'currentUser',
         availability: null,
         introduction: '',
-        details: [],
-        social: [],
+        details: [{ id: 1, category: 'education', text: 'I am a student' }],
+        social: [{ id: 1, type: 'instagram', link: 'https://instagram.com' }],
       })
       expect(userStore.getCurrentUser).toEqual({
         id: 666,
@@ -74,8 +76,8 @@ describe('User Store', () => {
         username: 'currentUser',
         availability: null,
         introduction: '',
-        details: [],
-        social: [],
+        details: [{ id: 1, category: 'education', text: 'I am a student' }],
+        social: [{ id: 1, type: 'instagram', link: 'https://instagram.com' }],
       })
     })
 
@@ -88,12 +90,16 @@ describe('User Store', () => {
   })
 
   describe('api', () => {
+    const userStore = useUserStore()
     it('queries the API', () => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const user = userStore.currentUser
       expect(currentUserQueryMock).toHaveBeenCalledTimes(1)
     })
   })
 
   describe('set current user action', () => {
+    const userStore = useUserStore()
     beforeAll(() => {
       userStore.setCurrentUser({
         id: 666,
@@ -197,6 +203,7 @@ describe('User Store', () => {
   })
 
   describe('update user', () => {
+    const userStore = useUserStore()
     beforeAll(async () => {
       updateUserMutationMock.mockResolvedValue({
         data: {
@@ -207,8 +214,8 @@ describe('User Store', () => {
             table: null,
             availability: 'available',
             introduction: 'My introduction',
-            details: [],
-            social: [],
+            details: [{ id: 1, category: 'education', text: 'I am a student' }],
+            social: [{ id: 1, type: 'instagram', link: 'https://instagram.com' }],
           },
         },
       })
@@ -226,79 +233,85 @@ describe('User Store', () => {
         username: 'currentUser',
         introduction: 'My introduction',
         availability: 'available',
-        details: [],
-        social: [],
+        details: [{ id: 1, category: 'education', text: 'I am a student' }],
+        social: [{ id: 1, type: 'instagram', link: 'https://instagram.com' }],
         table: null,
       })
     })
+  })
 
-    describe('add user detail', () => {
-      beforeAll(async () => {
-        addUserDetailMock.mockResolvedValue({
-          data: {
-            addUserDetail: {
-              id: 2,
-              category: 'work',
-              text: 'I am a developer',
-            },
+  describe('add user detail', () => {
+    const userStore = useUserStore()
+    beforeAll(async () => {
+      addUserDetailMock.mockResolvedValue({
+        data: {
+          addUserDetail: {
+            id: 2,
+            category: 'work',
+            text: 'I am a developer',
           },
-        })
-        await userStore.addUserDetail({
-          text: 'I am a developer',
-          category: 'work',
-        })
+        },
       })
-
-      it('adds a user detail', () => {
-        expect(userStore.getCurrentUser?.details).toEqual([
-          { id: 2, category: 'work', text: 'I am a developer' },
-        ])
+      await userStore.addUserDetail({
+        text: 'I am a developer',
+        category: 'work',
       })
     })
 
-    describe('remove user detail', () => {
-      beforeAll(async () => {
-        await userStore.removeUserDetail(2)
-      })
+    it('adds a user detail', () => {
+      expect(userStore.getCurrentUser?.details).toEqual([
+        { id: 1, category: 'education', text: 'I am a student' },
+        { id: 2, category: 'work', text: 'I am a developer' },
+      ])
+    })
+  })
 
-      it('removes a user detail', () => {
-        expect(userStore.getCurrentUser?.details).toEqual([])
-      })
+  describe('remove user detail', () => {
+    const userStore = useUserStore()
+    beforeAll(async () => {
+      await userStore.removeUserDetail(1)
     })
 
-    describe('add social media account', () => {
-      beforeAll(async () => {
-        addSocialMediaMock.mockResolvedValue({
-          data: {
-            addSocialMedia: {
-              id: 4,
-              type: 'twitter',
-              link: 'https://twitter.com',
-            },
+    it('removes a user detail', () => {
+      expect(userStore.getCurrentUser?.details).toEqual([])
+    })
+  })
+
+  describe('add social media account', () => {
+    const userStore = useUserStore()
+    beforeAll(async () => {
+      addSocialMediaMock.mockResolvedValue({
+        data: {
+          addSocialMedia: {
+            id: 4,
+            type: 'twitter',
+            link: 'https://twitter.com',
           },
-        })
-
-        await userStore.addSocialMedia({
-          type: 'twitter',
-          link: 'https://twitter.com',
-        })
+        },
       })
 
-      it('adds a social media account', () => {
-        expect(userStore.getCurrentUser?.social).toEqual([
-          { id: 4, type: 'twitter', link: 'https://twitter.com' },
-        ])
+      await userStore.addSocialMedia({
+        type: 'twitter',
+        link: 'https://twitter.com',
       })
     })
 
-    describe('remove social media account', () => {
-      beforeAll(async () => {
-        await userStore.removeSocialMedia(4)
-      })
+    it('adds a social media account', () => {
+      expect(userStore.getCurrentUser?.social).toEqual([
+        { id: 1, type: 'instagram', link: 'https://instagram.com' },
+        { id: 4, type: 'twitter', link: 'https://twitter.com' },
+      ])
+    })
+  })
 
-      it('removes a social media account', () => {
-        expect(userStore.getCurrentUser?.social).toEqual([])
-      })
+  describe('remove social media account', () => {
+    const userStore = useUserStore()
+    beforeAll(async () => {
+      await userStore.removeSocialMedia(1)
+    })
+
+    it('removes a social media account', () => {
+      expect(userStore.getCurrentUser?.social).toEqual([])
     })
   })
 })

--- a/frontend/src/stores/userStore.ts
+++ b/frontend/src/stores/userStore.ts
@@ -13,7 +13,7 @@ import {
   AddUserDetailMutationResult,
 } from '#mutations/addUserDetailMutation'
 import { removeSocialMediaMutation } from '#mutations/removeSocialMediaMutation'
-import { removeUserDetailMutation } from '#mutations/removeUserDetailMutation.js'
+import { removeUserDetailMutation } from '#mutations/removeUserDetailMutation'
 import {
   updateUserMutation,
   UpdateUserInput,

--- a/frontend/src/stores/userStore.ts
+++ b/frontend/src/stores/userStore.ts
@@ -1,8 +1,28 @@
-import { useQuery } from '@vue/apollo-composable'
+import { useMutation, useQuery } from '@vue/apollo-composable'
 import { acceptHMRUpdate, defineStore } from 'pinia'
 import { computed, ref, watch } from 'vue'
 
+import {
+  addSocialMediaMutation,
+  AddSocialMediaInput,
+  AddSocialMediaMutationResult,
+} from '#mutations/addSocialMediaMutation'
+import {
+  addUserDetailMutation,
+  AddUserDetailInput,
+  AddUserDetailMutationResult,
+} from '#mutations/addUserDetailMutation'
+import { removeSocialMediaMutation } from '#mutations/removeSocialMediaMutation'
+import { removeUserDetailMutation } from '#mutations/removeUserDetailMutation.js'
+import {
+  updateUserMutation,
+  UpdateUserInput,
+  UpdateUserMutationResult,
+} from '#mutations/updateUserMutation'
 import { currentUserQuery } from '#queries/currentUserQuery'
+
+export type { AddSocialMediaInput } from '#mutations/addSocialMediaMutation'
+export type { AddUserDetailInput } from '#mutations/addUserDetailMutation'
 
 export type UserInTable = {
   id: number
@@ -18,12 +38,32 @@ export type MyTable = {
   users: UserInTable[]
 }
 
+export type UserDetailCategory = 'place' | 'work' | 'language' | 'education' | 'feeling'
+
+export type UserDetail = {
+  id: number
+  category: UserDetailCategory
+  text: string
+}
+
+export type UserAvailability = null | 'available' | 'partly_available' | 'busy'
+
+export type SocialMedia = {
+  id: number
+  type: string
+  link: string
+}
+
 export type CurrentUser = {
   id: number
   name: string
   username: string
   avatar?: string
   table?: MyTable
+  introduction?: string
+  availability: UserAvailability
+  details: UserDetail[]
+  social: SocialMedia[]
 }
 
 export const useUserStore = defineStore(
@@ -31,7 +71,7 @@ export const useUserStore = defineStore(
   () => {
     const currentUser = ref<CurrentUser | null>(null)
 
-    const { result: currentUserQueryResult } = useQuery(
+    const { result: currentUserQueryResult, loading } = useQuery(
       currentUserQuery,
       {},
       {
@@ -66,7 +106,84 @@ export const useUserStore = defineStore(
       currentUser.value = user
     }
 
+    const { mutate: updateUserMutationResult } = useMutation<UpdateUserMutationResult>(
+      updateUserMutation,
+      {
+        fetchPolicy: 'no-cache',
+      },
+    )
+
+    const updateUser = async (data: UpdateUserInput) => {
+      const result = await updateUserMutationResult({ data })
+      if (result?.data) {
+        setCurrentUser(result.data.updateUser)
+      }
+    }
+
+    const { mutate: addUserDetailMutationResult } = useMutation<AddUserDetailMutationResult>(
+      addUserDetailMutation,
+      {
+        fetchPolicy: 'no-cache',
+      },
+    )
+
+    const addUserDetail = async (userDetail: AddUserDetailInput) => {
+      const result = await addUserDetailMutationResult({ data: userDetail })
+      if (result?.data && currentUser.value?.id) {
+        setCurrentUser({
+          ...currentUser.value,
+          details: [...currentUser.value.details, result.data.addUserDetail],
+        })
+      }
+    }
+
+    const { mutate: removeUserDetailMutationResult } = useMutation(removeUserDetailMutation, {
+      fetchPolicy: 'no-cache',
+    })
+
+    const removeUserDetail = async (userDetailId: number) => {
+      await removeUserDetailMutationResult({ id: userDetailId })
+      if (currentUser.value?.id) {
+        setCurrentUser({
+          ...currentUser.value,
+          details: currentUser.value.details.filter((d) => d.id !== userDetailId),
+        })
+      }
+    }
+
+    const { mutate: AddSocialMediaMutationResult } = useMutation<AddSocialMediaMutationResult>(
+      addSocialMediaMutation,
+      {
+        fetchPolicy: 'no-cache',
+      },
+    )
+
+    const addSocialMedia = async (socialMedia: AddSocialMediaInput) => {
+      const result = await AddSocialMediaMutationResult({ data: socialMedia })
+      if (result?.data && currentUser.value?.id) {
+        setCurrentUser({
+          ...currentUser.value,
+          social: [...currentUser.value.social, result.data.addSocialMedia],
+        })
+      }
+    }
+
+    const { mutate: removeSocialMediaMutationResult } = useMutation(removeSocialMediaMutation, {
+      fetchPolicy: 'no-cache',
+    })
+
+    const removeSocialMedia = async (socialMediaId: number) => {
+      await removeSocialMediaMutationResult({ id: socialMediaId })
+      if (currentUser.value?.id) {
+        setCurrentUser({
+          ...currentUser.value,
+          social: currentUser.value.social.filter((s) => s.id !== socialMediaId),
+        })
+      }
+    }
+
     return {
+      loading,
       currentUser,
       getCurrentUser,
       setCurrentUser,
@@ -74,10 +191,15 @@ export const useUserStore = defineStore(
       getCurrentUserAvatar,
       getMyTable,
       getUsersInMyTable,
+      updateUser,
+      addUserDetail,
+      addSocialMedia,
+      removeUserDetail,
+      removeSocialMedia,
     }
   },
   {
-    persist: true,
+    persist: false,
   },
 )
 


### PR DESCRIPTION
## 🍰 Pullrequest
- Adds mutations for adding and removing user details and social media accounts
- Adds a mutation to update availability and name of a user
- Modifies the user query to contain these informations
- Updates the user store, which now uses those mutations and exposes them as actions
- Don't persist user store to avoid hydration mismatches (sorry,  unrelated, but one line)

Will be used by #1327.

### Issues
- fixes part of #1018 
