### PR TITLE
fix(backend): ignore 2 more jose error classes

### DIFF
--- a/backend/src/context/context.spec.ts
+++ b/backend/src/context/context.spec.ts
@@ -1,4 +1,4 @@
-import { jwtVerify } from 'jose'
+import { jwtVerify, errors } from 'jose'
 
 import logger from '#src/logger'
 import { prisma, PrismaClientValidationError } from '#src/prisma'
@@ -23,7 +23,7 @@ describe('context', () => {
     beforeEach(() => {
       jest
         .mocked(jwtVerify<CustomJwtPayload>)
-        .mockRejectedValue(new Error('JWS verification failed'))
+        .mockRejectedValue(new errors.JWTExpired('"exp" claim timestamp check failed', {}))
     })
 
     it('returns `null` for `contextValue.user`', async () => {

--- a/backend/src/context/context.ts
+++ b/backend/src/context/context.ts
@@ -16,13 +16,13 @@ const brevo = createBrevoClient({ prisma, logger, config: CONFIG })
 
 const knownErrorClasses = [
   errors.JOSEAlgNotAllowed,
-  errors.JWTExpired,
-  errors.JWTInvalid,
+  errors.JOSENotSupported,
+  errors.JWKSNoMatchingKey,
   errors.JWSInvalid,
   errors.JWSSignatureVerificationFailed,
+  errors.JWTExpired,
+  errors.JWTInvalid,
 ]
-
-const knownErrorMessages = ['JWS verification failed']
 
 export type Context = {
   config: typeof CONFIG
@@ -49,10 +49,7 @@ const decodePayload = async (
     const { payload } = await jwtVerify<CustomJwtPayload>(token, JWKS)
     return payload
   } catch (error) {
-    if (
-      knownErrorClasses.some((errorClass) => error instanceof errorClass) ||
-      (error instanceof Error && knownErrorMessages.some((message) => message === error.message))
-    ) {
+    if (knownErrorClasses.some((errorClass) => error instanceof errorClass)) {
       logger.trace(error)
       return null
     } else throw error


### PR DESCRIPTION
Motivation
----------
I wanted to reproduce the case where we receive a generic `Error` with message `JWS verification failed` that is not an instance of any `jose.errors`.

I couldn't reproduce the case, so I deleted that condition. We will see any not-handled errors on Sentry.

Instead I found two cases that we also want to ignore:

* JOSENotSupported when the JWT has an algorithm that is not `RS256`. This is the case if someone sends a parseable JWT that does not belong to us, e.g. the default token from https://jwt.io/. That one has the headers `{ "alg": "HS256", "typ": "JWT" }`.
* JWKSNoMatchingKey this will happen when you `docker compose down -v` and `docker compose up` locally. The `kid` in the header will not match the one from Authentik anymore.

How to test
-----------
1. See examples above