### PR TITLE
refactor(frontend): remove unnecessary prop narrow

### DIFF
--- a/frontend/src/components/cockpit/about-me/AboutMeView.vue
+++ b/frontend/src/components/cockpit/about-me/AboutMeView.vue
@@ -1,5 +1,5 @@
 <template>
-  <CockpitCard narrow>
+  <CockpitCard>
     <template #default>
       <div class="header mb-2">
         <v-avatar class="avatar d-flex align-center text-font" size="90">

--- a/frontend/src/components/cockpit/about-me/EditSocialMedia.vue
+++ b/frontend/src/components/cockpit/about-me/EditSocialMedia.vue
@@ -1,5 +1,5 @@
 <template>
-  <CockpitCard narrow>
+  <CockpitCard>
     <template #header>
       <div class="header">
         <button class="back" @click="$emit('back')">

--- a/frontend/src/components/cockpit/about-me/EditUserDetails.vue
+++ b/frontend/src/components/cockpit/about-me/EditUserDetails.vue
@@ -1,5 +1,5 @@
 <template>
-  <CockpitCard narrow>
+  <CockpitCard>
     <template #header>
       <div class="header">
         <button class="back" @click="$emit('back')">

--- a/frontend/src/components/cockpit/about-me/__snapshots__/AboutMeView.test.ts.snap
+++ b/frontend/src/components/cockpit/about-me/__snapshots__/AboutMeView.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`AboutMeView > renders 1`] = `
 <section
-  class="cockpit-card narrow"
+  class="cockpit-card"
   data-v-1451ba78=""
   data-v-f444dc92=""
   editable="false"
@@ -590,7 +590,7 @@ exports[`AboutMeView > renders 1`] = `
 
 exports[`AboutMeView > renders initials 1`] = `
 <section
-  class="cockpit-card narrow"
+  class="cockpit-card"
   data-v-1451ba78=""
   data-v-f444dc92=""
   editable="false"
@@ -1178,7 +1178,7 @@ exports[`AboutMeView > renders initials 1`] = `
 
 exports[`AboutMeView > renders without social media accounts 1`] = `
 <section
-  class="cockpit-card narrow"
+  class="cockpit-card"
   data-v-1451ba78=""
   data-v-f444dc92=""
   editable="false"

--- a/frontend/src/components/cockpit/about-me/__snapshots__/EditSocialMedia.test.ts.snap
+++ b/frontend/src/components/cockpit/about-me/__snapshots__/EditSocialMedia.test.ts.snap
@@ -9,7 +9,7 @@ exports[`EditSocialMedia > renders 1`] = `
   >
     
     <section
-      class="cockpit-card narrow"
+      class="cockpit-card"
       data-v-1451ba78=""
       data-v-ef2a5740=""
     >

--- a/frontend/src/components/cockpit/about-me/__snapshots__/EditUserDetails.test.ts.snap
+++ b/frontend/src/components/cockpit/about-me/__snapshots__/EditUserDetails.test.ts.snap
@@ -9,7 +9,7 @@ exports[`EditUserDetails > renders 1`] = `
   >
     
     <section
-      class="cockpit-card narrow"
+      class="cockpit-card"
       data-v-1451ba78=""
       data-v-8714041d=""
     >

--- a/frontend/src/components/cockpit/cockpit-card/CockpitCard.vue
+++ b/frontend/src/components/cockpit/cockpit-card/CockpitCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="cockpit-card" :class="{ narrow: props.narrow }">
+  <section class="cockpit-card">
     <div v-if="slots.header" class="header">
       <slot name="header"></slot>
     </div>
@@ -12,10 +12,6 @@
 import { useSlots } from 'vue'
 
 const slots = useSlots()
-
-const props = defineProps<{
-  narrow?: boolean
-}>()
 </script>
 
 <style scoped lang="scss">
@@ -45,11 +41,5 @@ const props = defineProps<{
   border-color: rgb(var(--v-theme-background));
   border-style: solid;
   border-width: 0.5px;
-}
-
-@media #{map.get($display-breakpoints, 'md-and-up')} {
-  .narrow {
-    --card-width: 335px;
-  }
 }
 </style>

--- a/frontend/src/components/cockpit/cockpit-card/__snapshots__/CockpitCard.test.ts.snap
+++ b/frontend/src/components/cockpit/cockpit-card/__snapshots__/CockpitCard.test.ts.snap
@@ -4,6 +4,7 @@ exports[`CockpitCard > renders 1`] = `
 <section
   class="cockpit-card"
   data-v-1451ba78=""
+  narrow="false"
 >
   <div
     class="header"
@@ -29,8 +30,9 @@ exports[`CockpitCard > renders 1`] = `
 
 exports[`CockpitCard > renders narrow 1`] = `
 <section
-  class="cockpit-card narrow"
+  class="cockpit-card"
   data-v-1451ba78=""
+  narrow="true"
 >
   <div
     class="header"
@@ -58,6 +60,7 @@ exports[`CockpitCard > renders with empty header slot 1`] = `
 <section
   class="cockpit-card"
   data-v-1451ba78=""
+  narrow="false"
 >
   <div
     class="header"

--- a/frontend/src/components/cockpit/cockpit-layout/CockpitLayout.vue
+++ b/frontend/src/components/cockpit/cockpit-layout/CockpitLayout.vue
@@ -1,0 +1,26 @@
+<template>
+  <div class="cockpit">
+    <slot></slot>
+  </div>
+</template>
+
+<style scoped lang="scss">
+@use 'sass:map';
+@import 'vuetify/lib/styles/settings/_variables';
+
+.cockpit {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 20px;
+  align-items: center;
+  justify-content: center;
+  margin: auto;
+}
+
+@media #{map.get($display-breakpoints, 'md-and-up')} {
+  .cockpit {
+    grid-template-columns: 335px 335px;
+    max-width: 1200px;
+  }
+}
+</style>

--- a/frontend/src/components/cockpit/my-tables/MyTables.vue
+++ b/frontend/src/components/cockpit/my-tables/MyTables.vue
@@ -1,5 +1,5 @@
 <template>
-  <CockpitCard narrow>
+  <CockpitCard>
     <template #header>
       <div class="header">
         <h2>{{ $t('cockpit.myTables.header') }}</h2>

--- a/frontend/src/components/cockpit/my-tables/__snapshots__/MyTables.test.ts.snap
+++ b/frontend/src/components/cockpit/my-tables/__snapshots__/MyTables.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`MyTables > renders 1`] = `
 <section
-  class="cockpit-card narrow"
+  class="cockpit-card"
   data-v-1451ba78=""
   data-v-c2e63817=""
 >

--- a/frontend/src/pages/cockpit/+Page.vue
+++ b/frontend/src/pages/cockpit/+Page.vue
@@ -1,35 +1,15 @@
 <template>
   <DefaultLayout>
-    <div class="cockpit">
+    <CockpitLayout>
       <AboutMe />
       <MyTables />
-    </div>
+    </CockpitLayout>
   </DefaultLayout>
 </template>
 
 <script lang="ts" setup>
 import AboutMe from '#components/cockpit/about-me/AboutMe.vue'
+import CockpitLayout from '#components/cockpit/cockpit-layout/CockpitLayout.vue'
 import MyTables from '#components/cockpit/my-tables/MyTables.vue'
 import DefaultLayout from '#layouts/DefaultLayout.vue'
 </script>
-
-<style scoped lang="scss">
-@use 'sass:map';
-@import 'vuetify/lib/styles/settings/_variables';
-
-.cockpit {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 20px;
-  align-items: center;
-  justify-content: center;
-  margin: auto;
-}
-
-@media #{map.get($display-breakpoints, 'md-and-up')} {
-  .cockpit {
-    grid-template-columns: 335px 335px;
-    max-width: 1200px;
-  }
-}
-</style>

--- a/frontend/src/pages/cockpit/__snapshots__/Page.test.ts.snap
+++ b/frontend/src/pages/cockpit/__snapshots__/Page.test.ts.snap
@@ -11,7 +11,6 @@ exports[`Cockpit Page > without apollo error > renders 1`] = `
     <main
       class="v-main bg-background main-layout"
       data-v-75d0be1e=""
-      data-v-e027cbb0=""
       style="--v-layout-left: 0px; --v-layout-right: 0px; --v-layout-top: 70px; --v-layout-bottom: 0px; transition: none !important;"
     >
       
@@ -967,11 +966,12 @@ exports[`Cockpit Page > without apollo error > renders 1`] = `
         
         <div
           class="cockpit"
-          data-v-e027cbb0=""
+          data-v-b49ea567=""
         >
           
+          
           <section
-            class="cockpit-card narrow"
+            class="cockpit-card"
             data-v-1451ba78=""
             data-v-f444dc92=""
           >
@@ -1397,10 +1397,9 @@ exports[`Cockpit Page > without apollo error > renders 1`] = `
           <!--v-if-->
           
           <section
-            class="cockpit-card narrow"
+            class="cockpit-card"
             data-v-1451ba78=""
             data-v-c2e63817=""
-            data-v-e027cbb0=""
           >
             <div
               class="header"
@@ -1577,6 +1576,7 @@ exports[`Cockpit Page > without apollo error > renders 1`] = `
             <!--v-if-->
             
           </section>
+          
         </div>
         
       </div>


### PR DESCRIPTION
Motivation
----------
This is obsolete because we use CSS grid around CockpitCard components.

-----------
1. Nothing has changed
2. One property less
