### PR TITLE
fix(deps): dependabot remove groups & enable rebase

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,78 +26,78 @@ updates:
     day: "saturday"
     timezone: "Europe/Berlin"
     time: "03:00"
-  groups:
-    cypress:
-      applies-to: version-updates
-      patterns:
-        - "*cypress*"
-        - "*cucumber*"
-    remark:
-      applies-to: version-updates
-      patterns:
-        - "remark*"
-    vuepress:
-      applies-to: version-updates
-      patterns:
-        - "*vuepress*"
-    eslint:
-      applies-to: version-updates
-      patterns:
-        - "*eslint*"
-    linting:
-      applies-to: version-updates
-      patterns:
-        - "@eslint-community/eslint-plugin-eslint-comments"
-        - "@typescript-eslint/*"
-        - "eslint-*"
-        - "prettier"
-      exclude-patterns:
-        - "eslint"
-    prisma:
-      applies-to: version-updates
-      patterns:
-        - "*prisma*"
-    pinia:
-      applies-to: version-updates
-      patterns:
-        - "*pinia*"
-    react:
-      applies-to: version-updates
-      patterns:
-        - "react*"
-    sass:
-      applies-to: version-updates
-      patterns:
-        - "sass*"
-    storybook:
-      applies-to: version-updates
-      patterns:
-        - "*storybook*"
-    stylelint:
-      applies-to: version-updates
-      patterns:
-        - "*stylelint*"
-    typescript:
-      applies-to: version-updates
-      patterns:
-        - "ts*"
-        - "*types*"
-    vite:
-      applies-to: version-updates
-      patterns:
-        - "*vite*"
-      exclude-patterns:
-        - "@vuepress/bundler-vite"
-        - "eslint-plugin-vitest"
-        - "vite-plugin-checker"
-    vue:
-      applies-to: version-updates
-      patterns:
-        - "*vue?(/)*"
-      exclude-patterns:
-        - "vuetify"
-        - "*vuepress*"
-        - "vue-tsc"
+  #groups:
+  #  cypress:
+  #    applies-to: version-updates
+  #    patterns:
+  #      - "*cypress*"
+  #      - "*cucumber*"
+  #  remark:
+  #    applies-to: version-updates
+  #    patterns:
+  #      - "remark*"
+  #  vuepress:
+  #    applies-to: version-updates
+  #    patterns:
+  #      - "*vuepress*"
+  #  eslint:
+  #    applies-to: version-updates
+  #    patterns:
+  #      - "*eslint*"
+  #  linting:
+  #    applies-to: version-updates
+  #    patterns:
+  #      - "@eslint-community/eslint-plugin-eslint-comments"
+  #      - "@typescript-eslint/*"
+  #      - "eslint-*"
+  #      - "prettier"
+  #    exclude-patterns:
+  #      - "eslint"
+  #  prisma:
+  #    applies-to: version-updates
+  #    patterns:
+  #      - "*prisma*"
+  #  pinia:
+  #    applies-to: version-updates
+  #    patterns:
+  #      - "*pinia*"
+  #  react:
+  #    applies-to: version-updates
+  #    patterns:
+  #      - "react*"
+  #  sass:
+  #    applies-to: version-updates
+  #    patterns:
+  #      - "sass*"
+  #  storybook:
+  #    applies-to: version-updates
+  #    patterns:
+  #      - "*storybook*"
+  #  stylelint:
+  #    applies-to: version-updates
+  #    patterns:
+  #      - "*stylelint*"
+  #  typescript:
+  #    applies-to: version-updates
+  #    patterns:
+  #      - "ts*"
+  #      - "*types*"
+  #  vite:
+  #    applies-to: version-updates
+  #    patterns:
+  #      - "*vite*"
+  #    exclude-patterns:
+  #      - "@vuepress/bundler-vite"
+  #      - "eslint-plugin-vitest"
+  #      - "vite-plugin-checker"
+  #  vue:
+  #    applies-to: version-updates
+  #    patterns:
+  #      - "*vue?(/)*"
+  #    exclude-patterns:
+  #      - "vuetify"
+  #      - "*vuepress*"
+  #      - "vue-tsc"
 
 - package-ecosystem: docker
   open-pull-requests-limit: 99

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
 - package-ecosystem: "github-actions"
   open-pull-requests-limit: 99
   directory: "/"
-  rebase-strategy: "disabled"
+  #rebase-strategy: "disabled"
   schedule:
     interval: weekly
     day: "saturday"
@@ -20,7 +20,7 @@ updates:
     - "/frontend"
     - "/presenter"
     - "/tests"
-  rebase-strategy: "disabled"
+  #rebase-strategy: "disabled"
   schedule:
     interval: weekly
     day: "saturday"
@@ -107,7 +107,7 @@ updates:
     - "/backend"
     - "/frontend"
     - "/presenter"
-  rebase-strategy: "disabled"
+  #rebase-strategy: "disabled"
   schedule:
     interval: weekly
     day: "saturday"


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

This PR removes the grouping of Dependabot updates since that is incompatible with our new automerge feature (uses PR title to determine the version).

Furthermore I enable the rebaseing of the dependabot PRs, since I expect that the automerge can only merge one PR and then requires manual interaction for rebasing of the dependabot PRs.
There was a reason why we could not rebase automatically, but since its not documented and I do not know it anymore, I'd like to try again.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
