### PR TITLE
feat(backend): log unexpected brevo api responses

### DIFF
--- a/backend/src/api/Brevo/index.ts
+++ b/backend/src/api/Brevo/index.ts
@@ -1,1 +1,4 @@
-export * from './Brevo'
+import { createBrevoClient } from './Brevo'
+
+export type BrevoClient = ReturnType<typeof createBrevoClient>
+export { createBrevoClient }

--- a/backend/src/context/context.spec.ts
+++ b/backend/src/context/context.spec.ts
@@ -13,6 +13,11 @@ jest.mock('jose')
 
 const token = 'foobar'
 
+const sentry = {
+  withScope: jest.fn(),
+  captureException: jest.fn(),
+}
+
 describe('context', () => {
   beforeEach(async () => {
     await deleteAll()
@@ -27,7 +32,7 @@ describe('context', () => {
     })
 
     it('returns `null` for `contextValue.user`', async () => {
-      await expect(context({ prisma })(token)).resolves.toMatchObject({
+      await expect(context({ prisma, sentry })(token)).resolves.toMatchObject({
         user: null,
       })
     })
@@ -44,7 +49,7 @@ describe('context', () => {
     })
 
     it('creates and returns a new user in `contextValue.user`', async () => {
-      await expect(context({ prisma })(token)).resolves.toMatchObject({
+      await expect(context({ prisma, sentry })(token)).resolves.toMatchObject({
         user: {
           username: 'nickname',
           name: 'name',
@@ -67,7 +72,7 @@ describe('context', () => {
 
       it('returns the found user for `contextValue.user`', async () => {
         await setup()
-        await expect(context({ prisma })(token)).resolves.toMatchObject({
+        await expect(context({ prisma, sentry })(token)).resolves.toMatchObject({
           user: {
             id: 21,
             username: 'nickname',
@@ -83,7 +88,7 @@ describe('context', () => {
         const prisma = {
           user: { findUnique: jest.fn().mockRejectedValue('Ouch!') },
         } as unknown as PrismaClient
-        await expect(context({ prisma })(token)).rejects.toBe('Ouch!')
+        await expect(context({ prisma, sentry })(token)).rejects.toBe('Ouch!')
       })
     })
 
@@ -100,7 +105,9 @@ describe('context', () => {
       it('crashes quite dramatically', async () => {
         const silencedLogger = jest.spyOn(logger, 'error')
         silencedLogger.mockImplementation(() => undefined)
-        await expect(context({ prisma })(token)).rejects.toThrow(PrismaClientValidationError)
+        await expect(context({ prisma, sentry })(token)).rejects.toThrow(
+          PrismaClientValidationError,
+        )
         silencedLogger.mockRestore()
         // TODO: make sure we don't silence logger.error permanently by accident
         // logger.error('See me on the console!')

--- a/backend/src/context/expressContext.ts
+++ b/backend/src/context/expressContext.ts
@@ -1,13 +1,12 @@
 import { context } from './context'
 
-import type { PrismaClient } from '#src/prisma'
-import type { Context } from './context'
+import type { Context, ContextDependencies } from './context'
 import type { ContextFunction } from '@apollo/server'
 import type { ExpressContextFunctionArgument } from '@apollo/server/express4'
 
-export const expressContext: (deps: {
-  prisma: PrismaClient
-}) => ContextFunction<[ExpressContextFunctionArgument], Context> =
+export const expressContext: (
+  deps: ContextDependencies,
+) => ContextFunction<[ExpressContextFunctionArgument], Context> =
   (deps) =>
   async ({ req }) => {
     const token = req.headers.authorization

--- a/backend/src/context/subscriptionContext.ts
+++ b/backend/src/context/subscriptionContext.ts
@@ -1,12 +1,11 @@
 import { context } from './context'
 
-import type { PrismaClient } from '#src/prisma'
-import type { Context } from './context'
+import type { Context, ContextDependencies } from './context'
 import type { ContextFunction } from '@apollo/server'
 
-export const subscriptionContext: (deps: {
-  prisma: PrismaClient
-}) => ContextFunction<[{ connectionParams: { token: string } }], Context> =
+export const subscriptionContext: (
+  deps: ContextDependencies,
+) => ContextFunction<[{ connectionParams: { token: string } }], Context> =
   (deps) => async (ctx) => {
     const token = ctx.connectionParams.token
     return context(deps)(token)

--- a/backend/src/server/sentry/index.ts
+++ b/backend/src/server/sentry/index.ts
@@ -9,11 +9,16 @@ import { createApolloPlugin } from './createApolloPlugin'
 
 import type { NodeOptions } from '@sentry/node'
 
+const sentry = { withScope, captureException }
+
+export type Sentry = typeof sentry
+
 export const setupSentry = (sentryOptions: NodeOptions) => {
   init(sentryOptions)
-  const apolloPlugin = createApolloPlugin(sentryOptions, { withScope, captureException })
+  const apolloPlugin = createApolloPlugin(sentryOptions, sentry)
   return {
     apolloPlugin,
     setupExpress,
+    sentry,
   }
 }

--- a/backend/src/server/server.ts
+++ b/backend/src/server/server.ts
@@ -20,7 +20,11 @@ import { setupSentry } from './sentry'
 
 import type { Context } from '#src/context'
 
-const { apolloPlugin: sentryPlugin, setupExpress } = setupSentry({
+const {
+  apolloPlugin: sentryPlugin,
+  setupExpress,
+  sentry,
+} = setupSentry({
   dsn: CONFIG.SENTRY_DSN,
   environment: CONFIG.SENTRY_ENVIRONMENT,
 })
@@ -87,7 +91,7 @@ export async function listen(port: number) {
   const serverCleanup = useServer(
     {
       schema,
-      context: subscriptionContext({ prisma }),
+      context: subscriptionContext({ prisma, sentry }),
     },
     wsServer,
   )
@@ -96,7 +100,7 @@ export async function listen(port: number) {
 
   await apolloServer.start()
 
-  app.use(expressMiddleware(apolloServer, { context: expressContext({ prisma }) }))
+  app.use(expressMiddleware(apolloServer, { context: expressContext({ prisma, sentry }) }))
 
   setupExpress(app)
 

--- a/backend/test/mockContextValue.ts
+++ b/backend/test/mockContextValue.ts
@@ -7,6 +7,10 @@ import type { Context } from '#src/context'
 
 export const mockContextValue: (overrides?: Partial<Context>) => Context = (overrides = {}) => {
   const config = createMockConfig()
+  const sentry = {
+    withScope: jest.fn(),
+    captureException: jest.fn(),
+  }
   const brevo = {
     sendContactEmails: jest.fn(),
     subscribeToNewsletter: jest.fn(),
@@ -17,6 +21,7 @@ export const mockContextValue: (overrides?: Partial<Context>) => Context = (over
     config,
     brevo,
     dataSources: { prisma },
+    sentry,
   }
   return {
     ...defaults,


### PR DESCRIPTION
Motivation
----------
So, this should fix #2680 and fix #2589.

I was not able to reproduce the error in a manual E2E test. @ulfgebhardt do you know how to reproduce the catch block with Brevo?

I hoped to "unsubscribe" to a newsletter and resubscribe again to get into the catch block, but that would only trigger the "happy path" (status code 2XX).

How to test
-----------
1. `cd backend`
2. `npm install`
3. `npm run test:unit`
4. Tests pass