### PR TITLE
refactor(other): eslint no-catch-all

### DIFF
--- a/backend/.eslintrc.cjs
+++ b/backend/.eslintrc.cjs
@@ -19,7 +19,7 @@ module.exports = {
     parser: '@typescript-eslint/parser',
     sourceType: 'module',
   },
-  plugins: ['@typescript-eslint', 'import', 'promise', 'security', 'n'],
+  plugins: ['@typescript-eslint', 'import', 'promise', 'security', 'n', 'no-catch-all'],
   settings: {
     'import/resolver': {
       typescript: true,
@@ -27,6 +27,7 @@ module.exports = {
     },
   },
   rules: {
+    'no-catch-all/no-catch-all': 'error',
     'no-console': 'error',
     'no-debugger': 'error',
     camelcase: 'error',

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -60,6 +60,7 @@
         "eslint-plugin-jest": "^28.6.0",
         "eslint-plugin-json": "^3.1.0",
         "eslint-plugin-n": "^16.6.2",
+        "eslint-plugin-no-catch-all": "^1.1.0",
         "eslint-plugin-prettier": "^5.2.1",
         "eslint-plugin-promise": "^6.6.0",
         "eslint-plugin-security": "^3.0.1",
@@ -5568,6 +5569,15 @@
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-no-catch-all": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-catch-all/-/eslint-plugin-no-catch-all-1.1.0.tgz",
+      "integrity": "sha512-VkP62jLTmccPrFGN/W6V7a3SEwdtTZm+Su2k4T3uyJirtkm0OMMm97h7qd8pRFAHus/jQg9FpUpLRc7sAylBEQ==",
+      "dev": true,
+      "peerDependencies": {
+        "eslint": ">=2.0.0"
       }
     },
     "node_modules/eslint-plugin-prettier": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -79,6 +79,7 @@
     "eslint-plugin-jest": "^28.6.0",
     "eslint-plugin-json": "^3.1.0",
     "eslint-plugin-n": "^16.6.2",
+    "eslint-plugin-no-catch-all": "^1.1.0",
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-promise": "^6.6.0",
     "eslint-plugin-security": "^3.0.1",

--- a/backend/src/api/BBB/index.ts
+++ b/backend/src/api/BBB/index.ts
@@ -43,7 +43,7 @@ export const getMeetings = async (): Promise<MeetingInfo[]> => {
     } else {
       logger.error('parse getMeetings with error', parsed)
     }
-  } catch (err) {
+  } catch (err) /* eslint-disable-line no-catch-all/no-catch-all */ {
     logger.error('getMeetings with error', err)
   }
   return []
@@ -74,7 +74,7 @@ export const createMeeting = async (
       response: CreateMeetingResponse
     } = parser.parse(data as string)
     return parsed.response
-  } catch (err) {
+  } catch (err) /* eslint-disable-line no-catch-all/no-catch-all */ {
     logger.error('createMeeting with error', err)
     return null
   }

--- a/backend/src/api/Brevo/Brevo.ts
+++ b/backend/src/api/Brevo/Brevo.ts
@@ -179,7 +179,7 @@ export const subscribeToNewsletter =
       } else {
         // TODO: logging or event
       }
-    } catch (error) {
+    } catch (error) /* eslint-disable-line no-catch-all/no-catch-all */ {
       // TODO: logging or event
     }
 
@@ -235,7 +235,7 @@ const confirmNewsletter =
       } else {
         // TODO: logging or event
       }
-    } catch (error) {
+    } catch (error) /* eslint-disable-line no-catch-all/no-catch-all */ {
       // TODO: logging or event
     }
 

--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -22,7 +22,15 @@ module.exports = {
     parser: '@typescript-eslint/parser',
     sourceType: 'module',
   },
-  plugins: ['@typescript-eslint', 'import', 'promise', 'security', 'vue', 'storybook'],
+  plugins: [
+    '@typescript-eslint',
+    'import',
+    'promise',
+    'security',
+    'vue',
+    'storybook',
+    'no-catch-all',
+  ],
   settings: {
     'import/resolver': {
       typescript: true,
@@ -33,6 +41,7 @@ module.exports = {
     },
   },
   rules: {
+    'no-catch-all/no-catch-all': 'error',
     'no-console': 'error',
     'no-debugger': 'error',
     camelcase: 'error',

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -77,6 +77,7 @@
         "eslint-import-resolver-typescript": "^3.6.3",
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-json": "^3.1.0",
+        "eslint-plugin-no-catch-all": "^1.1.0",
         "eslint-plugin-prettier": "^5.1.3",
         "eslint-plugin-promise": "^6.1.1",
         "eslint-plugin-security": "^3.0.1",
@@ -8434,6 +8435,15 @@
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-no-catch-all": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-catch-all/-/eslint-plugin-no-catch-all-1.1.0.tgz",
+      "integrity": "sha512-VkP62jLTmccPrFGN/W6V7a3SEwdtTZm+Su2k4T3uyJirtkm0OMMm97h7qd8pRFAHus/jQg9FpUpLRc7sAylBEQ==",
+      "dev": true,
+      "peerDependencies": {
+        "eslint": ">=2.0.0"
       }
     },
     "node_modules/eslint-plugin-prettier": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -114,6 +114,7 @@
     "eslint-import-resolver-typescript": "^3.6.3",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-json": "^3.1.0",
+    "eslint-plugin-no-catch-all": "^1.1.0",
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-security": "^3.0.1",

--- a/frontend/src/components/sepa-iban/SepaIban.vue
+++ b/frontend/src/components/sepa-iban/SepaIban.vue
@@ -99,7 +99,7 @@ import { defineProps } from 'vue'
 import CockpitCardVariableHeight from '#components/cockpit/cockpit-card/CockpitCardVariableHeight.vue'
 import CockpitLayout from '#components/cockpit/cockpit-layout/CockpitLayout.vue'
 
-import { generateQrCode } from './qrCode'
+import { SepaValidationError, generateQrCode } from './qrCode'
 
 import type { PageContext } from 'vike/types'
 
@@ -123,9 +123,10 @@ const data = {
 try {
   qr = generateQrCode(data)
 } catch (error) {
-  // eslint-disable-next-line no-console
-  console.warn('Invalid QR code data.\n', error)
-  qr = undefined
+  if (error instanceof SepaValidationError) {
+    console.warn('Invalid QR code data.\n', error) // eslint-disable-line no-console
+    qr = undefined
+  } else throw error
 }
 </script>
 

--- a/frontend/src/components/sepa-iban/qrCode.ts
+++ b/frontend/src/components/sepa-iban/qrCode.ts
@@ -8,7 +8,7 @@ const IDENTIFICATION_CODE = 'SCT'
 
 const assertNonEmptyString = (val: unknown, name: string) => {
   if (typeof val !== 'string' || !val) {
-    throw new Error(name + ' must be a non-empty string.')
+    throw new SepaValidationError(name + ' must be a non-empty string.')
   }
 }
 
@@ -23,17 +23,24 @@ type QrCodeData = {
   information?: string
 }
 
+export class SepaValidationError extends Error {
+  constructor(message: string) {
+    super(message) // (1)
+    this.name = 'SepaValidationError' // (2)
+  }
+}
+
 export const generateQrCode = (data: QrCodeData) => {
-  if (!data) throw new Error('data must be an object.')
+  if (!data) throw new SepaValidationError('data must be an object.')
 
   // > AT-21 Name of the Beneficiary
   assertNonEmptyString(data.name, 'data.name')
-  if (data.name.length > 70) throw new Error('data.name must have <=70 characters')
+  if (data.name.length > 70) throw new SepaValidationError('data.name must have <=70 characters')
 
   // > AT-23 BIC of the Beneficiary Bank
   if (data.bic) {
     assertNonEmptyString(data.bic, 'data.bic')
-    if (data.bic.length > 11) throw new Error('data.bic must have <=11 characters')
+    if (data.bic.length > 11) throw new SepaValidationError('data.bic must have <=11 characters')
     // todo: validate more?
   }
 
@@ -41,22 +48,24 @@ export const generateQrCode = (data: QrCodeData) => {
   // > Only IBAN is allowed.
   assertNonEmptyString(data.iban, 'data.iban')
   if (!IBAN.isValid(data.iban)) {
-    throw new Error('data.iban must be a valid iban code.')
+    throw new SepaValidationError('data.iban must be a valid iban code.')
   }
 
   // > AT-04 Amount of the Credit Transfer in Euro
   // > Amount must be 0.01 or more and 999999999.99 or less
   if (data.amount !== null) {
-    if (typeof data.amount !== 'number') throw new Error('data.amount must be a number or null.')
+    if (typeof data.amount !== 'number')
+      throw new SepaValidationError('data.amount must be a number or null.')
     if (data.amount < 0.01 || data.amount > 999999999.99) {
-      throw new Error('data.amount must be >=0.01 and <=999999999.99.')
+      throw new SepaValidationError('data.amount must be >=0.01 and <=999999999.99.')
     }
   }
 
   // > AT-44 Purpose of the Credit Transfer
   if (data.purposeCode) {
     assertNonEmptyString(data.purposeCode, 'data.purposeCode')
-    if (data.purposeCode.length > 4) throw new Error('data.purposeCode must have <=4 characters')
+    if (data.purposeCode.length > 4)
+      throw new SepaValidationError('data.purposeCode must have <=4 characters')
     // todo: validate against AT-44
   }
 
@@ -65,23 +74,26 @@ export const generateQrCode = (data: QrCodeData) => {
   if (data.structuredReference) {
     assertNonEmptyString(data.structuredReference, 'data.structuredReference')
     if (data.structuredReference.length > 35)
-      throw new Error('data.structuredReference must have <=35 characters')
+      throw new SepaValidationError('data.structuredReference must have <=35 characters')
     // todo: validate against AT-05
   }
   // > AT-05 Remittance Information (Unstructured)
   if (data.unstructuredReference) {
     assertNonEmptyString(data.unstructuredReference, 'data.unstructuredReference')
     if (data.unstructuredReference.length > 140)
-      throw new Error('data.unstructuredReference must have <=140 characters')
+      throw new SepaValidationError('data.unstructuredReference must have <=140 characters')
   }
   if ('structuredReference' in data && 'unstructuredReference' in data) {
-    throw new Error('Use either data.structuredReference or data.unstructuredReference.')
+    throw new SepaValidationError(
+      'Use either data.structuredReference or data.unstructuredReference.',
+    )
   }
 
   // > Beneficiary to originator information
   if (data.information) {
     assertNonEmptyString(data.information, 'data.information')
-    if (data.information.length > 70) throw new Error('data.information must have <=70 characters')
+    if (data.information.length > 70)
+      throw new SepaValidationError('data.information must have <=70 characters')
   }
 
   return [

--- a/presenter/.eslintrc.cjs
+++ b/presenter/.eslintrc.cjs
@@ -30,6 +30,7 @@ module.exports = {
     'vue',
     'storybook',
     'eslint-plugin-local-rules',
+    'no-catch-all',
   ],
   settings: {
     'import/resolver': {
@@ -41,6 +42,7 @@ module.exports = {
     },
   },
   rules: {
+    'no-catch-all/no-catch-all': 'error',
     'no-console': 'error',
     'no-debugger': 'error',
     camelcase: 'error',

--- a/presenter/package-lock.json
+++ b/presenter/package-lock.json
@@ -64,6 +64,7 @@
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-json": "^3.1.0",
         "eslint-plugin-local-rules": "^3.0.2",
+        "eslint-plugin-no-catch-all": "^1.1.0",
         "eslint-plugin-prettier": "^5.2.1",
         "eslint-plugin-promise": "^6.6.0",
         "eslint-plugin-security": "^3.0.1",
@@ -8381,6 +8382,15 @@
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-no-catch-all": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-catch-all/-/eslint-plugin-no-catch-all-1.1.0.tgz",
+      "integrity": "sha512-VkP62jLTmccPrFGN/W6V7a3SEwdtTZm+Su2k4T3uyJirtkm0OMMm97h7qd8pRFAHus/jQg9FpUpLRc7sAylBEQ==",
+      "dev": true,
+      "peerDependencies": {
+        "eslint": ">=2.0.0"
       }
     },
     "node_modules/eslint-plugin-prettier": {

--- a/presenter/package.json
+++ b/presenter/package.json
@@ -100,6 +100,7 @@
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-json": "^3.1.0",
     "eslint-plugin-local-rules": "^3.0.2",
+    "eslint-plugin-no-catch-all": "^1.1.0",
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-promise": "^6.6.0",
     "eslint-plugin-security": "^3.0.1",

--- a/presenter/src/components/forms/ContactForm.vue
+++ b/presenter/src/components/forms/ContactForm.vue
@@ -156,7 +156,7 @@ async function submitForm() {
       setTimeout(() => {
         showFormSuccess.value = !showFormSuccess.value
       }, showInfoTime)
-    } catch {
+    } catch /* eslint-disable-line no-catch-all/no-catch-all */ {
       showFormError.value = !showFormError.value
       formIsLoading.value = !formIsLoading.value
 

--- a/presenter/src/components/forms/NewsletterForm.vue
+++ b/presenter/src/components/forms/NewsletterForm.vue
@@ -119,7 +119,7 @@ async function submitForm() {
       setTimeout(() => {
         showFormSuccess.value = !showFormSuccess.value
       }, showInfoTime)
-    } catch {
+    } catch /* eslint-disable-line no-catch-all/no-catch-all */ {
       showFormError.value = !showFormError.value
       formIsLoading.value = !formIsLoading.value
 

--- a/presenter/src/pages/optin/+Page.vue
+++ b/presenter/src/pages/optin/+Page.vue
@@ -44,7 +44,7 @@ onBeforeMount(async () => {
   try {
     const result = await confirmNewsletterMutation({ code })
     isError.value = !result?.data?.confirmNewsletter
-  } catch (error) {
+  } catch /* eslint-disable-line no-catch-all/no-catch-all */ {
     isError.value = true
   }
 


### PR DESCRIPTION
Motivation
----------
This PR will prevent errors from silently failing. It's a common bug to have a `try/catch` and some error thrown which is *not* the one the developer was looking for.

Have a look at this PR for example: https://github.com/dreammall-earth/dreammall.earth/pull/2405#pullrequestreview-2333456869

close #1548

How to test
-----------
1. Write a `try/catch` where you don't rethrow the `error`
2. `npm run test:lint:eslint`
3. Will fail

