### PR TITLE
fix(workflow): replace scope 'dev-deps' by 'deps-dev'

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,7 +32,7 @@ jobs:
             authentik
             backend
             deps
-            dev-deps
+            deps-dev
             docu
             docker
             frontend
@@ -74,10 +74,10 @@ jobs:
           # See: https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-commits-parser#headerpattern
           headerPattern: '^(\w*)(?:\(([\w$.\-*/ ]*)\))?: (.*)$'
           headerPatternCorrespondence: type, scope, subject
-          # For work-in-progress PRs you can typically use draft pull requests 
-          # from GitHub. However, private repositories on the free plan don't have 
-          # this option and therefore this action allows you to opt-in to using the 
-          # special "[WIP]" prefix to indicate this state. This will avoid the 
+          # For work-in-progress PRs you can typically use draft pull requests
+          # from GitHub. However, private repositories on the free plan don't have
+          # this option and therefore this action allows you to opt-in to using the
+          # special "[WIP]" prefix to indicate this state. This will avoid the
           # validation of the PR title and the pull request checks remain pending.
           # Note that a second check will be reported if this is enabled.
           wip: true


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
Name validation for PRs by dependabot, with updates of dev dependencies, fail because the scope they specify does not exist.
<img width="1122" alt="Screenshot 2024-09-09 at 10 17 43" src="https://github.com/user-attachments/assets/78b222e4-4168-49f7-82e1-9827f26e95b7">
The workflow file specifies a scope 'dev-deps', instead of 'deps-dev'.
<img width="666" alt="Screenshot 2024-09-09 at 10 18 04" src="https://github.com/user-attachments/assets/81d80a09-8309-48a5-a452-e087ff68bd5c">
Until now.

(If we think dev-deps is the better name, we could change some dependabot setting instead? But I think my solution here is good enough...)
