### PR TITLE
refactor(other): follow @Mogge's review on #2287

### DIFF
--- a/backend/.env.dist
+++ b/backend/.env.dist
@@ -14,3 +14,6 @@ BBB_URL=""
 # BBB_WEBHOOK_URL="http://localhost:4000/bbb-webhook"
 
 JWKS_URI="http://localhost:9000/application/o/dreammallearth/jwks/"
+
+# WELCOME_TABLE_ID=
+# WELCOME_TABLE_NAME=

--- a/backend/src/config/config.ts
+++ b/backend/src/config/config.ts
@@ -2,6 +2,8 @@
 import path from 'path'
 
 import { config } from 'dotenv'
+// eslint-disable-next-line import/named
+import { v4 as uuidv4 } from 'uuid'
 
 import { printConfigError } from './printConfigError'
 
@@ -47,10 +49,15 @@ if (!JWKS_URI) {
   throw new Error('missing environment variable: JWKS_URI')
 }
 
+const WELCOME_TABLE_MEETING_ID = process.env.WELCOME_TABLE_MEETING_ID ?? uuidv4()
+const WELCOME_TABLE_NAME = process.env.WELCOME_TABLE_NAME ?? 'DreamMall Coffeetime'
+
 export const CONFIG = {
   ...BREVO,
   ...BBB,
   ...FRONTEND,
+  WELCOME_TABLE_MEETING_ID,
+  WELCOME_TABLE_NAME,
   JWKS_URI,
 }
 

--- a/backend/src/graphql/models/TableModel.ts
+++ b/backend/src/graphql/models/TableModel.ts
@@ -7,6 +7,16 @@ import { UsersWithMeetings } from '#src/prisma'
 import { Attendee } from './AttendeeModel'
 import { UserInMeeting } from './UserInMeetingModel'
 
+export const getAttendees = (meeting: MeetingInfo): Attendee[] => {
+  const attendees =
+    typeof meeting.attendees !== 'string'
+      ? Array.isArray(meeting.attendees.attendee)
+        ? meeting.attendees.attendee.map((a: AttendeeInfo) => new Attendee(a))
+        : [meeting.attendees.attendee]
+      : []
+  return attendees
+}
+
 @ObjectType()
 export class Table {
   constructor(data: Pick<Table, 'id' | 'name' | 'public' | 'users'>) {
@@ -46,14 +56,9 @@ export class OpenTable {
   static fromMeetingInfo(meeting: MeetingInfo, id: number) {
     const { meetingID, meetingName, participantCount } = meeting
     const startTime = meeting.startTime.toString()
-    const attendees =
-      typeof meeting.attendees !== 'string'
-        ? Array.isArray(meeting.attendees.attendee)
-          ? meeting.attendees.attendee.map((a: AttendeeInfo) => new Attendee(a))
-          : [meeting.attendees.attendee]
-        : []
+    const attendees = getAttendees(meeting)
     return new OpenTable({
-      id,
+      id: String(id),
       meetingID,
       meetingName,
       participantCount,
@@ -62,8 +67,8 @@ export class OpenTable {
     })
   }
 
-  @Field(() => Int)
-  id: number
+  @Field()
+  id: string
 
   @Field()
   meetingID: string

--- a/backend/src/graphql/resolvers/TableResolver.spec.ts
+++ b/backend/src/graphql/resolvers/TableResolver.spec.ts
@@ -1886,6 +1886,43 @@ describe('TableResolver', () => {
             },
           })
         })
+
+        describe('but if CONFIG.WELCOME_TABLE_MEETING_ID is set', () => {
+          it('will always return a welcome table with id `welcome`', async () => {
+            const contextValue = { ...mockContextValue({ user }) }
+            contextValue.config.WELCOME_TABLE_MEETING_ID = 'some-bbb-meeting-id'
+            contextValue.config.WELCOME_TABLE_NAME = 'I am the welcome table'
+            await expect(
+              testServer.executeOperation(
+                {
+                  query:
+                    'query { openTables { id meetingName meetingID participantCount startTime attendees { fullName } } }',
+                },
+                { contextValue },
+              ),
+            ).resolves.toMatchObject({
+              body: {
+                kind: 'single',
+                singleResult: {
+                  data: {
+                    openTables: [
+                      {
+                        id: 'welcome',
+                        meetingName: 'I am the welcome table',
+                        meetingID: 'some-bbb-meeting-id',
+                        participantCount: 0,
+                        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                        startTime: expect.any(String),
+                        attendees: [],
+                      },
+                    ],
+                  },
+                  errors: undefined,
+                },
+              },
+            })
+          })
+        })
       })
 
       describe('meeting is not in database', () => {
@@ -2016,7 +2053,7 @@ describe('TableResolver', () => {
                   openTables: [
                     {
                       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-                      id: expect.any(Number),
+                      id: expect.any(String),
                       meetingName: 'Dreammall Entwicklung',
                       meetingID: 'Dreammall-Entwicklung',
                       participantCount: 0,
@@ -2109,7 +2146,7 @@ describe('TableResolver', () => {
                   openTables: [
                     {
                       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-                      id: expect.any(Number),
+                      id: expect.any(String),
                       meetingName: 'Dreammall Entwicklung',
                       meetingID: 'Dreammall-Entwicklung',
                       participantCount: 0,

--- a/backend/src/graphql/resolvers/TableResolver.spec.ts
+++ b/backend/src/graphql/resolvers/TableResolver.spec.ts
@@ -223,7 +223,7 @@ describe('TableResolver', () => {
 
     describe('joinTable', () => {
       const query = `
-        query ($tableId: Int!) {
+        query ($tableId: String!) {
           joinTable(tableId: $tableId)
         }
       `
@@ -234,7 +234,7 @@ describe('TableResolver', () => {
             {
               query,
               variables: {
-                tableId: 69,
+                tableId: '69',
               },
             },
             { contextValue: mockContextValue() },
@@ -1549,7 +1549,7 @@ describe('TableResolver', () => {
 
     describe('joinTable', () => {
       const query = `
-        query ($tableId: Int!) {
+        query ($tableId: String!) {
           joinTable(tableId: $tableId)
         }
       `
@@ -1561,7 +1561,7 @@ describe('TableResolver', () => {
               {
                 query,
                 variables: {
-                  tableId: -1,
+                  tableId: '-1',
                 },
               },
               { contextValue: mockContextValue({ user }) },
@@ -1606,7 +1606,7 @@ describe('TableResolver', () => {
                 {
                   query,
                   variables: {
-                    tableId,
+                    tableId: String(tableId),
                   },
                 },
                 { contextValue: mockContextValue({ user }) },
@@ -1627,7 +1627,7 @@ describe('TableResolver', () => {
               {
                 query,
                 variables: {
-                  tableId,
+                  tableId: String(tableId),
                 },
               },
               { contextValue: mockContextValue({ user }) },
@@ -1687,7 +1687,7 @@ describe('TableResolver', () => {
               {
                 query,
                 variables: {
-                  tableId,
+                  tableId: String(tableId),
                 },
               },
               { contextValue: mockContextValue({ user }) },
@@ -1730,7 +1730,7 @@ describe('TableResolver', () => {
                 {
                   query,
                   variables: {
-                    tableId,
+                    tableId: String(tableId),
                   },
                 },
                 { contextValue: mockContextValue({ user: peterUser }) },
@@ -1770,7 +1770,7 @@ describe('TableResolver', () => {
               {
                 query,
                 variables: {
-                  tableId,
+                  tableId: String(tableId),
                 },
               },
               { contextValue: mockContextValue({ user }) },
@@ -1788,7 +1788,7 @@ describe('TableResolver', () => {
               {
                 query,
                 variables: {
-                  tableId,
+                  tableId: String(tableId),
                 },
               },
               { contextValue: mockContextValue({ user: bibiUser }) },
@@ -1806,7 +1806,7 @@ describe('TableResolver', () => {
               {
                 query,
                 variables: {
-                  tableId,
+                  tableId: String(tableId),
                 },
               },
               { contextValue: mockContextValue({ user: peterUser }) },
@@ -1838,7 +1838,7 @@ describe('TableResolver', () => {
                 {
                   query,
                   variables: {
-                    tableId,
+                    tableId: String(tableId),
                   },
                 },
                 { contextValue: mockContextValue({ user: raeuberUser }) },

--- a/backend/src/graphql/resolvers/TableResolver/joinWelcomeTable.spec.ts
+++ b/backend/src/graphql/resolvers/TableResolver/joinWelcomeTable.spec.ts
@@ -23,9 +23,9 @@ const name = 'User'
 
 let testServer: ApolloServer<Context>
 
-const joinWelcomeTableQuery = `
-  query {
-    joinWelcomeTable
+const joinTableQuery = `
+  query ($id: String!) {
+    joinTable(tableId: $id)
   }
 `
 
@@ -36,12 +36,13 @@ describe('TableResolver', () => {
   beforeEach(jest.clearAllMocks)
 
   describe('unauthorized', () => {
-    describe('joinWelcomeTable', () => {
+    describe('joinTable', () => {
       it('throws access denied', async () => {
         await expect(
           testServer.executeOperation(
             {
-              query: joinWelcomeTableQuery,
+              query: joinTableQuery,
+              variables: { id: 'welcome' },
             },
             { contextValue: mockContextValue() },
           ),
@@ -64,7 +65,7 @@ describe('TableResolver', () => {
   })
 
   describe('authorized', () => {
-    describe('joinWelcomeTable', () => {
+    describe('joinTable (with id `welcome`)', () => {
       let contextValue: ReturnType<typeof mockContextValue>
       beforeEach(async () => {
         const user = await findOrCreateUser({ nickname, name })
@@ -95,7 +96,8 @@ describe('TableResolver', () => {
         await expect(
           testServer.executeOperation(
             {
-              query: joinWelcomeTableQuery,
+              query: joinTableQuery,
+              variables: { id: 'welcome' },
             },
             { contextValue },
           ),
@@ -103,7 +105,7 @@ describe('TableResolver', () => {
           body: {
             kind: 'single',
             singleResult: {
-              data: { joinWelcomeTable: 'https://my-link' },
+              data: { joinTable: 'https://my-link' },
               errors: undefined,
             },
           },
@@ -111,7 +113,10 @@ describe('TableResolver', () => {
       })
 
       it('builds a URL from the response of the API call to create a BBB session', async () => {
-        await testServer.executeOperation({ query: joinWelcomeTableQuery }, { contextValue })
+        await testServer.executeOperation(
+          { query: joinTableQuery, variables: { id: 'welcome' } },
+          { contextValue },
+        )
         expect(joinMeetingLinkMock).toHaveBeenCalledWith({
           fullName: 'User',
           meetingID: '4711-42',

--- a/backend/src/graphql/resolvers/TableResolver/joinWelcomeTable.spec.ts
+++ b/backend/src/graphql/resolvers/TableResolver/joinWelcomeTable.spec.ts
@@ -1,0 +1,123 @@
+import { ApolloServer } from '@apollo/server'
+
+import { createMeeting, joinMeetingLink } from '#api/BBB'
+import { findOrCreateUser } from '#src/context/findOrCreateUser'
+import { createTestServer } from '#src/server/server'
+import { mockContextValue } from '#test/mockContextValue'
+
+import type { Context } from '#src/context'
+
+jest.mock<typeof import('#api/BBB')>('#api/BBB', () => {
+  const api: typeof import('#api/BBB') = jest.requireActual('#api/BBB')
+  return {
+    ...api,
+    createMeeting: jest.fn(),
+    joinMeetingLink: jest.fn(),
+  }
+})
+
+const createMeetingMock = jest.mocked(createMeeting)
+const joinMeetingLinkMock = jest.mocked(joinMeetingLink)
+const nickname = 'mockedUser'
+const name = 'User'
+
+let testServer: ApolloServer<Context>
+
+const joinWelcomeTableQuery = `
+  query {
+    joinWelcomeTable
+  }
+`
+
+describe('TableResolver', () => {
+  beforeAll(async () => {
+    testServer = await createTestServer()
+  })
+  beforeEach(jest.clearAllMocks)
+
+  describe('unauthorized', () => {
+    describe('joinWelcomeTable', () => {
+      it('throws access denied', async () => {
+        await expect(
+          testServer.executeOperation(
+            {
+              query: joinWelcomeTableQuery,
+            },
+            { contextValue: mockContextValue() },
+          ),
+        ).resolves.toMatchObject({
+          body: {
+            kind: 'single',
+            singleResult: {
+              data: null,
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+              errors: expect.arrayContaining([
+                expect.objectContaining({
+                  message: 'Access denied! You need to be authenticated to perform this action!',
+                }),
+              ]),
+            },
+          },
+        })
+      })
+    })
+  })
+
+  describe('authorized', () => {
+    describe('joinWelcomeTable', () => {
+      let contextValue: ReturnType<typeof mockContextValue>
+      beforeEach(async () => {
+        const user = await findOrCreateUser({ nickname, name })
+        contextValue = mockContextValue({ user })
+        contextValue.config.WELCOME_TABLE_MEETING_ID = '4711-42'
+        contextValue.config.WELCOME_TABLE_NAME = 'I am the WELCOME_TABLE_ID'
+        createMeetingMock.mockResolvedValue({
+          returncode: 'SUCCESS',
+          meetingID: 'xxx',
+          internalMeetingID: 'b60d121b438a380c343d5ec3c2037564b82ffef3-1715231322715',
+          parentMeetingID: 'bbb-none',
+          attendeePW: 'w3VUvMcp',
+          moderatorPW: 'MyPp9Zfq',
+          createTime: 1718189921310,
+          voiceBridge: 255,
+          dialNumber: '613-555-1234',
+          createDate: new Date(),
+          hasUserJoined: false,
+          duration: 0,
+          hasBeenForciblyEnded: false,
+          messageKey: '',
+          message: '',
+        })
+        joinMeetingLinkMock.mockReturnValue('https://my-link')
+      })
+
+      it('responds with a url that can be embedded in an <iframe>', async () => {
+        await expect(
+          testServer.executeOperation(
+            {
+              query: joinWelcomeTableQuery,
+            },
+            { contextValue },
+          ),
+        ).resolves.toMatchObject({
+          body: {
+            kind: 'single',
+            singleResult: {
+              data: { joinWelcomeTable: 'https://my-link' },
+              errors: undefined,
+            },
+          },
+        })
+      })
+
+      it('builds a URL from the response of the API call to create a BBB session', async () => {
+        await testServer.executeOperation({ query: joinWelcomeTableQuery }, { contextValue })
+        expect(joinMeetingLinkMock).toHaveBeenCalledWith({
+          fullName: 'User',
+          meetingID: '4711-42',
+          password: 'MyPp9Zfq',
+        })
+      })
+    })
+  })
+})

--- a/backend/test/mockContextValue.ts
+++ b/backend/test/mockContextValue.ts
@@ -19,6 +19,8 @@ export const mockContextValue: (overrides?: Partial<Context>) => Context = (over
       BBB_WEBHOOK_URL: '',
       FRONTEND_URL: '',
       JWKS_URI: '',
+      WELCOME_TABLE_NAME: '',
+      WELCOME_TABLE_MEETING_ID: '',
     },
     dataSources: { prisma },
   }

--- a/frontend/src/graphql/queries/joinTableQuery.ts
+++ b/frontend/src/graphql/queries/joinTableQuery.ts
@@ -1,7 +1,7 @@
 import { gql } from 'graphql-tag'
 
 export const joinTableQuery = gql`
-  query ($tableId: Int!) {
+  query ($tableId: String!) {
     joinTable(tableId: $tableId)
   }
 `

--- a/frontend/src/pages/table/+Page.vue
+++ b/frontend/src/pages/table/+Page.vue
@@ -32,12 +32,12 @@ const tableUrl = ref<string | null>(null)
 
 const pageContext = usePageContext()
 
-const tableId = ref(Number(pageContext.routeParams?.id))
+const tableId = ref(pageContext.routeParams?.id)
 
 const errorMessage = ref<string | null>(null)
 
 watch(pageContext, (context) => {
-  tableId.value = Number(context.routeParams?.id)
+  tableId.value = context.routeParams?.id
 })
 
 const { result: joinTableQueryResult, error: joinTableQueryError } = useQuery(

--- a/frontend/src/pages/table/Page.test.ts
+++ b/frontend/src/pages/table/Page.test.ts
@@ -103,7 +103,7 @@ describe('Table Page', () => {
 
     it('calls the API accordingly', () => {
       expect(joinTableQueryMock).toHaveBeenCalledWith({
-        tableId: NaN,
+        tableId: undefined,
       })
     })
 


### PR DESCRIPTION
see: https://github.com/dreammall-earth/dreammall.earth/pull/2287#pullrequestreview-2327855858

It's a matter of taste, but I think it's cleaner without this commit.

`joinTable` refers to a `Table` in the database, with a numeric `id`. `openTables` refer to the transient class `OpenTable` which gets constructed from a BBB meeting and an (optional) `Table` in the database.
