### PR TITLE
feat(backend): change custom bbb layout to custom

### DIFF
--- a/backend/src/api/BBB.ts
+++ b/backend/src/api/BBB.ts
@@ -26,7 +26,7 @@ const parser = new XMLParser({
 
 const defaultCreateMeetingBodyOptions = {
   welcome: '<div></div>',
-  meetingLayout: MeetingLayouts.SMART_LAYOUT,
+  meetingLayout: MeetingLayouts.CUSTOM_LAYOUT,
   logoutURL: new URL('table-closed/', CONFIG.FRONTEND_URL),
 }
 


### PR DESCRIPTION
Motivation
---
On the SMART_LAYOUT we have a border from the presentation to the complete box and on small devices this makes the presentation even less visible.

Solution
---
Change the default layout to CUSTOM_LAYOUT does not change the mobile interaction.

#### User flow

##### Start View

<img width="372" alt="Chat click on '< Öffentlicher Chat'" src="https://github.com/user-attachments/assets/c4a90b97-e783-41aa-ab81-47c65c17ad23">

##### After click on "< Öffentlicher Chat"

<img width="373" alt="Screenshot 2024-10-02 at 12 58 41" src="https://github.com/user-attachments/assets/2842f242-cb15-4745-b6dc-d00a42e44850">

##### After click on "UserIcon"

<img width="375" alt="Screenshot 2024-10-02 at 12 59 12" src="https://github.com/user-attachments/assets/5d898ab1-c729-4642-8236-bf08d6461ab3">

##### CUSTOM_LAYOUT with one camera

<img width="374" alt="Screenshot 2024-10-02 at 12 56 26" src="https://github.com/user-attachments/assets/a076b615-5b28-45eb-8451-2fc8a4ca3bd2">


<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes https://github.com/dreammall-earth/dreammall.earth/issues/2260

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
