### PR TITLE
feat(other): easier deployments with defaults

### DIFF
--- a/infrastructure/helmfile/environments/default.yaml.gotmpl
+++ b/infrastructure/helmfile/environments/default.yaml.gotmpl
@@ -1,5 +1,8 @@
-domain: {{ env "DOMAIN" | default (printf "%s.git.dreammall.earth" (requiredEnv "BRANCH")) }}
-namespace: {{ env "NAMESPACE" | default (printf "dreammall-git-%s" (requiredEnv "BRANCH")) }}
+{{ $branch := env "BRANCH" | default (exec "../scripts/branch.sh" (list) | trim) }}
+{{ $image_tag:= env "IMAGE_TAG" | default (exec "../scripts/image_tag.sh" (list) | trim) }}
+
+domain: {{ env "DOMAIN" | default (printf "%s.git.dreammall.earth" $branch ) }}
+namespace: {{ env "NAMESPACE" | default (printf "dreammall-git-%s" $branch ) }}
 image_repository: ghcr.io/dreammall-earth/dreammall.earth
-image_tag: {{ requiredEnv "IMAGE_TAG" }}
+image_tag: {{ $image_tag }}
 cert_manager_issuer: dreammall-letsencrypt-prod

--- a/infrastructure/helmfile/scripts/branch.sh
+++ b/infrastructure/helmfile/scripts/branch.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# source https://stackoverflow.com/a/63286099
+git rev-parse --abbrev-ref HEAD | iconv -c -t ascii//TRANSLIT | sed -E 's/[~^]+//g' | sed -E 's/[^a-zA-Z0-9]+/-/g' | sed -E 's/^-+|-+$//g' | tr A-Z a-z

--- a/infrastructure/helmfile/scripts/image_tag.sh
+++ b/infrastructure/helmfile/scripts/image_tag.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+echo "sha-$(git rev-parse HEAD | cut -c 1-7)"


### PR DESCRIPTION
Motivation
----------
After #1994 branch deployments are getting used more often, because it became much easier.

This PR will make branch deployments even easier by providing defaults to `IMAGE_TAG` and `BRANCH`. You can still override these if you set the environments.

There is of course the risk of deploying an image tag that has not been pushed to our container registry, yet. But I guess that's something the developer would look out for.

This is how it looks if you forgot to push your branch:

![satty-20240919-15:40:34](https://github.com/user-attachments/assets/0b046f6d-cc75-43be-aff0-e1495baab75e)

As soon as you push your branch and the image tag gets pushed to the container registry, the deployment will recover:

![image](https://github.com/user-attachments/assets/7bfd6b95-94a5-456b-8034-45b05095ec98)


How to test
-----------
1. `cd infrastructure/helmfile`
2. `helmfile diff`
3. Does not complain about missing required environments