### PR TITLE
fix(frontend): remove imports for defineProps and defineEmits. 

### DIFF
--- a/frontend/src/components/buttons/SimpleButton.vue
+++ b/frontend/src/components/buttons/SimpleButton.vue
@@ -5,8 +5,6 @@
 </template>
 
 <script setup lang="ts">
-import { defineProps, defineEmits } from 'vue'
-
 defineProps({
   icon: {
     type: String,

--- a/frontend/src/components/cockpit/options-list/OptionButton.vue
+++ b/frontend/src/components/cockpit/options-list/OptionButton.vue
@@ -7,8 +7,6 @@
 </template>
 
 <script lang="ts" setup>
-import { defineEmits } from 'vue'
-
 defineEmits(['click'])
 </script>
 

--- a/frontend/src/components/cockpit/options-list/OptionsList.vue
+++ b/frontend/src/components/cockpit/options-list/OptionsList.vue
@@ -7,8 +7,6 @@
 </template>
 
 <script lang="ts" setup>
-import { defineProps } from 'vue'
-
 const props = defineProps<{
   isVisible?: boolean
 }>()

--- a/frontend/src/panels/PanelHeader.vue
+++ b/frontend/src/panels/PanelHeader.vue
@@ -17,8 +17,6 @@
 </template>
 
 <script setup lang="ts">
-import { defineProps, defineEmits } from 'vue'
-
 withDefaults(
   defineProps<{
     title: string

--- a/frontend/src/panels/dreammall/TableSetupStepC.vue
+++ b/frontend/src/panels/dreammall/TableSetupStepC.vue
@@ -41,7 +41,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, computed, watch, defineProps } from 'vue'
+import { ref, computed, watch } from 'vue'
 
 import SimpleButton from '#components/buttons/SimpleButton.vue'
 import UserInvitationItem from '#src/panels/dreammall/components/UserInvitationItem.vue'

--- a/frontend/src/panels/dreammall/TableSetupStepD.vue
+++ b/frontend/src/panels/dreammall/TableSetupStepD.vue
@@ -11,8 +11,6 @@
 </template>
 
 <script lang="ts" setup>
-import { defineProps } from 'vue'
-
 import SimpleButton from '#components/buttons/SimpleButton.vue'
 
 import { TableSetupEmits, TableSetupProps } from './TableSetupProps'

--- a/frontend/src/panels/dreammall/components/UserInvitationItem.vue
+++ b/frontend/src/panels/dreammall/components/UserInvitationItem.vue
@@ -37,8 +37,6 @@
 </template>
 
 <script lang="ts" setup>
-import { defineProps, defineEmits } from 'vue'
-
 import UserInvitation from '#src/panels/dreammall/interfaces/UserInvitation'
 
 const props = defineProps<{


### PR DESCRIPTION


<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
`defineProps` and `defineEmits` are vue compiler macros and don't need to be imported. So let's remove the imports.

<img width="755" alt="Screenshot 2024-08-29 at 22 42 47" src="https://github.com/user-attachments/assets/58602fd4-dcda-441c-ae59-39676501b49f">
