### PR TITLE
fix(frontend): revert typescript update to have lintfix working

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -57,7 +57,8 @@ jobs:
         with:
           node-version-file: './.tool-versions'
       - name: Frontend | Lint
-        run: npm install && npm run test:lint
+        # we also run lintfix since there was a dependency update of typescript which caused lintfix to fail
+        run: npm install && npm run test:lint && npm run test:lintfix
         working-directory: ./frontend
 
   unit:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,7 @@
         "stylelint-config-standard": "^36.0.1",
         "stylelint-config-standard-scss": "^13.1.0",
         "tsx": "^4.19.1",
-        "typescript": "^5.6.2",
+        "typescript": "^5.5.4",
         "vite-plugin-checker": "^0.8.0",
         "vite-plugin-compression": "^0.5.1",
         "vite-plugin-vuetify": "^2.0.3",
@@ -17574,10 +17574,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
-      "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "devOptional": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -141,7 +141,7 @@
     "stylelint-config-standard": "^36.0.1",
     "stylelint-config-standard-scss": "^13.1.0",
     "tsx": "^4.19.1",
-    "typescript": "^5.6.2",
+    "typescript": "^5.5.4",
     "vite-plugin-checker": "^0.8.0",
     "vite-plugin-compression": "^0.5.1",
     "vite-plugin-vuetify": "^2.0.3",


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

revert typescript update to have lintfix working

Furthermore I included lintfix in our workflow runs to detect this in the future

Before:
![image](https://github.com/user-attachments/assets/7f3ea1db-18a4-41c2-a409-ba92754eafc0)

After:
![image](https://github.com/user-attachments/assets/8e13c0c8-5d4e-4756-9656-d96336a83bc0)

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Sidenote

While in the past this never was a problem, with the update to `typescript 5.6.2` `eslint` and `eslint --fix` behave differently causing the bug described above
![image](https://github.com/user-attachments/assets/753b316c-f645-4c7e-ac53-e4f282605a12)

- [X] None
