### PR TITLE
fix(frontend): avoid overlap of desktop bottom bar with BBB interfaces

### DIFF
--- a/frontend/src/pages/table/+Page.vue
+++ b/frontend/src/pages/table/+Page.vue
@@ -47,7 +47,7 @@ watch(joinTableQueryError, (error) => {
 @import 'vuetify/lib/styles/settings/_variables';
 
 .container {
-  --bottom-height: 16px;
+  --bottom-height: 136px;
 
   width: 100%;
   height: calc(100vh - var(--v-layout-top) - var(--bottom-height));


### PR DESCRIPTION
## 🍰 Pullrequest
We don't want:
<img width="1506" alt="Screenshot 2024-08-15 at 12 29 54" src="https://github.com/user-attachments/assets/84eb8456-ce28-4b70-8418-fe732f2666be">

Quickfix: We change the container height for the table page.
<img width="1505" alt="Screenshot 2024-08-15 at 12 29 07" src="https://github.com/user-attachments/assets/148a9995-abb9-45b8-b33c-56ff1173685e">
