### PR TITLE
revert(backend): fix vserver deployment

### DIFF
--- a/backend/.env.dist
+++ b/backend/.env.dist
@@ -13,7 +13,7 @@ BBB_SHARED_SECRET=""
 BBB_URL=""
 # BBB_WEBHOOK_URL="http://localhost:4000/bbb-webhook"
 
-# JWKS_URI=
+JWKS_URI="http://localhost:9000/application/o/dreammallearth/jwks/"
 
 # WELCOME_TABLE_MEETING_ID=
 # WELCOME_TABLE_NAME=

--- a/backend/src/config/config.ts
+++ b/backend/src/config/config.ts
@@ -32,7 +32,7 @@ const {
 
   FRONTEND_URL = 'http://localhost:3000/',
 
-  JWKS_URI = 'http://localhost:9000/application/o/dreammallearth/jwks/',
+  JWKS_URI,
 
   WELCOME_TABLE_MEETING_ID = uuidv4(),
   WELCOME_TABLE_NAME = 'DreamMall Coffeetime',
@@ -41,9 +41,11 @@ const {
   SENTRY_ENVIRONMENT,
 
   WEBHOOK_SECRET,
-
-  LOG_LEVEL = 'DEBUG',
 } = process.env
+
+if (!JWKS_URI) {
+  throw new Error('missing environment variable: JWKS_URI')
+}
 
 const BREVO = {
   BREVO_KEY,
@@ -79,5 +81,4 @@ export const CONFIG = {
   SENTRY_DSN,
   SENTRY_ENVIRONMENT,
   WEBHOOK_SECRET,
-  LOG_LEVEL,
 }

--- a/backend/src/logger.ts
+++ b/backend/src/logger.ts
@@ -1,32 +1,5 @@
 import { ILogObj, Logger } from 'tslog'
 
-import { CONFIG } from '#config/config'
-
-const { LOG_LEVEL } = CONFIG
-
-const logLevels = ['SILLY', 'TRACE', 'DEBUG', 'INFO', 'WARN', 'ERROR', 'FATAL'] as const
-type LogLevel = (typeof logLevels)[number]
-
-function isLogLevel(level: string): level is LogLevel {
-  return logLevels.includes(level as LogLevel)
-}
-
-if (!isLogLevel(LOG_LEVEL)) {
-  throw new Error(`Unknown log level '${LOG_LEVEL}'`)
-}
-
-const logLevelsMap: Record<LogLevel, number> = {
-  SILLY: 0,
-  TRACE: 1,
-  DEBUG: 2,
-  INFO: 3,
-  WARN: 4,
-  ERROR: 5,
-  FATAL: 6,
-}
-
-const minLevel = logLevelsMap[LOG_LEVEL] // eslint-disable-line security/detect-object-injection
-
 /**
  * The Singleton class defines the `getInstance` method that lets clients access
  * the unique singleton instance.
@@ -49,7 +22,7 @@ class LoggerSingleton {
    */
   public static getInstance(): Logger<ILogObj> {
     if (!LoggerSingleton.instance) {
-      LoggerSingleton.instance = new Logger({ minLevel, name: 'mainLogger' })
+      LoggerSingleton.instance = new Logger({ name: 'mainLogger' })
     }
 
     return LoggerSingleton.instance

--- a/backend/test/mockConfig.ts
+++ b/backend/test/mockConfig.ts
@@ -21,6 +21,5 @@ export const createMockConfig = (): typeof CONFIG => {
     SENTRY_DSN: '',
     SENTRY_ENVIRONMENT: '',
     WEBHOOK_SECRET: undefined,
-    LOG_LEVEL: 'DEBUG',
   }
 }


### PR DESCRIPTION
Motivation
----------
For reasons unknown, this commit breaks the backend on our vServer deployment:
```
/root/.pm2/logs/backend-error.log last 15 lines:
0|backend  | 2024-10-10 23:52:20.281:             ^
0|backend  | 2024-10-10 23:52:20.281:
0|backend  | 2024-10-10 23:52:20.281: Error: BREVO_SEND_CONTACT functionality is disabled - some BREVO configs are missing
0|backend  | 2024-10-10 23:52:20.281:     at /var/www/localhost/htdocs/dreammall.earth/backend/build/src/api/Brevo/printConfigError.js:9:19
0|backend  | 2024-10-10 23:52:20.281:     at validateConfig (/var/www/localhost/htdocs/dreammall.earth/backend/build/src/api/Brevo/configChecks.js:20:63)
0|backend  | 2024-10-10 23:52:20.281:     at createBrevoClient (/var/www/localhost/htdocs/dreammall.earth/backend/build/src/api/Brevo/Brevo.js:188:39)
0|backend  | 2024-10-10 23:52:20.281:     at Object.<anonymous> (/var/www/localhost/htdocs/dreammall.earth/backend/build/src/context/context.js:15:45)
0|backend  | 2024-10-10 23:52:20.281:     at Module._compile (node:internal/modules/cjs/loader:1369:14)
0|backend  | 2024-10-10 23:52:20.282:     at Module._extensions..js (node:internal/modules/cjs/loader:1427:10)
0|backend  | 2024-10-10 23:52:20.282:     at Module.load (node:internal/modules/cjs/loader:1206:32)
0|backend  | 2024-10-10 23:52:20.282:     at Module._load (node:internal/modules/cjs/loader:1022:12)
0|backend  | 2024-10-10 23:52:20.282:     at Module.require (node:internal/modules/cjs/loader:1231:19)
0|backend  | 2024-10-10 23:52:20.282:     at require (node:internal/modules/helpers:179:18)
0|backend  | 2024-10-10 23:52:20.282:
0|backend  | 2024-10-10 23:52:20.282: Node.js v20.12.1
```

Revert "feat(backend): configure log level (#2446)"

This reverts commit 13a11f821343fe2ee4143363eac76f5a1cff3dc6.

