### PR TITLE
fix(frontend): wrong redirect_uri default

### DIFF
--- a/frontend/src/env.ts
+++ b/frontend/src/env.ts
@@ -8,7 +8,7 @@ const AUTH = {
   CLIENT_ID: (import.meta.env.PUBLIC_ENV__AUTH__CLIENT_ID ??
     'G3g0sjCjph1NAyGeeu5Te5ltx1I7WZ0DGB8i6vOI') as string,
   REDIRECT_URI: (import.meta.env.PUBLIC_ENV__AUTH__REDIRECT_URI ??
-    'http://localhost:3001/auth') as string,
+    'http://localhost:3000/auth') as string,
   SILENT_REDIRECT_URI: (import.meta.env.PUBLIC_ENV__AUTH__SILENT_REDIRECT_URI ??
     'http://localhost:3001/silent-refresh') as string,
   RESPONSE_TYPE: (import.meta.env.PUBLIC_ENV__AUTH__RESPONSE_TYPE ?? 'code') as string,


### PR DESCRIPTION
Motivation
----------
Side quest of #1994.

No one takes notices of this because we have too many sources of truth.

I vote to remove all values from `.env.dist` and make the source code the single source of truth.

How to test
-----------
1. Remove `PUBLIC_ENV__AUTH__REDIRECT_URI` from your `.env`
2. You will see an authentication error