### PR TITLE
refactor(backend): inject prisma via contextValue

### DIFF
--- a/backend/src/context/context.ts
+++ b/backend/src/context/context.ts
@@ -6,7 +6,7 @@ import { prisma } from '#src/prisma'
 import { findOrCreateUser } from './findOrCreateUser'
 import { getToken } from './getToken'
 
-import type { prisma as Prisma, UserWithProfile } from '#src/prisma'
+import type { PrismaClient, UserWithProfile } from '#src/prisma'
 import type { ContextFunction } from '@apollo/server'
 import type { ExpressContextFunctionArgument } from '@apollo/server/express4'
 
@@ -14,7 +14,7 @@ const JWKS = createRemoteJWKSet(new URL(CONFIG.JWKS_URI))
 
 export type Context = {
   user: UserWithProfile | null
-  dataSources: { prisma: typeof Prisma }
+  dataSources: { prisma: PrismaClient }
 }
 
 export interface CustomJwtPayload {

--- a/backend/src/graphql/resolvers/StarmapResolver.ts
+++ b/backend/src/graphql/resolvers/StarmapResolver.ts
@@ -1,15 +1,20 @@
-import { Resolver, Query, Authorized } from 'type-graphql'
+import { Resolver, Query, Ctx, Authorized } from 'type-graphql'
 
 import { StarMap } from '#models/StarModel'
-import { prisma, UserWithProfile } from '#src/prisma'
+import { UserWithProfile } from '#src/prisma'
 
 import { distributeStarsToSectorsRecursive } from './starmap/starmap'
+
+import type { Context } from '#src/context'
 
 @Resolver()
 export class StarmapResolver {
   @Authorized()
   @Query(() => StarMap)
-  async starmap(): Promise<StarMap> {
+  async starmap(@Ctx() context: Context): Promise<StarMap> {
+    const {
+      dataSources: { prisma },
+    } = context
     const users: UserWithProfile[] = await prisma.user.findMany({
       include: {
         userDetail: true,

--- a/backend/src/prisma.ts
+++ b/backend/src/prisma.ts
@@ -75,4 +75,12 @@ const userWithProfile = Prisma.validator<Prisma.UserDefaultArgs>()({
 
 type UserWithProfile = Prisma.UserGetPayload<typeof userWithProfile>
 
-export { prisma, UsersWithMeetings, UserWithMeeting, UserWithProfile }
+type DeamMallPrismaClient = typeof prisma
+
+export {
+  prisma,
+  DeamMallPrismaClient as PrismaClient,
+  UsersWithMeetings,
+  UserWithMeeting,
+  UserWithProfile,
+}


### PR DESCRIPTION
Motivation
----------
We already have `prisma` as `dataSource` in our `ContextValue`. This PR will import them in our resolvers.

We're not fully done yet, there are imports of `prisma` elsewhere. However, it's good for now. The code of the resolvers get copy+pasted, so it's important to refactor this part already.

How to test
-----------
1. `npm run test:unit`
2. All tests pass
