### PR TITLE
fix(frontend): reactive mock page context

### DIFF
--- a/frontend/scripts/tests/mock.vikePageContext.ts
+++ b/frontend/scripts/tests/mock.vikePageContext.ts
@@ -1,4 +1,5 @@
 import { config } from '@vue/test-utils'
+import { reactive } from 'vue'
 
 import { vikePageContext } from '#context/usePageContext'
 
@@ -9,9 +10,9 @@ type MockPageContext = {
   }
 }
 
-export const mockPageContext: MockPageContext = {
+export const mockPageContext: MockPageContext = reactive({
   urlPathname: '/some-url',
-}
+})
 
 config.global.provide = {
   ...config.global.provide,

--- a/frontend/src/pages/table/Page.test.ts
+++ b/frontend/src/pages/table/Page.test.ts
@@ -120,5 +120,15 @@ describe('Table Page', () => {
     it('shows an iframe', () => {
       expect(wrapper.find('iframe').exists()).toBe(true)
     })
+
+    it('open table changes when url changes', async () => {
+      mockPageContext.routeParams = {
+        id: 420,
+      }
+      await flushPromises()
+      expect(joinTableQueryMock).toHaveBeenCalledWith({
+        tableId: 420,
+      })
+    })
   })
 })


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
pageContext can change and we can (and do) watch on it. (`src/pages/table/+Page.vue` line 26)

When testing, we get:
<img width="708" alt="Screenshot 2024-08-30 at 11 40 06" src="https://github.com/user-attachments/assets/8e733a80-a925-46dd-b607-52f33b2fc33e">

This PR fixes the problem by making mockPageContext reactive.
