### PR TITLE
fix(frontend): table page iframe after meeting ended

### DIFF
--- a/backend/.env.dist
+++ b/backend/.env.dist
@@ -9,6 +9,7 @@ DATABASE_URL="mysql://root:@localhost:3306/dreammall.earth"
 
 FRONTEND_URL="http://localhost:3000/"
 FRONTEND_INVITE_LINK_URL="${FRONTEND_URL}join-table/"
+FRONTEND_BBB_LOGOUT_URL="${FRONTEND_URL}table-closed/"
 
 BBB_SHARED_SECRET=""
 BBB_URL=""

--- a/backend/src/api/BBB.ts
+++ b/backend/src/api/BBB.ts
@@ -26,6 +26,7 @@ const parser = new XMLParser({
 const defaultCreateMeetingBodyOptions = {
   welcome: '<div></div>',
   meetingLayout: MeetingLayouts.SMART_LAYOUT,
+  logoutURL: CONFIG.FRONTEND_BBB_LOGOUT_URL,
 }
 
 export const getMeetings = async (): Promise<MeetingInfo[]> => {

--- a/backend/src/api/BBB/types.ts
+++ b/backend/src/api/BBB/types.ts
@@ -91,4 +91,5 @@ export interface CreateMeetingBodyOptions {
   welcome?: string
   meetingLayout?: MeetingLayouts
   moderatorOnlyMessage?: string
+  logoutURL?: string
 }

--- a/backend/src/config/config.ts
+++ b/backend/src/config/config.ts
@@ -39,6 +39,8 @@ const FRONTEND = {
   FRONTEND_URL: process.env.FRONTEND_URL ?? 'http://localhost:3000/',
   FRONTEND_INVITE_LINK_URL:
     process.env.FRONTEND_INVITE_LINK_URL ?? 'http://localhost:3000/join-table/',
+  FRONTEND_BBB_LOGOUT_URL:
+    process.env.FRONTEND_BBB_LOGOUT_URL ?? 'http://localhost:3000/table-closed/',
 }
 
 const { JWKS_URI } = process.env

--- a/frontend/src/components/embedded-table/EmbeddedTable.vue
+++ b/frontend/src/components/embedded-table/EmbeddedTable.vue
@@ -5,14 +5,41 @@
     height="100%"
     :src="props.url"
     allow="camera;microphone;fullscreen;display-capture *;"
+    class="table-iframe"
   ></iframe>
 </template>
 
 <script setup lang="ts">
+import { onMounted, onUnmounted } from 'vue'
+
 const props = defineProps<{
   /**
    * The url of the BigBlueButton meeting table (CSP should allow only specific hosts)
    */
   url: string | null
 }>()
+
+const emit = defineEmits<{
+  (e: 'table-closed'): void
+}>()
+
+const postMessageListener = (event: MessageEvent) => {
+  if (event.data === 'close') {
+    emit('table-closed')
+  }
+}
+
+onMounted(() => {
+  window.addEventListener('message', postMessageListener)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('message', postMessageListener)
+})
 </script>
+
+<style scoped>
+.table-iframe {
+  border: none;
+}
+</style>

--- a/frontend/src/components/embedded-table/__snapshots__/EmbeddedTable.test.ts.snap
+++ b/frontend/src/components/embedded-table/__snapshots__/EmbeddedTable.test.ts.snap
@@ -3,6 +3,8 @@
 exports[`EmbeddedTable > renders 1`] = `
 <iframe
   allow="camera;microphone;fullscreen;display-capture *;"
+  class="table-iframe"
+  data-v-51765335=""
   height="100%"
   src="https://dreammall.earth"
   width="100%"

--- a/frontend/src/pages/table-closed/+Page.vue
+++ b/frontend/src/pages/table-closed/+Page.vue
@@ -1,0 +1,12 @@
+<template>
+  <div></div>
+</template>
+
+<script setup lang="ts">
+import { navigate } from 'vike/client/router'
+import { onBeforeMount } from 'vue'
+
+onBeforeMount(() => {
+  navigate('/')
+})
+</script>

--- a/frontend/src/pages/table-closed/+Page.vue
+++ b/frontend/src/pages/table-closed/+Page.vue
@@ -3,10 +3,9 @@
 </template>
 
 <script setup lang="ts">
-import { navigate } from 'vike/client/router'
-import { onBeforeMount } from 'vue'
+import { onMounted } from 'vue'
 
-onBeforeMount(() => {
-  navigate('/')
+onMounted(() => {
+  window.parent.postMessage('close', '*')
 })
 </script>

--- a/frontend/src/pages/table/+Page.vue
+++ b/frontend/src/pages/table/+Page.vue
@@ -1,13 +1,14 @@
 <template>
   <DefaultLayout>
     <div class="container">
-      <EmbeddedTable :url="tableUrl" />
+      <EmbeddedTable :url="tableUrl" @table-closed="onTableClosed" />
     </div>
   </DefaultLayout>
 </template>
 
 <script setup lang="ts">
 import { useQuery } from '@vue/apollo-composable'
+import { navigate } from 'vike/client/router'
 import { ref, watch } from 'vue'
 
 import EmbeddedTable from '#components/embedded-table/EmbeddedTable.vue'
@@ -41,6 +42,8 @@ watch(joinTableQueryResult, (data: { joinTable: string }) => {
 watch(joinTableQueryError, (error) => {
   GlobalErrorHandler.error('Error opening table', error)
 })
+
+const onTableClosed = () => navigate('/')
 </script>
 
 <style scoped lang="scss">

--- a/frontend/src/pages/table/__snapshots__/Page.test.ts.snap
+++ b/frontend/src/pages/table/__snapshots__/Page.test.ts.snap
@@ -967,6 +967,8 @@ exports[`Table Page > renders 1`] = `
         >
           <iframe
             allow="camera;microphone;fullscreen;display-capture *;"
+            class="table-iframe"
+            data-v-51765335=""
             data-v-dca85f6b=""
             height="100%"
             src="https://some-link-to-meeting.com"


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

BBB redirects the iframe of the table page to the table-closed page, which sends a postMessage message to the iframe's parent, which in turn triggers a redirect to the start page.

### Issues
- fixes #706

### How to test frontend part
- Checkout this branch
- Run backend and frontend
- Open http://localhost:3000
- Open a table
- Set iframe src manually / in console to '/page-closed'

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
