### PR TITLE
feat(backend): test brevo on kubernetes cluster

### DIFF
--- a/infrastructure/helmfile/dreammall/templates/backend-deployment.yaml
+++ b/infrastructure/helmfile/dreammall/templates/backend-deployment.yaml
@@ -14,7 +14,11 @@ spec:
     spec:
       restartPolicy: Always
       initContainers:
-        - env:
+        - name: backend-migrations
+          image: "{{ .Values.backend.image.repository }}:{{ default .Values.global.image.tag .Values.backend.image.tag "latest" }}"
+          imagePullPolicy: {{ quote .Values.global.image.pullPolicy }}
+          command: [ 'npm', 'run', 'db:migrate:deploy' ]
+          env:
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
@@ -27,12 +31,16 @@ spec:
                   key: frontend_url
             - name: NODE_ENV
               value: production
+      containers:
+        - name: backend
           image: "{{ .Values.backend.image.repository }}:{{ default .Values.global.image.tag .Values.backend.image.tag "latest" }}"
           imagePullPolicy: {{ quote .Values.global.image.pullPolicy }}
-          name: backend-migrations
-          command: [ 'npm', 'run', 'db:migrate:deploy' ]
-      containers:
-        - env:
+          ports:
+            - containerPort: 4000
+          envFrom:
+            - secretRef:
+                name: {{ .Release.Name }}-backend-env
+          env:
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
@@ -80,22 +88,3 @@ spec:
                   key: webhook_secret
             - name: NODE_ENV
               value: production
-            - name: BREVO_KEY
-              value: ""
-            - name: BREVO_ADMIN_NAME
-              value: ""
-            - name: BREVO_ADMIN_EMAIL
-              value: ""
-            - name: BREVO_CONTACT_TEMPLATE_ADMIN
-              value: "1"
-            - name: BREVO_CONTACT_TEMPLATE_USER
-              value: "2"
-            - name: BREVO_NEWSLETTER_TEMPLATE_OPTIN
-              value: "3"
-            - name: BREVO_NEWSLETTER_LIST
-              value: "3"
-          image: "{{ .Values.backend.image.repository }}:{{ default .Values.global.image.tag .Values.backend.image.tag "latest" }}"
-          imagePullPolicy: {{ quote .Values.global.image.pullPolicy }}
-          name: backend
-          ports:
-            - containerPort: 4000

--- a/infrastructure/helmfile/dreammall/templates/secret-env.yaml
+++ b/infrastructure/helmfile/dreammall/templates/secret-env.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-backend-env
+type: Opaque
+stringData:
+{{ .Values.secrets.backend.env | toYaml | indent 2 }}

--- a/infrastructure/helmfile/secrets/dreammall.yaml
+++ b/infrastructure/helmfile/secrets/dreammall.yaml
@@ -9,6 +9,15 @@ secrets:
     mariadb_replication_password: ENC[AES256_GCM,data:vn8lOoQY1v+tlfu2fR0VbRq8ZUo/C32CU/Zq38XSBoA=,iv:CpXs2mEq8fDqAUnHEBSy59BgdimrxwXISbA7LFcJN+U=,tag:ewIPm0PFsyXEPm9ajAeDVw==,type:str]
     mariadb_password: ENC[AES256_GCM,data:NI/FT1zebTVI8opgdLpYL6wvRoKG6DqK/E4PGKaUBto=,iv:qsYGh61oJymDbq/wC6PAYfaFfXfzNVZkah2nVB2LBBs=,tag:erWVtBZycrq4QB2/k9tf0w==,type:str]
     webhook_secret: ENC[AES256_GCM,data:Z4CuAh/kY8oK4HZmTM1Zk04UL0tmvMVDiQNxnoYy3mPrh8Bru6gQim1nVZ+ZdmDWL6ltirbUnwWibglf8TkbrA==,iv:Iaa0AFurOiHviTUzOQXzLAlnoTPX3VfxLYDcO9IFKAc=,tag:xLdwWI5qtxQlOR37mgaZXA==,type:str]
+    backend:
+        env:
+            BREVO_KEY: ENC[AES256_GCM,data:VXmXBia9eYhd2MUc5VmtnbWdJ7k2mCDJxpTBpGl47xqBCzteXXzNdpDlq5wCDpzYxJFxBKLjehqMLNmXSjghW5fnzmfN8ho3KK3RR6Jhrk5AplaCay0gwNc=,iv:EZ/Qiju9jZUcE9xRmD+3s1lG+DEoqXeajQ6VawN4xoI=,tag:DUkyqHNUGcMmLpH1jZUouA==,type:str]
+            BREVO_ADMIN_NAME: ENC[AES256_GCM,data:5Eodz4E1hlSPsu/YsyDq7Nc=,iv:dxwacji9In7As3eFtDNbVhiMtvIzRCJZJjObjDpZqAw=,tag:AV3CRO2NPXxGYnEm7ABWXw==,type:str]
+            BREVO_ADMIN_EMAIL: ENC[AES256_GCM,data:AQJcj0dB7JCN9BuK9UOI12N73BACjXo=,iv:zhyWgNxnoZZAmWzIRDum4gPCPMurvTJpaD5ONQ8oRPU=,tag:sMBYvMsywdGErGhGt3KZtA==,type:str]
+            BREVO_CONTACT_TEMPLATE_ADMIN: ENC[AES256_GCM,data:olA=,iv:Qj2ucrby8URZ1SI4CEi561/7+6Ceisfbr2rkJUX9tk4=,tag:Ubv7NfoRrqUxQmCnzzXA1w==,type:str]
+            BREVO_CONTACT_TEMPLATE_USER: ENC[AES256_GCM,data:yg==,iv:eGkkplWHVhG7br9o5FgbQzC3cJg6BwhyRTb9Q/5pM1s=,tag:eTj9eTuwn/qzQxEakEQc7Q==,type:str]
+            BREVO_NEWSLETTER_TEMPLATE_OPTIN: ENC[AES256_GCM,data:LbY=,iv:gnJuxVnSQun+un6YBZjHb7Odwii+dJMoWhrr+ZMkfhk=,tag:uVtJ4CJxzZ7FZ8N3pAHCYQ==,type:str]
+            BREVO_NEWSLETTER_LIST: ENC[AES256_GCM,data:Tg==,iv:zxdZnonFX7KkbiTBSnVAaJD+RD9nsjQ6fHBeElA3GgU=,tag:1ZDfy0M6brk8t4uS4NIGlw==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -78,8 +87,8 @@ sops:
             NDM4dE1JeFpqSUI0blB3WlcvbTd2cGsKscgnS2kbnztvBu2moNQKFSwjB35mGDZP
             OrUjDCPSz1iehO4hX1yNgiJcix4ZSYFRcUAmeyXQfnNGhDxab5UB0w==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-10-02T18:48:12Z"
-    mac: ENC[AES256_GCM,data:OshXjUN6XACUXs9y1DElZXJLIR6UplysEtxxHIKAgRi5W7g2oudcL9iO8eeEPzUPg+0TvLTOCg3xS2OQnusFMnvkJECMFxW/fKlAZnTCgRs68dp2nP5LNU6S/JCNZFjKCitXKzlV7+VZ6A1t6l8aTQCdbyiyb2yevQx2wdbKpYY=,iv:/RNexzBaY6MskJhfYjP6Rkos22N0NfPMzfthe+ojjPU=,tag:iGxw4V44MdzbRmKn8/hnTA==,type:str]
+    lastmodified: "2024-10-15T18:20:08Z"
+    mac: ENC[AES256_GCM,data:Wuzckb+cU985pqO4k0I7Sq0WyfsbASeq+32I/+LWUWZx1kQjOYggHZXsW/SbayVJytrSIGzbOyRRcnFRrLdLA0Q59oldhOygaESrIXK4/C0yWE4MWRmUYHy5jXP00yY7fK9oxWUSuAyq/tTEk8UB0H3TIVv3k0xOFMjZY3d3o7E=,iv:3XDXTjGIDS/uYfjmT/YJEylCbLnM4NuhxECQ+PFgMRM=,tag:O+Krm81dA+QIb6dRq18QHw==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.9.0


### PR DESCRIPTION
Motivation
----------
We used to have brevo mocked out on our kubernetes cluster. I guess it would be best to be able to test it there as well.

This PR makes use of `envFrom.secretRef` which I found easier to maintain than enumerating all env vars.

![image](https://github.com/user-attachments/assets/0315fa8f-42ad-42e9-9bbb-adf15a304623)


![image](https://github.com/user-attachments/assets/2240552f-c7d7-4bd6-a2a6-b3d1021eaf45)

How to test
-----------
1. Deploy to kubernetes
2. `k9s` check if env vars are set correctly