### PR TITLE
build(authentik): add smtp configuration

### DIFF
--- a/infrastructure/helmfile/secrets/authentik.yaml
+++ b/infrastructure/helmfile/secrets/authentik.yaml
@@ -2,6 +2,11 @@ authentik:
     secret_key: ENC[AES256_GCM,data:bHrp5V3/Y/BQdEEoKDFwsSg80q/KYyY+vIoTrwvUqdL7tmDfzOyr5aLWMSbJjBQwvOI=,iv:Bb4AjKVJjWDanWBMddXr5fZuBlQvJj3E9UNWpU6ybS0=,tag:v3xqu94fq0+LGVLA5UifTw==,type:str]
     postgresql:
         password: ENC[AES256_GCM,data:yWs3japHB1KM9ld3ttunHXMsqUBnhfdbn1uM+i476Bgt2mbxECbOj+dqI384/yzQC+Q=,iv:MUr/w5B01rnDL0Fd0h/2lzHnqtgIUtoQBsSyPYlUSS4=,tag:Q9NvHR+CFvPVTOM9hISzjw==,type:str]
+    email:
+        from: ENC[AES256_GCM,data:ByKpauTiHQPwljCOCHk8gzH9KtJL69k=,iv:0p2FGq55yuDl97bF/gD6mXF7uhCX9YLWUYACYpar3R0=,tag:6/i6w6Gazz3rllNLYjrizA==,type:str]
+        host: ENC[AES256_GCM,data:jy51Ug/Ch3Nt/Y4HvQ==,iv:a0vQLLESLMbLbmd5dIJXce6fsyQKKmIlmyKWozeK8cA=,tag:11maaoOxt1iRlYw+CHtNDQ==,type:str]
+        password: ENC[AES256_GCM,data:u3uN6UTwjA8B0d1ndjnuZpwLwWojYDt2S1LQsA==,iv:7FtgkB4NLiDeegYLjAfsWR6VmfJUPMMMRe7M5wcxk6E=,tag:W8bejJFCdNXtYNMv0+tNPA==,type:str]
+        username: ENC[AES256_GCM,data:AR7z1bdDY09HICvn5vDEhOVLDdc=,iv:j0SuCe6ZBYDgFROv0XORBFldlr931yg/4qGe7hiO9eI=,tag:i/5Rv7g9msaALjbToABweQ==,type:str]
 postgresql:
     auth:
         password: ENC[AES256_GCM,data:6qsS3P241SZiMC4afvX/vRmcDuFv+758WrUT5JtkjbA/oSrD2EvpLgjL8L1jkWdqc20=,iv:nVP1t/3KTqKd23w95S9hf+ZhZvjP8S4hYH+xnFk7u9k=,tag:qgmg/Stu/GmxVOr6TXqdcA==,type:str]
@@ -74,8 +79,8 @@ sops:
             cnZmQzlkTlRhejFBT3ozeTAzYXg5SXcKD/BQqFAUmqtxUZvRRcdWPJJbybIjRjwH
             NaLmsMGkEYVYlEOSnTYJqz7pIvKagecOSi1jwKK8qkUtf99g8pXyog==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-08-01T14:36:33Z"
-    mac: ENC[AES256_GCM,data:2UiO3pJoQITr1Ga6cofEuTIbu1VYe5oS22i1CQVUaNuK6f3PDe3nGr50PTbu/q50Aj65ggLhkOjcsUZj+QiBE2dLX5I7JdOqzrXspDCmr/khUudaqep7DCHET+Ah7Xp1tzZGacZUONDL4wnLFynuPlKbt/P7OEqQn1W5szTu/vU=,iv:0VuKhtrksor0BA4aMkaVL/yGyN9MMAnMAdBC7B862pI=,tag:DYdQfkW/ocB44a+lSAor8w==,type:str]
+    lastmodified: "2024-09-18T12:47:27Z"
+    mac: ENC[AES256_GCM,data:9fS0fF08+pM/BYDTFjxRXDbrLmYJL4jkZ5aUFhTeuKhoXbhrUWLPFe8vUVZy3s6Y9KVg9iNUBtvybBapysfin7cV+JdZeopHNECrDSU5hv/m0uQkNkEfT2H/kyP48zXZryaVkxCcPXtPURG53A0sjN+PLCMRS53ArptKXxtGUo0=,iv:dhFH03jnAPcSA+zpkrtwugOUiiwmTUAA8BZhpk0G47U=,tag:p24xAZy6gBqCSPoXm4Z0rA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.9.0

--- a/infrastructure/helmfile/values/authentik.yaml.gotmpl
+++ b/infrastructure/helmfile/values/authentik.yaml.gotmpl
@@ -1,3 +1,9 @@
+authentik:
+  email:
+    port: 587
+    timeout: 10
+    use_ssl: false
+    use_tls: true
 global:
   image:
     repository: {{ .StateValues.image_repository }}/authentik


### PR DESCRIPTION
Motivation
----------
This will allow us to test signup and other workflows on `*.git.dreammall.earth`.

We decided not to deploy mailpit in these environments and re-use the same credentials/account as in production.

close #1911

How to test
-----------
1. Test signup on https://add-authentik-smtp-configuration.git.dreammall.earth