### PR TITLE
fix(backend): use context.user in subscriptions

### DIFF
--- a/backend/src/graphql/resolvers/TableResolver.ts
+++ b/backend/src/graphql/resolvers/TableResolver.ts
@@ -538,17 +538,9 @@ export class TableResolver {
   })
   async updateOpenTables(
     @Root() meetings: MeetingInfo[],
-    @Arg('username') username: string,
     @Ctx() context: Context,
   ): Promise<OpenTables> {
-    const {
-      dataSources: { prisma },
-    } = context
-    const user = await prisma.user.findUnique({
-      where: {
-        username,
-      },
-    })
+    const { user } = context
     if (!user) return { permanentTables: [], mallTalkTables: [], projectTables: [] }
     return openTablesFromOpenMeetings(context)({ meetings, user })
   }

--- a/frontend/src/graphql/subscriptions/updateOpenTablesSubscription.ts
+++ b/frontend/src/graphql/subscriptions/updateOpenTablesSubscription.ts
@@ -1,8 +1,8 @@
 import { gql } from 'graphql-tag'
 
 export const updateOpenTablesSubscription = gql`
-  subscription ($username: String!) {
-    updateOpenTables(username: $username) {
+  subscription {
+    updateOpenTables {
       mallTalkTables {
         id
         meetingID

--- a/frontend/src/stores/tablesStore.ts
+++ b/frontend/src/stores/tablesStore.ts
@@ -108,11 +108,7 @@ export const useTablesStore = defineStore(
 
     const {
       result: updateOpenTablesSubscriptionResult /* , error: updateOpenTablesSubscriptionError */,
-    } = useSubscription(
-      updateOpenTablesSubscription,
-      () => ({ username: userStore.getCurrentUser?.username || 'Unknown User' }),
-      { fetchPolicy: 'no-cache' },
-    )
+    } = useSubscription(updateOpenTablesSubscription, () => ({}), { fetchPolicy: 'no-cache' })
 
     watch(updateOpenTablesSubscriptionResult, (data: { updateOpenTables: TableList }) => {
       setTables(data.updateOpenTables)


### PR DESCRIPTION
Motivation
----------
This is quite a security fix. By setting the current user via arguments, it was possible to update tables as any user.

How to test
-----------
1. There is no quick way to reproduce this. Maybe just check the code changes.

