### PR TITLE
feat(docker): pull and test docker images locally

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,0 +1,1 @@
+IMAGE_TAG=

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ build/
 .vscode
 
 .DS_Store
+
+.env

--- a/authentik/docker-compose.yml
+++ b/authentik/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - redis:/data
 
   authentik:
-    image: ghcr.io/dreammall-earth/dreammall.earth/authentik:latest
+    image: ghcr.io/dreammall-earth/dreammall.earth/authentik:${IMAGE_TAG:-latest}
     build:
       context: .
       target: production
@@ -60,7 +60,7 @@ services:
       - redis
 
   authentik-worker:
-    image: ghcr.io/dreammall-earth/dreammall.earth/authentik:latest
+    image: ghcr.io/dreammall-earth/dreammall.earth/authentik:${IMAGE_TAG:-latest}
     build:
       context: .
       target: production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - db_vol:/var/lib/mysql
 
   presenter:
-    image: ghcr.io/dreammall-earth/dreammall.earth/presenter:latest
+    image: ghcr.io/dreammall-earth/dreammall.earth/presenter:${IMAGE_TAG:-latest}
     build:
       context: ./presenter
       target: production
@@ -30,7 +30,7 @@ services:
       - NODE_ENV=production
 
   frontend:
-    image: ghcr.io/dreammall-earth/dreammall.earth/frontend:latest
+    image: ghcr.io/dreammall-earth/dreammall.earth/frontend:${IMAGE_TAG:-latest}
     build:
       context: ./frontend
       target: production
@@ -40,7 +40,7 @@ services:
       - NODE_ENV=production
 
   backend:
-    image: ghcr.io/dreammall-earth/dreammall.earth/backend:latest
+    image: ghcr.io/dreammall-earth/dreammall.earth/backend:${IMAGE_TAG:-latest}
     build:
       context: ./backend
       target: production
@@ -51,16 +51,22 @@ services:
         condition: service_started
       migrations:
         condition: service_completed_successfully
-
     ports:
       - 4000:4000
     environment:
       DATABASE_URL: mysql://root:@database:3306/dreammall.earth
       JWKS_URI: http://authentik:9000/application/o/dreammallearth/jwks/
       NODE_ENV: production
+      BREVO_KEY: ""
+      BREVO_ADMIN_NAME: ""
+      BREVO_ADMIN_EMAIL: ""
+      BREVO_CONTACT_TEMPLATE_ADMIN: "1"
+      BREVO_CONTACT_TEMPLATE_USER: "2"
+      BREVO_NEWSLETTER_TEMPLATE_OPTIN: "3"
+      BREVO_NEWSLETTER_LIST: "3"
 
   migrations:
-    image: ghcr.io/dreammall-earth/dreammall.earth/backend:latest
+    image: ghcr.io/dreammall-earth/dreammall.earth/backend:${IMAGE_TAG:-latest}
     command: npm run db:migrate:deploy
     build:
       context: ./backend


### PR DESCRIPTION
Motivation
----------

Side quest of #1994:

We push our docker images to Github's container registry here: https://github.com/orgs/dreammall-earth/packages?repo_name=dreammall.earth

With this change, we will be able to pull these images and test them locally. This speeds up development significantly, especially since on my machine it takes ages to build `frontend` and `presenter`.

Setting `BREVO` environment variables was necessary so that the backend server does not terminate immediately.

How to test
-----------
1. From the root directory: ``` echo "IMAGE_TAG=<image_tag>" > .env ```
2. `docker compose -f docker-compose.yml pull`
3. Images get downloaded from container registry
