### PR TITLE
fix(presenter): env defaults in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     environment:
       - NODE_ENV=production
       - PUBLIC_ENV__SIGNUP_URI=http://localhost:9000/if/flow/dreammallearth-enrollment/
-      - PUBLIC_ENV__SIGNIN_URI="http://localhost:3000/signin"
+      - PUBLIC_ENV__SIGNIN_URI=http://localhost:3000/signin
 
   frontend:
     image: ghcr.io/dreammall-earth/dreammall.earth/frontend:${IMAGE_TAG:-latest}


### PR DESCRIPTION
Motivation
----------
If you do a `git clean -dfx` (-> `rm presenter/.env`) and you start `docker compose up` you won't be able to signin. Because you get redirected to `http://localhost:3001/"http:/localhost:3000/signin"` which is obviously a bug.

How to test
-----------
1. `rm presenter/.env`
2. `docker compose up`
3. Visit http://localhost:3001/
4. Click on "Signin"
5. You get redirected to Authentik