### PR TITLE
fix(backend): catch error of leaving a table you do not join

### DIFF
--- a/backend/src/graphql/resolvers/TableResolver.spec.ts
+++ b/backend/src/graphql/resolvers/TableResolver.spec.ts
@@ -2345,7 +2345,7 @@ describe('TableResolver', () => {
           ).resolves.toBeNull()
         })
 
-        it('throws error for already deleted connection', async () => {
+        it('throws error that meeting is not found', async () => {
           await expect(
             testServer.executeOperation(
               {
@@ -2361,7 +2361,7 @@ describe('TableResolver', () => {
               kind: 'single',
               singleResult: {
                 data: null,
-                errors: [expect.objectContaining({ message: 'User could not be detached.' })],
+                errors: [expect.objectContaining({ message: 'Meeting not found!' })],
               },
             },
           })

--- a/backend/src/graphql/resolvers/TableResolver.ts
+++ b/backend/src/graphql/resolvers/TableResolver.ts
@@ -374,6 +374,11 @@ export class TableResolver {
     const meeting = await prisma.meeting.findFirst({
       where: {
         id: tableId,
+        users: {
+          some: {
+            userId: user?.id,
+          },
+        },
       },
       include: {
         users: true,


### PR DESCRIPTION
… refactor the delete table method, that this error is catched before

<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
### Motivation

```bash
console.log
    2024-09-24 10:37:26.928     ERROR   /src/prisma.ts:37       mainLogger      Prisma Error {
      message: '\n' +
        'Invalid `prisma.usersInMeetings.delete()` invocation:\n' +
        '\n' +
        '\n' +
        'An operation failed because it depends on one or more records that were required but not found. Record to delete does not exist.',
      target: 'usersInMeetings.delete',
      timestamp: 2024-09-24T10:37:26.927Z
    }

      at Object.transportFormatted (node_modules/tslog/dist/cjs/runtime/nodejs/index.js:116:13)

  console.log
    2024-09-24 10:37:26.944     ERROR   /src/graphql/resolvers/TableResolver.ts:421     mainLogger      User could not be detached
    
     PrismaClientKnownRequestError  
    Invalid `prisma.usersInMeetings.delete()` invocation:
    
    
    An operation failed because it depends on one or more records that were required but not found. Record to delete does not exist., PrismaClientKnownRequestError, P2025, 5.19.1, [object Object], 
    error stack:
      • library.js      Ln.handleRequestError
        /node_modules/@prisma/client/runtime/library.js:121
      • library.js      Ln.handleAndLogRequestError
        /node_modules/@prisma/client/runtime/library.js:121
      • library.js      Ln.request
        /node_modules/@prisma/client/runtime/library.js:121
      • library.js      l
        /node_modules/@prisma/client/runtime/library.js:130
      • nestedOperations.js
        /node_modules/prisma-extension-nested-operations/dist/lib/nestedOperations.js:29
      • TableResolver.ts        TableResolver.deleteTable
        /src/graphql/resolvers/TableResolver.ts:405
      • helpers.js      dispatchHandler
        /node_modules/type-graphql/build/cjs/resolvers/helpers.js:79
      • helpers.js
        /node_modules/type-graphql/build/cjs/resolvers/helpers.js:80
      • helpers.js      dispatchHandler
        /node_modules/type-graphql/build/cjs/resolvers/helpers.js:79

      at Object.transportFormatted (node_modules/tslog/dist/cjs/runtime/nodejs/index.js:116:13)
```
This was shown on the console when running the unit tests of the table resolver. This case should be handled before

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
