### PR TITLE
feat(backend): remove meeting that has no more moderators

### DIFF
--- a/backend/src/graphql/resolvers/TableResolver.spec.ts
+++ b/backend/src/graphql/resolvers/TableResolver.spec.ts
@@ -2534,12 +2534,9 @@ describe('TableResolver', () => {
             body: {
               kind: 'single',
               singleResult: {
-                data: null,
-                errors: [
-                  expect.objectContaining({
-                    message: 'There is no other Moderator in this table.',
-                  }),
-                ],
+                data: {
+                  deleteTable: true,
+                },
               },
             },
           })

--- a/backend/src/graphql/resolvers/TableResolver.ts
+++ b/backend/src/graphql/resolvers/TableResolver.ts
@@ -345,8 +345,6 @@ export class TableResolver {
     })
     if (!meeting) {
       throw new Error('Meeting not found!')
-    } else if (!meeting.users.some((u) => u.userId !== user?.id && u.role === 'MODERATOR')) {
-      throw new Error('There is no other Moderator in this table.')
     }
     try {
       await prisma.usersInMeetings.delete({
@@ -357,6 +355,13 @@ export class TableResolver {
           },
         },
       })
+      if (!meeting.users.some((u) => u.userId !== user?.id && u.role === 'MODERATOR')) {
+        await prisma.meeting.delete({
+          where: {
+            id: tableId,
+          },
+        })
+      }
     } catch (e) {
       logger.error('User could not be detached', e)
       throw new Error('User could not be detached.')


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest

### Motivation
The application can't be cleaned if we are the last moderator in a group table.

### Solution
Delete the table if we are the last moderator in the table.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes #2142 

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
