### PR TITLE
fix(frontend): fix position of empty tables list message

### DIFF
--- a/frontend/src/components/cockpit/my-tables/MyTables.vue
+++ b/frontend/src/components/cockpit/my-tables/MyTables.vue
@@ -13,10 +13,10 @@
       </div>
     </template>
     <template #default>
-      <ul class="list">
+      <ul v-if="tables.length > 0" class="list">
         <TableItem v-for="table in tables" :key="table.id" v-bind="table" />
       </ul>
-      <div v-if="tables.length === 0">
+      <div v-else>
         {{ $t('cockpit.myTables.noTables') }}
       </div>
     </template>

--- a/frontend/src/components/cockpit/my-tables/__snapshots__/MyTables.test.ts.snap
+++ b/frontend/src/components/cockpit/my-tables/__snapshots__/MyTables.test.ts.snap
@@ -39,13 +39,6 @@ exports[`MyTables > renders 1`] = `
     data-v-1451ba78=""
   />
   
-  <ul
-    class="list"
-    data-v-c2e63817=""
-  >
-    
-    
-  </ul>
   <div
     data-v-c2e63817=""
   >

--- a/frontend/src/pages/cockpit/__snapshots__/Page.test.ts.snap
+++ b/frontend/src/pages/cockpit/__snapshots__/Page.test.ts.snap
@@ -1404,13 +1404,6 @@ exports[`Cockpit Page > without apollo error > renders 1`] = `
               data-v-1451ba78=""
             />
             
-            <ul
-              class="list"
-              data-v-c2e63817=""
-            >
-              
-              
-            </ul>
             <div
               data-v-c2e63817=""
             >


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
The message for an empty tables list is now at a more reasonable place.

<img width="414" alt="Screenshot 2024-09-20 at 11 34 50" src="https://github.com/user-attachments/assets/2c7a7dfd-7b10-4010-99cf-2bbc41a8cf7a">

### Issues
- fixes #2167 

