### PR TITLE
fix(frontend): add missing button at end of create table flow

### DIFF
--- a/frontend/src/components/cockpit/my-tables/create-table/TableCreated.vue
+++ b/frontend/src/components/cockpit/my-tables/create-table/TableCreated.vue
@@ -10,6 +10,8 @@
 <script lang="ts" setup>
 import { navigate } from 'vike/client/router'
 
+import SimpleButton from '#components/buttons/SimpleButton.vue'
+
 import MotivationBox from './MotivationBox.vue'
 
 import type { StepEmits, StepProps } from '#components/steps/StepComponentTypes'


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
The button in the last step of the create table flow is not visible.

This PR imports the button, so it is visible.

### Issues
- relates #2011 
