### PR TITLE
fix(docker): migrate database when building docker

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -54,6 +54,7 @@ COPY prisma ./prisma
 RUN npm install --include=dev --frozen-lockfile --non-interactive
 COPY . .
 RUN npm run build
+RUN npm run db:migrate
 
 ##################################################################################
 # PRODUCTION (Does contain only "binary"- and static-files to reduce image size) #


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

When there is no database present the database is not migrated initially (or so it seems).
In my case this resulted in a missing table User, since I had a very old Version of the database present.

![2024-08-27_11-36-38_screenshot](https://github.com/user-attachments/assets/cacabba9-b961-414f-bc84-4368783fbfd5)

This PR fixes it.

Te reproduce run
1. ` docker system prune --all --volumes`
2. `docker compose up --build`

This should migrate the database properly.

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
