### PR TITLE
refactor(other): auto-migrate with docker-compose

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -58,6 +58,16 @@ services:
     volumes:
       - ./backend:/server
 
+  migrations:
+    build:
+      context: ./backend
+      target: development
+    command: npm run db:migrate
+    environment:
+      - NODE_ENV=development
+    volumes:
+      - ./backend:/server
+
   documentation:
     build:
       target: documentation

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,12 @@ include:
 services:
   database:
     image: mariadb:10.5
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      start_period: 10s
+      interval: 10s
+      timeout: 5s
+      retries: 3
     environment:
       - MARIADB_ALLOW_EMPTY_PASSWORD=1
       - MARIADB_ALLOW_EMPTY_ROOT_PASSWORD=1
@@ -39,13 +45,31 @@ services:
       context: ./backend
       target: production
     depends_on:
-      - database
-      - authentik
+      authentik: # because JWKS_URI
+        condition: service_started
+      database:
+        condition: service_started
+      migrations:
+        condition: service_completed_successfully
+
     ports:
       - 4000:4000
     environment:
       DATABASE_URL: mysql://root:@database:3306/dreammall.earth
       JWKS_URI: http://authentik:9000/application/o/dreammallearth/jwks/
+      NODE_ENV: production
+
+  migrations:
+    image: ghcr.io/dreammall-earth/dreammall.earth/backend:latest
+    command: npm run db:migrate:deploy
+    build:
+      context: ./backend
+      target: production
+    depends_on:
+      database:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: mysql://root:@database:3306/dreammall.earth
       NODE_ENV: production
 
 volumes:


### PR DESCRIPTION
Motivation
----------
I got quite annoyed to run the database migrations manually when doing
a `docker compose down -v` and `docker compose up`.

This will help a little.

Inspired by: https://stackoverflow.com/a/44283611

Healthcheck configuration: https://mariadb.com/kb/en/using-healthcheck-sh/

How to test
-----------
1. `docker compose down -v`
2. `docker compose up`
3. Migrations are auto-applied

For production:
1. `docker compose -f docker-compose.yml down -v`
2. `docker compose -f docker-compose.yml up`
3. Migrations are auto-applied

