### PR TITLE
feat(backend): check user right to get meeting information.

### DIFF
--- a/backend/src/graphql/resolvers/TableResolver.spec.ts
+++ b/backend/src/graphql/resolvers/TableResolver.spec.ts
@@ -8,6 +8,7 @@ import { createTestServer } from '#src/server/server'
 
 import type { Context } from '#src/context'
 import type { UserWithProfile } from '#src/prisma'
+import { Meeting } from '@prisma/client'
 
 jest.mock('#api/BBB')
 
@@ -2152,6 +2153,109 @@ describe('TableResolver', () => {
                       ],
                     },
                   ],
+                },
+                errors: undefined,
+              },
+            },
+          })
+        })
+      })
+
+      describe('private meeting in DB', () => {
+        beforeAll(async () => {
+          const meeting = await prisma.meeting.create({
+            data: {
+              name: 'Dreammall Entwicklung',
+              meetingID: 'Dreammall-Entwicklung-2',
+              attendeePW: '1234',
+              public: false,
+            },
+          })
+          await prisma.usersInMeetings.create({
+            data: {
+              meetingId: meeting.id,
+              userId: user.id,
+            },
+          })
+        })
+
+        beforeEach(() => {
+          getMeetingsMock.mockResolvedValue([
+            {
+              meetingName: 'Dreammall Entwicklung',
+              meetingID: 'Dreammall-Entwicklung-2',
+              internalMeetingID: '258ea7269760758304b6b8494f17e9bf69dc1efe-1718189921310',
+              createTime: 1718189921310,
+              createDate: new Date('Wed Jun 12 10:58:41 UTC 2024'),
+              voiceBridge: 96378,
+              dialNumber: '613-555-1234',
+              attendeePW: 'MqgUFwdD',
+              moderatorPW: 'mTtxYGo2',
+              running: true,
+              duration: 0,
+              hasUserJoined: true,
+              recording: false,
+              hasBeenForciblyEnded: false,
+              startTime: 1718189,
+              endTime: 0,
+              participantCount: 0,
+              listenerCount: 1,
+              voiceParticipantCount: 0,
+              videoCount: 0,
+              maxUsers: 0,
+              moderatorCount: 1,
+              attendees: {
+                attendee: {
+                  userID: '1234',
+                  fullName: 'Peter Lustig',
+                  role: 'moderator',
+                  isPresenter: false,
+                  isListeningOnly: false,
+                  hasJoinedVoice: true,
+                  hasVideo: true,
+                  clientType: 'html5',
+                },
+              },
+              metadata: '',
+              isBreakout: false,
+            },
+          ])
+        })
+
+        afterAll(async () => {
+          await prisma.usersInMeetings.deleteMany({
+            where: {
+              userId: user.id,
+            },
+          })
+          await prisma.meeting.deleteMany({
+            where: {
+              meetingID: 'Dreammall-Entwicklung-2',
+            },
+          })
+        })
+
+        it('returns empty array of meeting', async () => {
+          jest.clearAllMocks()
+          await expect(
+            testServer.executeOperation(
+              {
+                query:
+                  'query { openTables { id meetingName meetingID participantCount startTime attendees { fullName } } }',
+              },
+              {
+                contextValue: {
+                  user: bibiUser,
+                  dataSources: { prisma },
+                },
+              },
+            ),
+          ).resolves.toMatchObject({
+            body: {
+              kind: 'single',
+              singleResult: {
+                data: {
+                  openTables: [],
                 },
                 errors: undefined,
               },

--- a/backend/src/graphql/resolvers/TableResolver.spec.ts
+++ b/backend/src/graphql/resolvers/TableResolver.spec.ts
@@ -8,7 +8,6 @@ import { createTestServer } from '#src/server/server'
 
 import type { Context } from '#src/context'
 import type { UserWithProfile } from '#src/prisma'
-import { Meeting } from '@prisma/client'
 
 jest.mock('#api/BBB')
 

--- a/backend/src/graphql/resolvers/TableResolver.ts
+++ b/backend/src/graphql/resolvers/TableResolver.ts
@@ -172,9 +172,9 @@ export class TableResolver {
 
   @Authorized()
   @Query(() => [OpenTable])
-  async openTables(): Promise<OpenTable[]> {
+  async openTables(@Ctx() context: Context): Promise<OpenTable[]> {
     const meetings = await getMeetings()
-    return openTablesFromOpenMeetings(meetings)
+    return openTablesFromOpenMeetings(meetings, context)
   }
 
   @Authorized()
@@ -364,10 +364,11 @@ export class TableResolver {
   })
   async updateOpenTables(
     @Root() meetings: MeetingInfo[],
+    @Ctx() context: Context,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     @Arg('username') username: string,
   ): Promise<OpenTable[]> {
-    return openTablesFromOpenMeetings(meetings)
+    return openTablesFromOpenMeetings(meetings, context)
   }
 
   /*
@@ -383,7 +384,10 @@ export class TableResolver {
   */
 }
 
-const openTablesFromOpenMeetings = async (meetings: MeetingInfo[]): Promise<OpenTable[]> => {
+const openTablesFromOpenMeetings = async (
+  meetings: MeetingInfo[],
+  context: Context,
+): Promise<OpenTable[]> => {
   if (meetings.length) {
     const dbMeetings = await prisma.meeting.findMany({
       where: {
@@ -392,15 +396,24 @@ const openTablesFromOpenMeetings = async (meetings: MeetingInfo[]): Promise<Open
       select: {
         id: true,
         meetingID: true,
+        public: true,
+        users: true,
       },
     })
 
     const openTables: OpenTable[] = []
 
-    dbMeetings.forEach((ids) => {
-      const meeting = meetings.find((m) => ids.meetingID === m.meetingID)
-      if (meeting) openTables.push(new OpenTable(meeting, ids.id ? ids.id : 0))
-    })
+    const { user } = context
+    dbMeetings
+      .filter(
+        (meeting) =>
+          meeting.public ||
+          meeting.users.some((userInMeeting) => user?.id === userInMeeting.userId),
+      )
+      .forEach((ids) => {
+        const meeting = meetings.find((m) => ids.meetingID === m.meetingID)
+        if (meeting) openTables.push(new OpenTable(meeting, ids.id ? ids.id : 0))
+      })
     return openTables
   }
 


### PR DESCRIPTION
Motivation
----
If a user set a meeting to private he want to be sure that no other user as the ones invited can see the meeting.

Test
----
Create a private table invite multiple users then open the table. 
On another tab delete the table from the cockpit my tables section.
Now this table is not present in the table side bar.

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
