### PR TITLE
fix(frontend): possible scrolling of whole starmap canvas revealed white space

### DIFF
--- a/frontend/src/components/starmap/StarMap.vue
+++ b/frontend/src/components/starmap/StarMap.vue
@@ -317,11 +317,11 @@ onMounted(() => {
 
 <style scoped>
 .canvas-container {
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
   width: 100vw;
-  height: 100vh;
+  height: 100dvh;
   overflow: hidden;
   border: none;
 }


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->
On smartphone the starmap was scrollable and revealed a white space under the starmap, WHEN browser toolbar was collapsing by scrolling.


### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- #2641 

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] Fixed
