### PR TITLE
fix(backend): load .env vars before prisma

### DIFF
--- a/backend/.env.dist
+++ b/backend/.env.dist
@@ -13,7 +13,7 @@ BBB_SHARED_SECRET=""
 BBB_URL=""
 # BBB_WEBHOOK_URL="http://localhost:4000/bbb-webhook"
 
-JWKS_URI="http://localhost:9000/application/o/dreammallearth/jwks/"
+# JWKS_URI=
 
 # WELCOME_TABLE_MEETING_ID=
 # WELCOME_TABLE_NAME=

--- a/backend/src/config/config.ts
+++ b/backend/src/config/config.ts
@@ -1,14 +1,11 @@
 /* eslint-disable n/no-process-env */
-import path from 'path'
 
 import { config } from 'dotenv'
 // eslint-disable-next-line import/named
 import { v4 as uuidv4 } from 'uuid'
 
 // Load env file
-config({
-  path: path.resolve(__dirname, '../../.env'),
-})
+config()
 
 const toNumber = (env: string | undefined): number | undefined => {
   const number = Number(env)

--- a/backend/src/config/config.ts
+++ b/backend/src/config/config.ts
@@ -32,7 +32,7 @@ const {
 
   FRONTEND_URL = 'http://localhost:3000/',
 
-  JWKS_URI,
+  JWKS_URI = 'http://localhost:9000/application/o/dreammallearth/jwks/',
 
   WELCOME_TABLE_MEETING_ID = uuidv4(),
   WELCOME_TABLE_NAME = 'DreamMall Coffeetime',
@@ -41,11 +41,9 @@ const {
   SENTRY_ENVIRONMENT,
 
   WEBHOOK_SECRET,
-} = process.env
 
-if (!JWKS_URI) {
-  throw new Error('missing environment variable: JWKS_URI')
-}
+  LOG_LEVEL = 'DEBUG',
+} = process.env
 
 const BREVO = {
   BREVO_KEY,
@@ -81,4 +79,5 @@ export const CONFIG = {
   SENTRY_DSN,
   SENTRY_ENVIRONMENT,
   WEBHOOK_SECRET,
+  LOG_LEVEL,
 }

--- a/backend/src/logger.ts
+++ b/backend/src/logger.ts
@@ -1,5 +1,32 @@
 import { ILogObj, Logger } from 'tslog'
 
+import { CONFIG } from '#config/config'
+
+const { LOG_LEVEL } = CONFIG
+
+const logLevels = ['SILLY', 'TRACE', 'DEBUG', 'INFO', 'WARN', 'ERROR', 'FATAL'] as const
+type LogLevel = (typeof logLevels)[number]
+
+function isLogLevel(level: string): level is LogLevel {
+  return logLevels.includes(level as LogLevel)
+}
+
+if (!isLogLevel(LOG_LEVEL)) {
+  throw new Error(`Unknown log level '${LOG_LEVEL}'`)
+}
+
+const logLevelsMap: Record<LogLevel, number> = {
+  SILLY: 0,
+  TRACE: 1,
+  DEBUG: 2,
+  INFO: 3,
+  WARN: 4,
+  ERROR: 5,
+  FATAL: 6,
+}
+
+const minLevel = logLevelsMap[LOG_LEVEL] // eslint-disable-line security/detect-object-injection
+
 /**
  * The Singleton class defines the `getInstance` method that lets clients access
  * the unique singleton instance.
@@ -22,7 +49,7 @@ class LoggerSingleton {
    */
   public static getInstance(): Logger<ILogObj> {
     if (!LoggerSingleton.instance) {
-      LoggerSingleton.instance = new Logger({ name: 'mainLogger' })
+      LoggerSingleton.instance = new Logger({ minLevel, name: 'mainLogger' })
     }
 
     return LoggerSingleton.instance

--- a/backend/test/mockConfig.ts
+++ b/backend/test/mockConfig.ts
@@ -21,5 +21,6 @@ export const createMockConfig = (): typeof CONFIG => {
     SENTRY_DSN: '',
     SENTRY_ENVIRONMENT: '',
     WEBHOOK_SECRET: undefined,
+    LOG_LEVEL: 'DEBUG',
   }
 }


### PR DESCRIPTION
Motivation
----------
Both PRs https://github.com/dreammall-earth/dreammall.earth/pull/1868 and https://github.com/dreammall-earth/dreammall.earth/pull/2446 broke our vServer deployment.

How? Well, if you load `#config/config` before `prisma` then we load this line first: https://github.com/dreammall-earth/dreammall.earth/blob/master/backend/src/config/config.ts#L10

Which means we read `'../../.env'` relative to `__dirname` which is different after `npm run build`, it's now in `build/src/config/` not `src/config`. So, our `process.env` vars are already `undefined` *but given* when `prisma` reads the `.env` file. That's how we end up with the error.

Removing the optional `path` will load from the default location that is `path.resolve(process.cwd(), '.env')`.
See: https://github.com/motdotla/dotenv?tab=readme-ov-file#path

How to test
-----------
First:
1. `cd backend`
2. `rm -rf build`
2. `cp .env.dist .env`

Error case:
1. `git checkout HEAD^`
2. `npm run build`
3. `NODE_ENV=production TZ=UTC TS_NODE_BASEURL=./build node -r tsconfig-paths/register build/src/index.js`
4. Crashes with:
```
Error: BREVO_SEND_CONTACT functionality is disabled - some BREVO configs are missing
```

Fix:
1. `git switch fix-load-config-before-prisma`
2. `npm run build`
3. `NODE_ENV=production TZ=UTC TS_NODE_BASEURL=./build node -r tsconfig-paths/register build/src/index.js`
4. Starts just fine

