### PR TITLE
fix(backend): silence AuthenticationError

### DIFF
--- a/backend/src/server/sentry/createApolloPlugin.spec.ts
+++ b/backend/src/server/sentry/createApolloPlugin.spec.ts
@@ -1,5 +1,5 @@
 import { ApolloServer } from '@apollo/server'
-import { buildSchema, Resolver, Query, Float, AuthorizationError } from 'type-graphql'
+import { buildSchema, Resolver, Query, Float, AuthenticationError } from 'type-graphql'
 
 import { createApolloPlugin } from './createApolloPlugin'
 
@@ -19,7 +19,9 @@ class ExampleResolver {
 
   @Query(() => Float)
   unauthorized(): number {
-    throw new AuthorizationError('Not allowed!')
+    throw new AuthenticationError(
+      'Access denied! You need to be authenticated to perform this action!',
+    )
   }
 }
 
@@ -133,7 +135,7 @@ describe('createApolloPlugin', () => {
       })
     })
 
-    describe('but on AuthorizationError', () => {
+    describe('but on AuthenticationError', () => {
       const query = `{ unauthorized }`
 
       it('ignores the error', async () => {

--- a/backend/src/server/sentry/createApolloPlugin.ts
+++ b/backend/src/server/sentry/createApolloPlugin.ts
@@ -1,4 +1,4 @@
-import { AuthorizationError } from 'type-graphql'
+import { AuthenticationError } from 'type-graphql'
 
 import type { Context } from '#src/context'
 import type {
@@ -29,10 +29,10 @@ export const createApolloPlugin: (
           return
         }
         for (const err of ctx.errors) {
-          if (err.extensions?.code === 'UNAUTHORIZED') {
+          if (err.extensions?.code === 'UNAUTHENTICATED') {
             return
           }
-          if (err instanceof AuthorizationError) {
+          if (err instanceof AuthenticationError) {
             return
           }
           sentry.withScope((scope) => {


### PR DESCRIPTION
Motivation
----------
We see plenty `AuthenticationError`s on Sentry.

![image](https://github.com/user-attachments/assets/0c2fa4d0-4dfa-4684-8130-2709f90b4186)


Apparently, the provided `AuthChecker` from `type-graphql` does not throw `AuthorizationError` but `AuthenticationError`. (why? 🤷‍♂️)

How to test
-----------
1. `git switch master`
2. `docker compose up database migrations backend authentik authentik-worker`
3. Visit http://localhost:4000/
4. Send:
```graphql
{
  currentUser {
    id
  }
}
```
5. See:
```
{
  "errors": [
    {
      "message": "Access denied! You need to be authenticated to perform this action!",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "currentUser"
      ],
      "extensions": {
        "code": "UNAUTHENTICATED",
        "stacktrace": [
          "GraphQLError: Access denied! You need to be authenticated to perform this action!",
          "    at new AuthenticationError (/server/node_modules/type-graphql/build/cjs/errors/graphql/AuthenticationError.js:7:9)",
          "    at /server/node_modules/type-gra
```

This PR changes the spec that checks if we capture auhtentication/authorization errors:
1. `npm run test:unit -- --no-coverage src/server/sentry/createApolloPlugin.spec.ts`
2. See:
```
 PASS  src/server/sentry/createApolloPlugin.spec.ts
  createApolloPlugin
    ...
    applied on an apollo server
      ...
      on internal server error
        ✓ responds some errors (27 ms)
        ✓ reports the error (9 ms)
      but on AuthenticationError
        ✓ ignores the error (13 ms)
```