### PR TITLE
refactor(frontend): table-name in TableSettings header

### DIFF
--- a/frontend/src/components/cockpit/my-tables/create-table/CreateTable.vue
+++ b/frontend/src/components/cockpit/my-tables/create-table/CreateTable.vue
@@ -41,7 +41,7 @@ const steps: Step[] = [
   {
     component: EnterNameAndVisibility,
     id: 'settings',
-    title: 'Tisch eröffnen',
+    title: ref('Tisch eröffnen'),
     submit: 'users',
     submitText: 'Weiter',
     back: 'previous',
@@ -49,7 +49,7 @@ const steps: Step[] = [
   {
     component: SelectUsers,
     id: 'users',
-    title: 'Leute einladen',
+    title: ref('Leute einladen'),
     submit: 'next',
     submitText: 'Weiter',
     back: 'previous',
@@ -57,7 +57,7 @@ const steps: Step[] = [
   {
     component: TableCreated,
     id: 'end',
-    title: 'Kleine Erinnerung',
+    title: ref('Kleine Erinnerung'),
     submit: 'close',
     submitText: 'Tisch eröffnen',
     back: () => 'users',

--- a/frontend/src/components/malltalk/invitation/InvitationSteps.vue
+++ b/frontend/src/components/malltalk/invitation/InvitationSteps.vue
@@ -55,14 +55,14 @@ const steps: Step[] = [
   {
     component: IncomingInvitation,
     id: 'start',
-    title: t('dream-mall-panel.incoming-invitation.title'),
+    title: ref(t('dream-mall-panel.incoming-invitation.title')),
     submit: 'next',
     back: 'previous',
   },
   {
     component: TableSwap,
     id: 'swap',
-    title: t('dream-mall-panel.incoming-invitation.title'),
+    title: ref(t('dream-mall-panel.incoming-invitation.title')),
     submit: 'next',
     back: 'previous',
   },

--- a/frontend/src/components/malltalk/settings/TableSettings.vue
+++ b/frontend/src/components/malltalk/settings/TableSettings.vue
@@ -10,10 +10,12 @@
 
 <script setup lang="ts">
 import { storeToRefs } from 'pinia'
-import { reactive, watch, ref } from 'vue'
+import { reactive, watch, ref, computed } from 'vue'
 
 import StepControl from '#components/steps/StepControl.vue'
 import { Step } from '#components/steps/useSteps'
+import { usePageContext } from '#context/usePageContext'
+import { useTablesStore } from '#stores/tablesStore'
 import { useUserStore } from '#stores/userStore'
 
 import ChangeUsers from './ChangeUsers.vue'
@@ -33,6 +35,19 @@ const tableSettings = reactive<MyTableSettings>({
   meetingID: myTable.value?.meetingID || '',
 })
 
+const pageContext = usePageContext()
+const tablesStore = useTablesStore()
+
+const tableId = computed(() => {
+  return pageContext.routeParams?.id ? pageContext.routeParams.id : ''
+})
+
+watch(tablesStore.getTables, () => {
+  meetingName.value = tablesStore.getTable(tableId.value)?.meetingName || 'Mein Tisch'
+})
+
+const meetingName = ref<string>('Mein Tisch')
+
 watch(myTable, (value) => {
   tableSettings.name = value?.name || ''
   tableSettings.isPrivate = !value?.public || false
@@ -44,7 +59,7 @@ const steps: Step[] = [
   {
     component: TableSettingsRoot,
     id: 'root',
-    title: 'Mein Tisch',
+    title: meetingName,
     submit: 'close',
     submitText: 'Beenden',
     back: 'previous',
@@ -52,7 +67,7 @@ const steps: Step[] = [
   {
     component: ChangeUsers,
     id: 'users',
-    title: 'Teilnehmer',
+    title: ref('Teilnehmer'),
     submit: 'root',
     submitText: 'Übernehmen',
     back: 'root',

--- a/frontend/src/components/malltalk/settings/TableSettingsRoot.vue
+++ b/frontend/src/components/malltalk/settings/TableSettingsRoot.vue
@@ -24,7 +24,6 @@
 </template>
 
 <script setup lang="ts">
-import { storeToRefs } from 'pinia'
 import { navigate } from 'vike/client/router'
 import { computed, ref, inject } from 'vue'
 import { useI18n } from 'vue-i18n'
@@ -66,18 +65,8 @@ const isModeratorData = inject<IsModeratorInjection>(IsModeratorSymbol, {
   isModerator: ref(false),
 })
 
-const { getTables } = storeToRefs(tablesStore)
-
-const allTables = computed(() => {
-  const { mallTalkTables, permanentTables, projectTables } = getTables.value
-  return [...mallTalkTables, ...permanentTables, ...projectTables]
-})
-
 const meetingID = computed(() => {
-  if (!(tableId.value && allTables.value?.length)) return ''
-  const currentTable = allTables.value.find((t) => t.id.toString() === tableId.value.toString())
-  if (currentTable) return currentTable.meetingID
-  return ''
+  return tablesStore.getTable(tableId.value)?.meetingID ?? ''
 })
 
 const copiedIndicator = ref(false)

--- a/frontend/src/components/malltalk/setup/TableSetup.vue
+++ b/frontend/src/components/malltalk/setup/TableSetup.vue
@@ -58,7 +58,7 @@ const steps: Step[] = [
   {
     component: StartSetup,
     id: 'start',
-    title: 'Mall Talk',
+    title: ref('Mall Talk'),
     submit: 'next',
     submitText: t('dream-mall-panel.setup.continue'),
     back: 'previous',
@@ -66,7 +66,7 @@ const steps: Step[] = [
   {
     component: EnterNameAndVisibility,
     id: 'settings',
-    title: t('dream-mall-panel.setup.table-creation-title'),
+    title: ref(t('dream-mall-panel.setup.table-creation-title')),
     submit: 'next',
     submitText: t('dream-mall-panel.setup.continue'),
     back: 'previous',
@@ -74,7 +74,7 @@ const steps: Step[] = [
   {
     component: SelectUsers,
     id: 'users',
-    title: t('dream-mall-panel.setup.invitation-title'),
+    title: ref(t('dream-mall-panel.setup.invitation-title')),
     submit: 'next',
     submitText: t('dream-mall-panel.setup.continue'),
     back: 'previous',
@@ -82,7 +82,7 @@ const steps: Step[] = [
   {
     component: SubmitTable,
     id: 'end',
-    title: t('dream-mall-panel.setup.submit-title'),
+    title: ref(t('dream-mall-panel.setup.submit-title')),
     submit: 'next',
     submitText: t('dream-mall-panel.setup.create-table'),
     back: 'previous',

--- a/frontend/src/components/steps/StepControl.vue
+++ b/frontend/src/components/steps/StepControl.vue
@@ -1,7 +1,7 @@
 <template>
   <StepHeader
     v-if="steps"
-    :title="steps[currentStep]?.title ?? 'unknown'"
+    :title="steps[currentStep]?.title.value ?? 'unknown'"
     :is-back-button-visible="currentStep > 0 && steps[currentStep]?.canBack !== false"
     :is-close-button-visible="true"
     :is-dream-mall-button-mode="props.isDreamMallButtonMode"

--- a/frontend/src/components/steps/useSteps.ts
+++ b/frontend/src/components/steps/useSteps.ts
@@ -1,10 +1,10 @@
-import { Component, onMounted, onUnmounted, ref } from 'vue'
+import { Component, onMounted, onUnmounted, Ref, ref } from 'vue'
 
 type StepId = string | (() => string)
 export type Step = {
   component: Component
   id: string
-  title: string
+  title: Ref<string>
   submit: StepId
   submitText?: string
   back: StepId

--- a/frontend/src/stores/tablesStore.ts
+++ b/frontend/src/stores/tablesStore.ts
@@ -152,6 +152,19 @@ export const useTablesStore = defineStore(
 
     const getTables = computed(() => tables)
 
+    function getTableFromTables(tableId: string, tables: Table[]): Table | undefined {
+      if (!tableId || !tables.length) return undefined
+      return tables.find((t) => t.id.toString() === tableId.toString())
+    }
+
+    const getTable = (tableId: string) => {
+      return (
+        getTableFromTables(tableId, tables.mallTalkTables) ||
+        getTableFromTables(tableId, tables.permanentTables) ||
+        getTableFromTables(tableId, tables.projectTables)
+      )
+    }
+
     const setTables = (newTables: TableList) => {
       tables.mallTalkTables = newTables.mallTalkTables.map((table) => ({
         ...table,
@@ -267,6 +280,7 @@ export const useTablesStore = defineStore(
       openTables: tables,
       setTables,
       getTables,
+      getTable,
       isLoadingTables,
       getProjectTables,
       setProjectTables,


### PR DESCRIPTION
- added getTable(id) to tablesStores
- changed Step.title to Ref<string>
- loading of table name in TableSettings

<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->
The table name was not visible in the TableSettings 

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- #2671 

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] Refactoring
- [X] Table name
