### PR TITLE
fix(frontend): show table not found message instead of broken iframe

### DIFF
--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -94,6 +94,9 @@
     "defaultTitle": "DreamMall",
     "joinTableTitle": "Raum beitreten"
   },
+  "table": {
+    "notFound": "Tisch nicht gefunden."
+  },
   "tables": {
     "participantCount": "{count} Teilnehmer"
   },

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -94,6 +94,9 @@
     "defaultTitle": "DreamMall",
     "joinTableTitle": "Enter Table"
   },
+  "table": {
+    "notFound": "Table not found."
+  },
   "tables": {
     "participantCount": "{count} participants"
   },

--- a/frontend/src/pages/table/+Page.vue
+++ b/frontend/src/pages/table/+Page.vue
@@ -1,7 +1,10 @@
 <template>
   <DefaultLayout>
     <div class="container">
-      <EmbeddedTable :url="tableUrl" @table-closed="onTableClosed" />
+      <EmbeddedTable v-if="errorMessage === null" :url="tableUrl" @table-closed="onTableClosed" />
+      <div v-else class="test-not-found">
+        {{ $t('table.notFound') }}
+      </div>
     </div>
   </DefaultLayout>
 </template>
@@ -23,6 +26,8 @@ const pageContext = usePageContext()
 
 const tableId = ref(Number(pageContext.routeParams?.id))
 
+const errorMessage = ref<string | null>(null)
+
 watch(pageContext, (context) => {
   tableId.value = Number(context.routeParams?.id)
 })
@@ -39,12 +44,17 @@ const { result: joinTableQueryResult, error: joinTableQueryError } = useQuery(
 )
 
 watch(joinTableQueryResult, (data: { joinTable: string }) => {
+  if (!data.joinTable) return
   tableUrl.value = data.joinTable
+  errorMessage.value = null
 })
 
 // eslint-disable-next-line promise/prefer-await-to-callbacks
 watch(joinTableQueryError, (error) => {
+  if (!error) return
   GlobalErrorHandler.error('Error opening table', error)
+  errorMessage.value = error.message
+  tableUrl.value = null
 })
 
 const onTableClosed = () => navigate('/')

--- a/frontend/src/pages/table/Page.test.ts
+++ b/frontend/src/pages/table/Page.test.ts
@@ -97,6 +97,29 @@ describe('Table Page', () => {
     })
   })
 
+  describe('route params in page context contains an id and API throws error', () => {
+    beforeEach(async () => {
+      vi.clearAllMocks()
+      wrapper.unmount()
+      mockPageContext.routeParams = {
+        id: 70,
+      }
+      joinTableQueryMock.mockResolvedValue({
+        errors: [{ message: 'Table does not exist' }],
+      })
+      wrapper = Wrapper()
+      await flushPromises()
+    })
+
+    it('does not show an iframe', () => {
+      expect(wrapper.find('iframe').exists()).toBeFalsy()
+    })
+
+    it('renders table not found message', () => {
+      expect(wrapper.find('.test-not-found').exists()).toBeTruthy()
+    })
+  })
+
   describe('route params in page context contains an id and API returns link', () => {
     beforeEach(async () => {
       vi.clearAllMocks()
@@ -105,7 +128,7 @@ describe('Table Page', () => {
         id: 69,
       }
       joinTableQueryMock.mockResolvedValue({
-        data: { joinTable: 'https://some-link-to-meeting.com' },
+        data: { joinTable: 'https://some-link-to-meeting.com', errors: [] },
       })
       wrapper = Wrapper()
       await flushPromises()


### PR DESCRIPTION
## 🍰 Pullrequest
Shows a simple table not found message instead of broken iframe when table cannot be joined or does not exist.

### Issues
- fixes #1873 
