### PR TITLE
refactor(other): rename all remaining "room" to "table"

### DIFF
--- a/backend/src/graphql/pubSub.ts
+++ b/backend/src/graphql/pubSub.ts
@@ -3,5 +3,5 @@ import { createPubSub } from 'graphql-yoga'
 import { MeetingInfo } from '#api/BBB'
 
 export const pubSub = createPubSub<{
-  OPEN_ROOM_SUBSCRIPTION: [MeetingInfo[]]
+  OPEN_TABLE_SUBSCRIPTION: [MeetingInfo[]]
 }>()

--- a/backend/src/graphql/resolvers/TableResolver.spec.ts
+++ b/backend/src/graphql/resolvers/TableResolver.spec.ts
@@ -626,7 +626,7 @@ describe('TableResolver', () => {
           await expect(prisma.usersInMeetings.findMany()).resolves.toHaveLength(0)
         })
 
-        it('creates update my room event', async () => {
+        it('creates update my table event', async () => {
           const user = await prisma.user.findUnique({
             where: {
               username: nickname,
@@ -764,7 +764,7 @@ describe('TableResolver', () => {
             {
               query: createMyTableMutation,
               variables: {
-                name: 'My Room',
+                name: 'My Table',
                 isPublic: true,
               },
             },
@@ -835,7 +835,7 @@ describe('TableResolver', () => {
             meeting: {
               // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
               id: expect.any(Number),
-              name: 'My Room',
+              name: 'My Table',
               // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
               meetingID: expect.any(String),
               attendeePW: 'w3VUvMcp',

--- a/backend/src/graphql/resolvers/TableResolver.ts
+++ b/backend/src/graphql/resolvers/TableResolver.ts
@@ -278,7 +278,7 @@ export class TableResolver {
   }
 
   @Subscription(() => [OpenTable], {
-    topics: 'OPEN_ROOM_SUBSCRIPTION',
+    topics: 'OPEN_TABLE_SUBSCRIPTION',
   })
   async updateOpenTables(
     @Root() meetings: MeetingInfo[],
@@ -292,7 +292,7 @@ export class TableResolver {
   @Query(() => Boolean)
   test(): boolean {
     try {
-      pubSub.publish('OPEN_ROOM_SUBSCRIPTION', 'Hallo')
+      pubSub.publish('OPEN_TABLE_SUBSCRIPTION', 'Hallo')
     } catch (err) {
       console.log(err)
     }

--- a/backend/src/graphql/resolvers/dal/handleOpenTables.ts
+++ b/backend/src/graphql/resolvers/dal/handleOpenTables.ts
@@ -4,7 +4,7 @@ import { prisma } from '#src/prisma'
 
 export const handleOpenTables = async (): Promise<void> => {
   const meetings = await getMeetings()
-  pubSub.publish('OPEN_ROOM_SUBSCRIPTION', meetings)
+  pubSub.publish('OPEN_TABLE_SUBSCRIPTION', meetings)
   await prisma.meeting.updateMany({
     where: {
       createTime: { not: null },

--- a/frontend/src/stores/userStore.spec.ts
+++ b/frontend/src/stores/userStore.spec.ts
@@ -155,7 +155,7 @@ describe('User Store', () => {
       })
     })
 
-    it('updates my room', () => {
+    it('updates my table', () => {
       expect(userStore.getMyTable).toEqual({
         id: 1234,
         name: 'My Table',
@@ -177,7 +177,7 @@ describe('User Store', () => {
       })
     })
 
-    it('updates users in my room', () => {
+    it('updates users in my table', () => {
       expect(userStore.getUsersInMyTable).toEqual([
         {
           id: 333,


### PR DESCRIPTION
## 🍰 Pullrequest
There are still instances of `room` wordings left, but we changed the term to `table`.