### PR TITLE
fix(frontend): reset drawer before it is opened, not before it's closed

### DIFF
--- a/frontend/src/layouts/DefaultLayout.vue
+++ b/frontend/src/layouts/DefaultLayout.vue
@@ -102,7 +102,7 @@ const isButtonListVisible = ref(false)
 const tableSetupRef = ref<InstanceType<typeof TableSetup> | null>(null)
 
 const toggleButtonList = () => {
-  if (isButtonListVisible.value) {
+  if (!isButtonListVisible.value) {
     tableSetupRef.value?.reset()
   }
   isButtonListVisible.value = !isButtonListVisible.value


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
There is a little bug when creating a new table. Scenario: I start to create my table. I see the dialog panel where I can enter the table's name. I decide to abort and click cancel (or close the drawer in any other way). At this moment, the content changes again back to the initial one, before sliding down.  But I would expect it stays the same at least until it is closed.
This PR fixes that.
