### PR TITLE
feat(backend): query to validate the invitation

### DIFF
--- a/backend/prisma/migrations/20241023112212_add_invitation_links_related_to_user_and_redeemer/migration.sql
+++ b/backend/prisma/migrations/20241023112212_add_invitation_links_related_to_user_and_redeemer/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE `InvitationLink` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `code` VARCHAR(36) NOT NULL,
+    `userId` INTEGER NOT NULL,
+    `acceptedUserId` INTEGER NULL,
+
+    UNIQUE INDEX `InvitationLink_code_key`(`code`),
+    UNIQUE INDEX `InvitationLink_acceptedUserId_key`(`acceptedUserId`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `InvitationLink` ADD CONSTRAINT `InvitationLink_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `User`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `InvitationLink` ADD CONSTRAINT `InvitationLink_acceptedUserId_fkey` FOREIGN KEY (`acceptedUserId`) REFERENCES `User`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -74,6 +74,8 @@ model User {
   userDetail        UserDetail[]
   socialMedia       SocialMedia[]
   testphaseEndsAt   DateTime @default("2024-10-31T00:00:00Z")
+  invitationLinks   InvitationLink[] @relation("owner")
+  redeemedLink      InvitationLink?  @relation("redeemer")
 }
 
 model Meeting {
@@ -117,4 +119,13 @@ model SocialMedia {
   link              String   @db.VarChar(60)
   user              User     @relation(fields: [userId], references: [id])
   userId            Int
+}
+
+model InvitationLink {
+  id                Int     @id @default(autoincrement())
+  code              String  @db.VarChar(36) @unique
+  user              User    @relation("owner", fields: [userId], references: [id])
+  userId            Int
+  acceptedUser      User?   @relation("redeemer", fields: [acceptedUserId], references: [id])
+  acceptedUserId    Int?    @unique
 }

--- a/backend/src/graphql/models/InvitationModel.ts
+++ b/backend/src/graphql/models/InvitationModel.ts
@@ -1,0 +1,11 @@
+import { Field, ObjectType } from 'type-graphql'
+
+@ObjectType()
+export class Invitation {
+  constructor(name: string) {
+    this.name = name
+  }
+
+  @Field()
+  name: string
+}

--- a/backend/src/graphql/resolvers/UserResolver.spec.ts
+++ b/backend/src/graphql/resolvers/UserResolver.spec.ts
@@ -1934,6 +1934,82 @@ describe('UserResolver', () => {
     })
   })
 
+  describe('validateInvitationLink query', () => {
+    const query = `query($code: String!) {
+      validateInvitationLink(code: $code) {
+        name
+      }
+    }`
+    describe('unauthenticated', () => {
+      let user: UserWithProfile
+      beforeEach(async () => {
+        user = await findOrCreateUser({ prisma })({ pk, nickname, name })
+      })
+      describe('with non existing code', () => {
+        it('throws an error', async () => {
+          const response = await testServer.executeOperation(
+            {
+              query,
+              variables: {
+                code: 'mocked-validate',
+              },
+            },
+            {
+              contextValue: mockContextValue(),
+            },
+          )
+          expect(response).toMatchObject({
+            body: {
+              kind: 'single',
+              singleResult: {
+                data: null,
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                errors: expect.arrayContaining([
+                  expect.objectContaining({
+                    message: 'Invalid invitation code.',
+                  }),
+                ]),
+              },
+            },
+          })
+        })
+      })
+
+      describe('with existing code', () => {
+        beforeAll(async () => {
+          await prisma.invitationLink.create({
+            data: {
+              code: 'mocked-validate',
+              userId: user.id,
+            },
+          })
+        })
+
+        it('returns an unauthenticated error', async () => {
+          const response = await testServer.executeOperation(
+            {
+              query,
+              variables: {
+                code: 'mocked-validate',
+              },
+            },
+            { contextValue: mockContextValue() },
+          )
+          expect(response.body).toMatchObject({
+            kind: 'single',
+            singleResult: {
+              data: {
+                validateInvitationLink: {
+                  name: 'User',
+                },
+              },
+            },
+          })
+        })
+      })
+    })
+  })
+
   describe('redeemInvitationLink mutation', () => {
     const query = `mutation($code: String!) {
       redeemInvitationLink(code: $code)

--- a/backend/src/graphql/resolvers/UserResolver.spec.ts
+++ b/backend/src/graphql/resolvers/UserResolver.spec.ts
@@ -1933,4 +1933,135 @@ describe('UserResolver', () => {
       })
     })
   })
+
+  describe('redeemInvitationLink mutation', () => {
+    const query = `mutation($code: String!) {
+      redeemInvitationLink(code: $code)
+    }`
+    describe('unauthenticated', () => {
+      it('returns an unauthenticated error', async () => {
+        const response = await testServer.executeOperation(
+          {
+            query,
+            variables: {
+              code: 'mocked',
+            },
+          },
+          { contextValue: mockContextValue() },
+        )
+        expect(response).toMatchObject({
+          body: {
+            kind: 'single',
+            singleResult: {
+              data: null,
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+              errors: expect.arrayContaining([
+                expect.objectContaining({
+                  message: 'Access denied! You need to be authenticated to perform this action!',
+                }),
+              ]),
+            },
+          },
+        })
+      })
+    })
+
+    describe('authenticated', () => {
+      let user: UserWithProfile
+      beforeEach(async () => {
+        user = await findOrCreateUser({ prisma })({ pk, nickname, name })
+      })
+
+      describe('with non existing code', () => {
+        it('throws an error', async () => {
+          const response = await testServer.executeOperation(
+            {
+              query,
+              variables: {
+                code: 'mocked',
+              },
+            },
+            {
+              contextValue: mockContextValue({ user }),
+            },
+          )
+          expect(response).toMatchObject({
+            body: {
+              kind: 'single',
+              singleResult: {
+                data: null,
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                errors: expect.arrayContaining([
+                  expect.objectContaining({
+                    message: 'Invalid invitation code.',
+                  }),
+                ]),
+              },
+            },
+          })
+        })
+      })
+
+      describe('with existing code', () => {
+        beforeAll(async () => {
+          await prisma.invitationLink.create({
+            data: {
+              code: 'mocked',
+              userId: user.id,
+            },
+          })
+        })
+
+        it('returns a success at first call', async () => {
+          const response = await testServer.executeOperation(
+            {
+              query,
+              variables: {
+                code: 'mocked',
+              },
+            },
+            {
+              contextValue: mockContextValue({ user }),
+            },
+          )
+          expect(response.body).toMatchObject({
+            kind: 'single',
+            singleResult: {
+              data: {
+                redeemInvitationLink: true,
+              },
+            },
+          })
+        })
+
+        it('throws an error after first usage', async () => {
+          const response = await testServer.executeOperation(
+            {
+              query,
+              variables: {
+                code: 'mocked',
+              },
+            },
+            {
+              contextValue: mockContextValue({ user }),
+            },
+          )
+          expect(response).toMatchObject({
+            body: {
+              kind: 'single',
+              singleResult: {
+                data: null,
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                errors: expect.arrayContaining([
+                  expect.objectContaining({
+                    message: 'Link already used.',
+                  }),
+                ]),
+              },
+            },
+          })
+        })
+      })
+    })
+  })
 })

--- a/backend/src/graphql/resolvers/UserResolver.spec.ts
+++ b/backend/src/graphql/resolvers/UserResolver.spec.ts
@@ -1884,12 +1884,6 @@ describe('UserResolver', () => {
         const response = await testServer.executeOperation(
           {
             query,
-            variables: {
-              data: {
-                link: 'https://yunite.me/user/ork',
-                type: 'discord',
-              },
-            },
           },
           { contextValue: mockContextValue() },
         )

--- a/backend/src/graphql/resolvers/UserResolver.ts
+++ b/backend/src/graphql/resolvers/UserResolver.ts
@@ -9,8 +9,9 @@ import { AddSocialMediaInput } from '#inputs/AddSocialMediaInput'
 import { AddUserDetailInput } from '#inputs/AddUserDetailInput'
 import { UpdateUserInput } from '#inputs/UpdateUserInput'
 
-import type { AuthenticatedContext } from '#src/context'
+import type { AuthenticatedContext, Context } from '#src/context'
 import type { PrismaClient, UsersWithMeetings, UserWithProfile } from '#src/prisma'
+import { Invitation } from '#graphql/models/InvitationModel'
 
 @Resolver()
 export class UserResolver {
@@ -202,6 +203,31 @@ export class UserResolver {
     return config.FRONTEND_URL + 'invite/' + dbInviationLink.code
   }
 
+  @Query(() => Invitation)
+  async validateInvitationLink(
+    @Arg('code') code: string,
+    @Ctx() context: Context,
+  ): Promise<Invitation> {
+    const {
+      dataSources: { prisma },
+    } = context
+    const invitationLink = await prisma.invitationLink.findUnique({
+      where: {
+        code,
+      },
+      include: {
+        user: true,
+      },
+    })
+    if (!invitationLink) throw new Error('Invalid invitation code.')
+    if (invitationLink.acceptedUserId) {
+      throw new Error('Link already used.')
+    }
+    return {
+      name: invitationLink.user.name,
+    }
+  }
+
   @Authorized()
   @Mutation(() => Boolean)
   async redeemInvitationLink(
@@ -262,4 +288,8 @@ const createInvitationCode = (prisma: PrismaClient) => async (): Promise<string>
     invitationCode = uuidv4()
   }
   return invitationCode
+}
+
+export type InvitationLinkName = {
+  username: string
 }

--- a/backend/src/graphql/resolvers/UserResolver.ts
+++ b/backend/src/graphql/resolvers/UserResolver.ts
@@ -289,7 +289,3 @@ const createInvitationCode = (prisma: PrismaClient) => async (): Promise<string>
   }
   return invitationCode
 }
-
-export type InvitationLinkName = {
-  username: string
-}

--- a/backend/src/graphql/resolvers/UserResolver.ts
+++ b/backend/src/graphql/resolvers/UserResolver.ts
@@ -4,6 +4,7 @@ import { Resolver, Query, Authorized, Ctx, Arg, Mutation, Int } from 'type-graph
 import { v4 as uuidv4 } from 'uuid'
 
 import { UpdateUserDetailInput } from '#graphql/inputs/UpdateUserDetailInput'
+import { Invitation } from '#graphql/models/InvitationModel'
 import { User, CurrentUser, UserDetail, SocialMedia } from '#graphql/models/UserModel'
 import { AddSocialMediaInput } from '#inputs/AddSocialMediaInput'
 import { AddUserDetailInput } from '#inputs/AddUserDetailInput'
@@ -11,7 +12,6 @@ import { UpdateUserInput } from '#inputs/UpdateUserInput'
 
 import type { AuthenticatedContext, Context } from '#src/context'
 import type { PrismaClient, UsersWithMeetings, UserWithProfile } from '#src/prisma'
-import { Invitation } from '#graphql/models/InvitationModel'
 
 @Resolver()
 export class UserResolver {

--- a/backend/src/graphql/resolvers/UserResolver.ts
+++ b/backend/src/graphql/resolvers/UserResolver.ts
@@ -1,5 +1,7 @@
 import { Prisma } from '@prisma/client'
 import { Resolver, Query, Authorized, Ctx, Arg, Mutation, Int } from 'type-graphql'
+// eslint-disable-next-line import/named
+import { v4 as uuidv4 } from 'uuid'
 
 import { UpdateUserDetailInput } from '#graphql/inputs/UpdateUserDetailInput'
 import { User, CurrentUser, UserDetail, SocialMedia } from '#graphql/models/UserModel'
@@ -184,6 +186,21 @@ export class UserResolver {
 
     return true
   }
+
+  @Authorized()
+  @Mutation(() => String)
+  async createInvitationLink(@Ctx() context: AuthenticatedContext): Promise<string> {
+    const {
+      user,
+      config,
+      dataSources: { prisma },
+    } = context
+    const inviationCode = await createInvitationCode(prisma)()
+    const dbInviationLink = await prisma.invitationLink.create({
+      data: { code: inviationCode, userId: user.id },
+    })
+    return config.FRONTEND_URL + 'invite/' + dbInviationLink.code
+  }
 }
 
 const createCurrentUser =
@@ -200,3 +217,17 @@ const createCurrentUser =
 
     return new CurrentUser(user, usersInMeetings)
   }
+
+const createInvitationCode = (prisma: PrismaClient) => async (): Promise<string> => {
+  let invitationCode: string = uuidv4()
+  while (
+    await prisma.invitationLink.count({
+      where: {
+        code: invitationCode,
+      },
+    })
+  ) {
+    invitationCode = uuidv4()
+  }
+  return invitationCode
+}

--- a/backend/test/helpers.ts
+++ b/backend/test/helpers.ts
@@ -8,6 +8,7 @@ export const deleteAll = async () => {
   await prisma.usersInMeetings.deleteMany()
   await prisma.userDetail.deleteMany()
   await prisma.socialMedia.deleteMany()
+  await prisma.invitationLink.deleteMany()
   await prisma.user.deleteMany()
   await prisma.meeting.deleteMany()
 }


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->
Motivation
----
We want to validate the invitation link before we send the user to the registration.

Solution
----
Query to validate the code, that gives back the name of the user that invited you
```
query($code: String!) {
  validateInvitationLink(code: $code) {
    name
  }
}
```
Success
```
{
  "data": {
    "validateInvitationLink": {
      "name": "authentik Default Admin"
    }
  }
}
```

Issues
----
- relates #2255

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
