### PR TITLE
fix(deps): give all permissions to the automerge job

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   auto-merge:
+    permissions: write-all
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

give all permissions to the automerge job.

This is undocumented but might be the correct solution.

Ressources:
- https://github.com/ahmadnassri/action-dependabot-auto-merge/issues/243
- https://stackoverflow.com/questions/70435286/resource-not-accessible-by-integration-on-github-post-repos-owner-repo-ac

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- relates https://github.com/dreammall-earth/dreammall.earth/issues/1595

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
