### PR TITLE
feat(backend): remove MyTable from tables query

### DIFF
--- a/backend/src/graphql/resolvers/TableResolver.spec.ts
+++ b/backend/src/graphql/resolvers/TableResolver.spec.ts
@@ -2202,7 +2202,7 @@ describe('TableResolver', () => {
           )
         })
 
-        it('returns array for tables where user is owner', async () => {
+        it('returns empty array for tables where user is moderator', async () => {
           await expect(
             testServer.executeOperation(
               {
@@ -2215,15 +2215,7 @@ describe('TableResolver', () => {
               kind: 'single',
               singleResult: {
                 data: {
-                  tables: [
-                    {
-                      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-                      id: expect.any(Number),
-                      name: 'My Table',
-                      public: true,
-                      users: [],
-                    },
-                  ],
+                  tables: [],
                 },
                 errors: undefined,
               },
@@ -2266,13 +2258,6 @@ describe('TableResolver', () => {
               singleResult: {
                 data: {
                   tables: [
-                    {
-                      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-                      id: expect.any(Number),
-                      name: 'My Table',
-                      public: true,
-                      users: [],
-                    },
                     {
                       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
                       id: expect.any(Number),

--- a/backend/src/graphql/resolvers/TableResolver.ts
+++ b/backend/src/graphql/resolvers/TableResolver.ts
@@ -303,21 +303,12 @@ export class TableResolver {
     const { user } = context
     const dbMeetings = await prisma.meeting.findMany({
       where: {
-        OR: [
-          {
-            user: {
-              id: user?.id,
-            },
+        users: {
+          some: {
+            userId: user?.id,
+            role: AttendeeRole.MODERATOR,
           },
-          {
-            users: {
-              some: {
-                userId: user?.id,
-                role: AttendeeRole.MODERATOR,
-              },
-            },
-          },
-        ],
+        },
       },
       include: {
         users: true,


### PR DESCRIPTION
## 🍰 Pullrequest
We can not delete MyTable and we most likely don't want to give moderation right to my table to other users. Each time we click on Join My Table we create a new Table so it is not needed in the My Tables list.

### Issues
- None

### Todo
- [X] None
