### PR TITLE
feat(backend): get table name query

### DIFF
--- a/backend/src/graphql/resolvers/TableResolver.ts
+++ b/backend/src/graphql/resolvers/TableResolver.ts
@@ -331,6 +331,24 @@ export class TableResolver {
     })
   }
 
+  @Query(() => String)
+  async getTableName(
+    @Arg('tableId', () => Int) tableId: number,
+    @Ctx() context: Context,
+  ): Promise<string> {
+    const {
+      dataSources: { prisma },
+    } = context
+    const meeting = await prisma.meeting.findUnique({
+      where: {
+        id: tableId,
+      },
+    })
+    if (!meeting) throw new Error('Table does not exist')
+
+    return meeting.name
+  }
+
   @Authorized()
   @Query(() => [Table])
   async tables(@Ctx() context: Context): Promise<Table[]> {


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
To join a table as guest, the client expects to know the name of the table. Here it is.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
