### PR TITLE
refactor(docker): remove redundant labels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,27 +3,18 @@ FROM node:21-alpine3.17 as base
 # ENVs (available in production aswell, can be overwritten by commandline or env file)
 ## DOCKER_WORKDIR would be a classical ARG, but that is not multi layer persistent - shame
 ENV DOCKER_WORKDIR="/app"
-## We Cannot do `$(date -u +'%Y-%m-%dT%H:%M:%SZ')` here so we use unix timestamp=0
-ENV BUILD_DATE="1970-01-01T00:00:00.00Z"
-## We cannot do $(npm run version).${BUILD_NUMBER} here so we default to 0.0.0.0
-ENV BUILD_VERSION="0.0.0.0"
-## We cannot do `$(git rev-parse --short HEAD)` here so we default to 0000000
-ENV BUILD_COMMIT="0000000"
 ## SET NODE_ENV
 ENV NODE_ENV="production"
 ## App relevant Envs
 ENV PORT="3000"
 
 # Labels
-LABEL org.label-schema.build-date="${BUILD_DATE}"
 LABEL org.label-schema.name="dreammall"
 LABEL org.label-schema.description="DreamMall"
 LABEL org.label-schema.usage="https://github.com/dreammall-earth/dreammall.earth/blob/master/README.md"
 LABEL org.label-schema.url="https://github.com/dreammall-earth/dreammall.earth/"
 LABEL org.label-schema.vcs-url="https://github.com/dreammall-earth/dreammall.earth/tree/master/"
-LABEL org.label-schema.vcs-ref="${BUILD_COMMIT}"
 LABEL org.label-schema.vendor="DreamMall"
-LABEL org.label-schema.version="${BUILD_VERSION}"
 LABEL org.label-schema.schema-version="1.0"
 LABEL maintainer="info@it4c.dev"
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,27 +3,18 @@ FROM node:21-alpine3.17 AS base
 # ENVs (available in production aswell, can be overwritten by commandline or env file)
 ## DOCKER_WORKDIR would be a classical ARG, but that is not multi layer persistent - shame
 ENV DOCKER_WORKDIR="/server"
-## We Cannot do `$(date -u +'%Y-%m-%dT%H:%M:%SZ')` here so we use unix timestamp=0
-ENV BUILD_DATE="1970-01-01T00:00:00.00Z"
-## We cannot do $(npm run version).${BUILD_NUMBER} here so we default to 0.0.0.0
-ENV BUILD_VERSION="0.0.0.0"
-## We cannot do `$(git rev-parse --short HEAD)` here so we default to 0000000
-ENV BUILD_COMMIT="0000000"
 ## SET NODE_ENV
 ENV NODE_ENV="production"
 ## App relevant Envs
 ENV PORT="4000"
 
 # Labels
-LABEL org.label-schema.build-date="${BUILD_DATE}"
 LABEL org.label-schema.name="dreammall:backend"
 LABEL org.label-schema.description="DreamMall Backend"
 LABEL org.label-schema.usage="https://github.com/dreammall-earth/dreammall.earth/tree/master/backend/README.md"
 LABEL org.label-schema.url="https://github.com/dreammall-earth/dreammall.earth/tree/master/backend"
 LABEL org.label-schema.vcs-url="https://github.com/dreammall-earth/dreammall.earth/tree/master/backend"
-LABEL org.label-schema.vcs-ref="${BUILD_COMMIT}"
 LABEL org.label-schema.vendor="DreamMall"
-LABEL org.label-schema.version="${BUILD_VERSION}"
 LABEL org.label-schema.schema-version="1.0"
 LABEL maintainer="info@it4c.dev"
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,27 +3,18 @@ FROM node:21-alpine3.17 AS base
 # ENVs (available in production aswell, can be overwritten by commandline or env file)
 ## DOCKER_WORKDIR would be a classical ARG, but that is not multi layer persistent - shame
 ENV DOCKER_WORKDIR="/app"
-## We Cannot do `$(date -u +'%Y-%m-%dT%H:%M:%SZ')` here so we use unix timestamp=0
-ENV BUILD_DATE="1970-01-01T00:00:00.00Z"
-## We cannot do $(npm run version).${BUILD_NUMBER} here so we default to 0.0.0.0
-ENV BUILD_VERSION="0.0.0.0"
-## We cannot do `$(git rev-parse --short HEAD)` here so we default to 0000000
-ENV BUILD_COMMIT="0000000"
 ## SET NODE_ENV
 ENV NODE_ENV="production"
 ## App relevant Envs
 ENV PORT="3000"
 
 # Labels
-LABEL org.label-schema.build-date="${BUILD_DATE}"
 LABEL org.label-schema.name="dreammall:frontend"
 LABEL org.label-schema.description="DreamMall Frontend"
 LABEL org.label-schema.usage="https://github.com/dreammall-earth/dreammall.earth/tree/master/frontend/README.md"
 LABEL org.label-schema.url="https://github.com/dreammall-earth/dreammall.earth/tree/master/frontend"
 LABEL org.label-schema.vcs-url="https://github.com/dreammall-earth/dreammall.earth/tree/master/frontend"
-LABEL org.label-schema.vcs-ref="${BUILD_COMMIT}"
 LABEL org.label-schema.vendor="DreamMall"
-LABEL org.label-schema.version="${BUILD_VERSION}"
 LABEL org.label-schema.schema-version="1.0"
 LABEL maintainer="info@it4c.dev"
 

--- a/presenter/Dockerfile
+++ b/presenter/Dockerfile
@@ -3,27 +3,18 @@ FROM node:21-alpine3.17 AS base
 # ENVs (available in production aswell, can be overwritten by commandline or env file)
 ## DOCKER_WORKDIR would be a classical ARG, but that is not multi layer persistent - shame
 ENV DOCKER_WORKDIR="/app"
-## We Cannot do `$(date -u +'%Y-%m-%dT%H:%M:%SZ')` here so we use unix timestamp=0
-ENV BUILD_DATE="1970-01-01T00:00:00.00Z"
-## We cannot do $(npm run version).${BUILD_NUMBER} here so we default to 0.0.0.0
-ENV BUILD_VERSION="0.0.0.0"
-## We cannot do `$(git rev-parse --short HEAD)` here so we default to 0000000
-ENV BUILD_COMMIT="0000000"
 ## SET NODE_ENV
 ENV NODE_ENV="production"
 ## App relevant Envs
 ENV PORT="3000"
 
 # Labels
-LABEL org.label-schema.build-date="${BUILD_DATE}"
 LABEL org.label-schema.name="dreamMall:presenter"
 LABEL org.label-schema.description="DreamMall Presenter"
 LABEL org.label-schema.usage="https://github.com/dreammall-earth/dreammall.earth/tree/master/presenter/README.md"
 LABEL org.label-schema.url="https://github.com/dreammall-earth/dreammall.earth/tree/master/presenter"
 LABEL org.label-schema.vcs-url="https://github.com/dreammall-earth/dreammall.earth/tree/master/presenter/"
-LABEL org.label-schema.vcs-ref="${BUILD_COMMIT}"
 LABEL org.label-schema.vendor="DreamMall"
-LABEL org.label-schema.version="${BUILD_VERSION}"
 LABEL org.label-schema.schema-version="1.0"
 LABEL maintainer="info@it4c.dev"
 


### PR DESCRIPTION
Motivation
----------
The github action [docker metatadata-action](https://github.com/docker/metadata-action/) sets a number of labels for us.

We never properly set them in our CI and now they're redundant.

If you do `docker inspect 2f6a43daaef6` you see this:

![image](https://github.com/user-attachments/assets/bba893b7-5085-489d-a59d-ffd66fbce4fa)


`org.opencontainers.image.created` is the `BUILD_DATE`

`org.opencontainers.image.revision` is the `BUILD_COMMIT`

`org.opencontainers.image.version` is currently the git branch and would be `BUILD_VERSION` if we would trigger the workflow with a tag. See here: https://github.com/docker/metadata-action?tab=readme-ov-file#json-output-object

How to test
-----------
1. Nothing to test here

