### PR TITLE
feat(backend): configure log level

### DIFF
--- a/backend/.env.dist
+++ b/backend/.env.dist
@@ -13,7 +13,7 @@ BBB_SHARED_SECRET=""
 BBB_URL=""
 # BBB_WEBHOOK_URL="http://localhost:4000/bbb-webhook"
 
-JWKS_URI="http://localhost:9000/application/o/dreammallearth/jwks/"
+# JWKS_URI=
 
 # WELCOME_TABLE_MEETING_ID=
 # WELCOME_TABLE_NAME=

--- a/backend/src/config/config.ts
+++ b/backend/src/config/config.ts
@@ -32,7 +32,7 @@ const {
 
   FRONTEND_URL = 'http://localhost:3000/',
 
-  JWKS_URI,
+  JWKS_URI = 'http://localhost:9000/application/o/dreammallearth/jwks/',
 
   WELCOME_TABLE_MEETING_ID = uuidv4(),
   WELCOME_TABLE_NAME = 'DreamMall Coffeetime',
@@ -41,11 +41,9 @@ const {
   SENTRY_ENVIRONMENT,
 
   WEBHOOK_SECRET,
-} = process.env
 
-if (!JWKS_URI) {
-  throw new Error('missing environment variable: JWKS_URI')
-}
+  LOG_LEVEL = 'DEBUG',
+} = process.env
 
 const BREVO = {
   BREVO_KEY,
@@ -81,4 +79,5 @@ export const CONFIG = {
   SENTRY_DSN,
   SENTRY_ENVIRONMENT,
   WEBHOOK_SECRET,
+  LOG_LEVEL,
 }

--- a/backend/src/logger.ts
+++ b/backend/src/logger.ts
@@ -1,5 +1,32 @@
 import { ILogObj, Logger } from 'tslog'
 
+import { CONFIG } from '#config/config'
+
+const { LOG_LEVEL } = CONFIG
+
+const logLevels = ['SILLY', 'TRACE', 'DEBUG', 'INFO', 'WARN', 'ERROR', 'FATAL'] as const
+type LogLevel = (typeof logLevels)[number]
+
+function isLogLevel(level: string): level is LogLevel {
+  return logLevels.includes(level as LogLevel)
+}
+
+if (!isLogLevel(LOG_LEVEL)) {
+  throw new Error(`Unknown log level '${LOG_LEVEL}'`)
+}
+
+const logLevelsMap: Record<LogLevel, number> = {
+  SILLY: 0,
+  TRACE: 1,
+  DEBUG: 2,
+  INFO: 3,
+  WARN: 4,
+  ERROR: 5,
+  FATAL: 6,
+}
+
+const minLevel = logLevelsMap[LOG_LEVEL] // eslint-disable-line security/detect-object-injection
+
 /**
  * The Singleton class defines the `getInstance` method that lets clients access
  * the unique singleton instance.
@@ -22,7 +49,7 @@ class LoggerSingleton {
    */
   public static getInstance(): Logger<ILogObj> {
     if (!LoggerSingleton.instance) {
-      LoggerSingleton.instance = new Logger({ name: 'mainLogger' })
+      LoggerSingleton.instance = new Logger({ minLevel, name: 'mainLogger' })
     }
 
     return LoggerSingleton.instance

--- a/backend/test/mockConfig.ts
+++ b/backend/test/mockConfig.ts
@@ -21,5 +21,6 @@ export const createMockConfig = (): typeof CONFIG => {
     SENTRY_DSN: '',
     SENTRY_ENVIRONMENT: '',
     WEBHOOK_SECRET: undefined,
+    LOG_LEVEL: 'DEBUG',
   }
 }


### PR DESCRIPTION
Motivation
----------
This will allow us to set the global logger's log level with an
environment variable.

How to test
-----------
1. Put e.g. a `logger.trace` somewhere
2. Run the code
3. No output
4. `export LOG_LEVEL=SILLY`
5. Run the code
6. Log output happens

