### PR TITLE
fix(frontend): fix pinia test warning and clean up console output while testing

### DIFF
--- a/frontend/renderer/plugins/globalErrorHandler.ts
+++ b/frontend/renderer/plugins/globalErrorHandler.ts
@@ -1,10 +1,11 @@
 import { App } from 'vue'
 import { toast } from 'vue3-toastify'
 
-const handleError = (message: string, data?: unknown) => {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const handleError = (message: string, _data?: unknown) => {
   toast.error(message)
-  // eslint-disable-next-line no-console
-  console.error(message, data)
+  // TODO log errors while developing, but not in tests
+  // console.error(message, data)
 }
 const handleWarning = (message: string) => {
   toast.warning(message)

--- a/frontend/scripts/tests/mock.vikePageContext.ts
+++ b/frontend/scripts/tests/mock.vikePageContext.ts
@@ -1,4 +1,5 @@
 import { config } from '@vue/test-utils'
+import { reactive } from 'vue'
 
 import { vikePageContext } from '#context/usePageContext'
 
@@ -9,9 +10,9 @@ type MockPageContext = {
   }
 }
 
-export const mockPageContext: MockPageContext = {
+export const mockPageContext: MockPageContext = reactive({
   urlPathname: '/some-url',
-}
+})
 
 config.global.provide = {
   ...config.global.provide,

--- a/frontend/src/components/cockpit/about-me/AboutMe.test.ts
+++ b/frontend/src/components/cockpit/about-me/AboutMe.test.ts
@@ -1,4 +1,3 @@
-import { createTestingPinia } from '@pinia/testing'
 import { provideApolloClient } from '@vue/apollo-composable'
 import { mount } from '@vue/test-utils'
 import { createMockClient } from 'mock-apollo-client'
@@ -128,9 +127,6 @@ describe('AboutMe', () => {
   const Wrapper = (props = {}) =>
     mount(AboutMe, {
       props,
-      global: {
-        plugins: [createTestingPinia()],
-      },
     })
 
   it('renders', () => {

--- a/frontend/src/pages/table/Page.test.ts
+++ b/frontend/src/pages/table/Page.test.ts
@@ -120,5 +120,15 @@ describe('Table Page', () => {
     it('shows an iframe', () => {
       expect(wrapper.find('iframe').exists()).toBe(true)
     })
+
+    it('open table changes when url changes', async () => {
+      mockPageContext.routeParams = {
+        id: 420,
+      }
+      await flushPromises()
+      expect(joinTableQueryMock).toHaveBeenCalledWith({
+        tableId: 420,
+      })
+    })
   })
 })


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
- Fixes this test warning:
<img width="715" alt="Screenshot 2024-08-30 at 12 21 19" src="https://github.com/user-attachments/assets/0efd4888-2d9b-4663-98df-50c75b916fff">

- When testing, the console is full of outputs like this:
<img width="711" alt="Screenshot 2024-08-30 at 12 21 04" src="https://github.com/user-attachments/assets/5f30f1ed-9076-4ee0-a487-576fda6ac157">
But those are expected errors, caught by our global error handler.  I deactivated the recently introduced `console.error` there for now.

### Issues
- relates #1887 
