### PR TITLE
build(backend): seed 2000 users instead of 100

### DIFF
--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -4,6 +4,9 @@ import { PrismaClient } from '@prisma/client'
 
 const prisma = new PrismaClient()
 
+const numberOfUsers = 100
+// const numberOfUsers = 2000 // for load tests
+
 const seedUsers = async () => {
   await prisma.user.createMany({
     data: [
@@ -27,7 +30,7 @@ const seedUsers = async () => {
         name: 'Räuber Hotzenplotz',
         referenceId: faker.string.alphanumeric({ length: 8, casing: 'upper', exclude: 'O' }),
       },
-      ...Array.from(new Array(100), (_, i) => ({
+      ...Array.from(new Array(numberOfUsers), (_, i) => ({
         name: faker.person.fullName(),
         username: faker.internet.userName() + i,
         referenceId: faker.string.alphanumeric({ length: 8, casing: 'upper', exclude: 'O' }),


### PR DESCRIPTION
Motivation
----------
We wanted to check how our application behaves with 2000 users.

![image](https://github.com/user-attachments/assets/79f56d23-6608-47da-a58c-a18822f84030)

Backend-wise there is no problem (64ms).

![image](https://github.com/user-attachments/assets/6bbb35d8-c7e7-4403-88a7-0a9248dd5acd)

The browser will slow down on this screen with too many users.

How to test
-----------
1. `docker compose down -v`
2. `docker compose up`
3. Create a table at http://localhost:3000/

close #2773

